### PR TITLE
feat(substation/editors): add tooltip to header icon buttons

### DIFF
--- a/__snapshots__/bay-editor.md
+++ b/__snapshots__/bay-editor.md
@@ -6,24 +6,24 @@
 <section tabindex="0">
   <h3>
     COUPLING_BAY — Bay
-    <abbr title="[tooltip.iconbutton.add]">
+    <abbr title="[add]">
       <mwc-icon-button icon="playlist_add">
       </mwc-icon-button>
     </abbr>
     <nav>
-      <abbr title="[tooltip.iconbutton.lnodewizard]">
+      <abbr title="[lnode.tooltip]">
         <mwc-icon-button icon="account_tree">
         </mwc-icon-button>
       </abbr>
-      <abbr title="[tooltip.iconbutton.edit]">
+      <abbr title="[edit]">
         <mwc-icon-button icon="edit">
         </mwc-icon-button>
       </abbr>
-      <abbr title="[tooltip.iconbutton.forward]">
+      <abbr title="[move]">
         <mwc-icon-button icon="forward">
         </mwc-icon-button>
       </abbr>
-      <abbr title="[tooltip.iconbutton.delete]">
+      <abbr title="[remove]">
         <mwc-icon-button icon="delete">
         </mwc-icon-button>
       </abbr>

--- a/__snapshots__/bay-editor.md
+++ b/__snapshots__/bay-editor.md
@@ -6,17 +6,27 @@
 <section tabindex="0">
   <h3>
     COUPLING_BAY — Bay
-    <mwc-icon-button icon="playlist_add">
-    </mwc-icon-button>
+    <abbr title="[tooltip.iconbutton.add]">
+      <mwc-icon-button icon="playlist_add">
+      </mwc-icon-button>
+    </abbr>
     <nav>
-      <mwc-icon-button icon="account_tree">
-      </mwc-icon-button>
-      <mwc-icon-button icon="edit">
-      </mwc-icon-button>
-      <mwc-icon-button icon="forward">
-      </mwc-icon-button>
-      <mwc-icon-button icon="delete">
-      </mwc-icon-button>
+      <abbr title="[tooltip.iconbutton.lnodewizard]">
+        <mwc-icon-button icon="account_tree">
+        </mwc-icon-button>
+      </abbr>
+      <abbr title="[tooltip.iconbutton.edit]">
+        <mwc-icon-button icon="edit">
+        </mwc-icon-button>
+      </abbr>
+      <abbr title="[tooltip.iconbutton.forward]">
+        <mwc-icon-button icon="forward">
+        </mwc-icon-button>
+      </abbr>
+      <abbr title="[tooltip.iconbutton.delete]">
+        <mwc-icon-button icon="delete">
+        </mwc-icon-button>
+      </abbr>
     </nav>
   </h3>
   <div id="ceContainer">

--- a/__snapshots__/substation-editor.md
+++ b/__snapshots__/substation-editor.md
@@ -6,20 +6,20 @@
 <section tabindex="0">
   <h1>
     AA1 — Substation
-    <abbr title="[tooltip.iconbutton.add]">
+    <abbr title="[add]">
       <mwc-icon-button icon="playlist_add">
       </mwc-icon-button>
     </abbr>
     <nav>
-      <abbr title="[tooltip.iconbutton.lnodewizard]">
+      <abbr title="[lnode.tooltip]">
         <mwc-icon-button icon="account_tree">
         </mwc-icon-button>
       </abbr>
-      <abbr title="[tooltip.iconbutton.edit]">
+      <abbr title="[edit]">
         <mwc-icon-button icon="edit">
         </mwc-icon-button>
       </abbr>
-      <abbr title="[tooltip.iconbutton.delete]">
+      <abbr title="[remove]">
         <mwc-icon-button icon="delete">
         </mwc-icon-button>
       </abbr>

--- a/__snapshots__/substation-editor.md
+++ b/__snapshots__/substation-editor.md
@@ -6,15 +6,23 @@
 <section tabindex="0">
   <h1>
     AA1 — Substation
-    <mwc-icon-button icon="playlist_add">
-    </mwc-icon-button>
+    <abbr title="[tooltip.iconbutton.add]">
+      <mwc-icon-button icon="playlist_add">
+      </mwc-icon-button>
+    </abbr>
     <nav>
-      <mwc-icon-button icon="account_tree">
-      </mwc-icon-button>
-      <mwc-icon-button icon="edit">
-      </mwc-icon-button>
-      <mwc-icon-button icon="delete">
-      </mwc-icon-button>
+      <abbr title="[tooltip.iconbutton.lnodewizard]">
+        <mwc-icon-button icon="account_tree">
+        </mwc-icon-button>
+      </abbr>
+      <abbr title="[tooltip.iconbutton.edit]">
+        <mwc-icon-button icon="edit">
+        </mwc-icon-button>
+      </abbr>
+      <abbr title="[tooltip.iconbutton.delete]">
+        <mwc-icon-button icon="delete">
+        </mwc-icon-button>
+      </abbr>
     </nav>
   </h1>
   <voltage-level-editor>

--- a/__snapshots__/voltage-level-editor.md
+++ b/__snapshots__/voltage-level-editor.md
@@ -7,17 +7,27 @@
   <h2>
     E1 — Voltage Level
       (110.0 kV)
-    <mwc-icon-button icon="playlist_add">
-    </mwc-icon-button>
+    <abbr title="[tooltip.iconbutton.add]">
+      <mwc-icon-button icon="playlist_add">
+      </mwc-icon-button>
+    </abbr>
     <nav>
-      <mwc-icon-button icon="account_tree">
-      </mwc-icon-button>
-      <mwc-icon-button icon="edit">
-      </mwc-icon-button>
-      <mwc-icon-button icon="forward">
-      </mwc-icon-button>
-      <mwc-icon-button icon="delete">
-      </mwc-icon-button>
+      <abbr title="[tooltip.iconbutton.lnodewizard]">
+        <mwc-icon-button icon="account_tree">
+        </mwc-icon-button>
+      </abbr>
+      <abbr title="[tooltip.iconbutton.edit]">
+        <mwc-icon-button icon="edit">
+        </mwc-icon-button>
+      </abbr>
+      <abbr title="[tooltip.iconbutton.forward]">
+        <mwc-icon-button icon="forward">
+        </mwc-icon-button>
+      </abbr>
+      <abbr title="[tooltip.iconbutton.delete]">
+        <mwc-icon-button icon="delete">
+        </mwc-icon-button>
+      </abbr>
     </nav>
   </h2>
   <div id="bayContainer">

--- a/__snapshots__/voltage-level-editor.md
+++ b/__snapshots__/voltage-level-editor.md
@@ -7,24 +7,24 @@
   <h2>
     E1 — Voltage Level
       (110.0 kV)
-    <abbr title="[tooltip.iconbutton.add]">
+    <abbr title="[add]">
       <mwc-icon-button icon="playlist_add">
       </mwc-icon-button>
     </abbr>
     <nav>
-      <abbr title="[tooltip.iconbutton.lnodewizard]">
+      <abbr title="[lnode.tooltip]">
         <mwc-icon-button icon="account_tree">
         </mwc-icon-button>
       </abbr>
-      <abbr title="[tooltip.iconbutton.edit]">
+      <abbr title="[edit]">
         <mwc-icon-button icon="edit">
         </mwc-icon-button>
       </abbr>
-      <abbr title="[tooltip.iconbutton.forward]">
+      <abbr title="[move]">
         <mwc-icon-button icon="forward">
         </mwc-icon-button>
       </abbr>
-      <abbr title="[tooltip.iconbutton.delete]">
+      <abbr title="[remove]">
         <mwc-icon-button icon="delete">
         </mwc-icon-button>
       </abbr>

--- a/src/editors/substation/bay-editor.ts
+++ b/src/editors/substation/bay-editor.ts
@@ -80,53 +80,32 @@ export class BayEditor extends LitElement {
   renderHeader(): TemplateResult {
     return html`<h3>
       ${this.name} ${this.desc === null ? '' : html`&mdash;`} ${this.desc}
-      <abbr
-        title="${get('tooltip.iconbutton.add', {
-          childTag: get('conductingequipment.name'),
-        })}"
-      >
+      <abbr title="${translate('add')}">
         <mwc-icon-button
           icon="playlist_add"
           @click=${() => this.openConductingEquipmentWizard()}
         ></mwc-icon-button>
       </abbr>
       <nav>
-        <abbr
-          title="${get('tooltip.iconbutton.lnodewizard', {
-            tagName: get('bay.name'),
-          })}"
-        >
+        <abbr title="${translate('lnode.tooltip')}">
           <mwc-icon-button
             icon="account_tree"
             @click="${() => this.openLNodeWizard()}"
           ></mwc-icon-button>
         </abbr>
-        <abbr
-          title="${get('tooltip.iconbutton.edit', {
-            tagName: get('bay.name'),
-          })}"
-        >
+        <abbr title="${translate('edit')}">
           <mwc-icon-button
             icon="edit"
             @click=${() => this.openEditWizard()}
           ></mwc-icon-button>
         </abbr>
-        <abbr
-          title="${get('tooltip.iconbutton.forward', {
-            parentTag: get('voltagelevel.name'),
-            name: this.name,
-          })}"
-        >
+        <abbr title="${translate('move')}">
           <mwc-icon-button
             icon="forward"
             @click=${() => startMove(this, BayEditor, VoltageLevelEditor)}
           ></mwc-icon-button>
         </abbr>
-        <abbr
-          title="${get('tooltip.iconbutton.delete', {
-            tagName: get('bay.name'),
-          })}"
-        >
+        <abbr title="${translate('remove')}">
           <mwc-icon-button
             icon="delete"
             @click=${() => this.remove()}

--- a/src/editors/substation/bay-editor.ts
+++ b/src/editors/substation/bay-editor.ts
@@ -80,27 +80,58 @@ export class BayEditor extends LitElement {
   renderHeader(): TemplateResult {
     return html`<h3>
       ${this.name} ${this.desc === null ? '' : html`&mdash;`} ${this.desc}
-      <mwc-icon-button
-        icon="playlist_add"
-        @click=${() => this.openConductingEquipmentWizard()}
-      ></mwc-icon-button>
+      <abbr
+        title="${get('tooltip.iconbutton.add', {
+          childTag: get('conductingequipment.name'),
+        })}"
+      >
+        <mwc-icon-button
+          icon="playlist_add"
+          @click=${() => this.openConductingEquipmentWizard()}
+        ></mwc-icon-button>
+      </abbr>
       <nav>
-        <mwc-icon-button
-          icon="account_tree"
-          @click="${() => this.openLNodeWizard()}"
-        ></mwc-icon-button>
-        <mwc-icon-button
-          icon="edit"
-          @click=${() => this.openEditWizard()}
-        ></mwc-icon-button>
-        <mwc-icon-button
-          icon="forward"
-          @click=${() => startMove(this, BayEditor, VoltageLevelEditor)}
-        ></mwc-icon-button>
-        <mwc-icon-button
-          icon="delete"
-          @click=${() => this.remove()}
-        ></mwc-icon-button>
+        <abbr
+          title="${get('tooltip.iconbutton.lnodewizard', {
+            tagName: get('bay.name'),
+          })}"
+        >
+          <mwc-icon-button
+            icon="account_tree"
+            @click="${() => this.openLNodeWizard()}"
+          ></mwc-icon-button>
+        </abbr>
+        <abbr
+          title="${get('tooltip.iconbutton.edit', {
+            tagName: get('bay.name'),
+          })}"
+        >
+          <mwc-icon-button
+            icon="edit"
+            @click=${() => this.openEditWizard()}
+          ></mwc-icon-button>
+        </abbr>
+        <abbr
+          title="${get('tooltip.iconbutton.forward', {
+            parentTag: get('voltagelevel.name'),
+            name: this.name,
+          })}"
+        >
+          <mwc-icon-button
+            icon="forward"
+            @click=${() => startMove(this, BayEditor, VoltageLevelEditor)}
+          ></mwc-icon-button>
+        </abbr>
+        <abbr
+          title="${get('tooltip.iconbutton.delete', {
+            tagName: get('bay.name'),
+          })}"
+        >
+          <mwc-icon-button
+            icon="delete"
+            @click=${() => this.remove()}
+          ></mwc-icon-button>
+        </abbr>
       </nav>
     </h3>`;
   }

--- a/src/editors/substation/foundation.ts
+++ b/src/editors/substation/foundation.ts
@@ -193,9 +193,15 @@ export const styles = css`
   h1 > nav,
   h2 > nav,
   h3 > nav,
-  h1 > mwc-icon-button,
-  h2 > mwc-icon-button,
-  h3 > mwc-icon-button {
+  h1 > abbr > mwc-icon-button,
+  h2 > abbr > mwc-icon-button,
+  h3 > abbr > mwc-icon-button {
     float: right;
+  }
+
+  abbr[title] {
+    border-bottom: none !important;
+    cursor: inherit !important;
+    text-decoration: none !important;
   }
 `;

--- a/src/editors/substation/substation-editor.ts
+++ b/src/editors/substation/substation-editor.ts
@@ -118,42 +118,26 @@ export class SubstationEditor extends LitElement {
     return html`
       <h1>
         ${this.name} ${this.desc === null ? '' : html`&mdash;`} ${this.desc}
-        <abbr
-          title="${get('tooltip.iconbutton.add', {
-            childTag: get('voltagelevel.name'),
-          })}"
-        >
+        <abbr title="${translate('add')}">
           <mwc-icon-button
             icon="playlist_add"
             @click=${() => this.openVoltageLevelWizard()}
           ></mwc-icon-button>
         </abbr>
         <nav>
-          <abbr
-            title="${get('tooltip.iconbutton.lnodewizard', {
-              tagName: get('substation.name'),
-            })}"
-          >
+          <abbr title="${translate('lnode.tooltip')}">
             <mwc-icon-button
               icon="account_tree"
               @click=${() => this.openLNodeWizard()}
             ></mwc-icon-button>
           </abbr>
-          <abbr
-            title="${get('tooltip.iconbutton.edit', {
-              tagName: get('substation.name'),
-            })}"
-          >
+          <abbr title="${translate('edit')}">
             <mwc-icon-button
               icon="edit"
               @click=${() => this.openEditWizard()}
             ></mwc-icon-button>
           </abbr>
-          <abbr
-            title="${get('tooltip.iconbutton.delete', {
-              tagName: get('substation.name'),
-            })}"
-          >
+          <abbr title="${translate('remove')}">
             <mwc-icon-button
               icon="delete"
               @click=${() => this.remove()}

--- a/src/editors/substation/substation-editor.ts
+++ b/src/editors/substation/substation-editor.ts
@@ -118,23 +118,47 @@ export class SubstationEditor extends LitElement {
     return html`
       <h1>
         ${this.name} ${this.desc === null ? '' : html`&mdash;`} ${this.desc}
-        <mwc-icon-button
-          icon="playlist_add"
-          @click=${() => this.openVoltageLevelWizard()}
-        ></mwc-icon-button>
+        <abbr
+          title="${get('tooltip.iconbutton.add', {
+            childTag: get('voltagelevel.name'),
+          })}"
+        >
+          <mwc-icon-button
+            icon="playlist_add"
+            @click=${() => this.openVoltageLevelWizard()}
+          ></mwc-icon-button>
+        </abbr>
         <nav>
-          <mwc-icon-button
-            icon="account_tree"
-            @click=${() => this.openLNodeWizard()}
-          ></mwc-icon-button>
-          <mwc-icon-button
-            icon="edit"
-            @click=${() => this.openEditWizard()}
-          ></mwc-icon-button>
-          <mwc-icon-button
-            icon="delete"
-            @click=${() => this.remove()}
-          ></mwc-icon-button>
+          <abbr
+            title="${get('tooltip.iconbutton.lnodewizard', {
+              tagName: get('substation.name'),
+            })}"
+          >
+            <mwc-icon-button
+              icon="account_tree"
+              @click=${() => this.openLNodeWizard()}
+            ></mwc-icon-button>
+          </abbr>
+          <abbr
+            title="${get('tooltip.iconbutton.edit', {
+              tagName: get('substation.name'),
+            })}"
+          >
+            <mwc-icon-button
+              icon="edit"
+              @click=${() => this.openEditWizard()}
+            ></mwc-icon-button>
+          </abbr>
+          <abbr
+            title="${get('tooltip.iconbutton.delete', {
+              tagName: get('substation.name'),
+            })}"
+          >
+            <mwc-icon-button
+              icon="delete"
+              @click=${() => this.remove()}
+            ></mwc-icon-button>
+          </abbr>
         </nav>
       </h1>
     `;

--- a/src/editors/substation/voltage-level-editor.ts
+++ b/src/editors/substation/voltage-level-editor.ts
@@ -137,27 +137,58 @@ export class VoltageLevelEditor extends LitElement {
     return html`<h2>
       ${this.name} ${this.desc === null ? '' : html`&mdash;`} ${this.desc}
       ${this.voltage === null ? '' : html`(${this.voltage})`}
-      <mwc-icon-button
-        icon="playlist_add"
-        @click=${() => this.openBayWizard()}
-      ></mwc-icon-button>
+      <abbr
+        title="${get('tooltip.iconbutton.add', {
+          childTag: get('bay.name'),
+        })}"
+      >
+        <mwc-icon-button
+          icon="playlist_add"
+          @click=${() => this.openBayWizard()}
+        ></mwc-icon-button>
+      </abbr>
       <nav>
-        <mwc-icon-button
-          icon="account_tree"
-          @click=${() => this.openLNodeWizard()}
-        ></mwc-icon-button>
-        <mwc-icon-button
-          icon="edit"
-          @click=${() => this.openEditWizard()}
-        ></mwc-icon-button>
-        <mwc-icon-button
-          icon="forward"
-          @click=${() => startMove(this, VoltageLevelEditor, SubstationEditor)}
-        ></mwc-icon-button>
-        <mwc-icon-button
-          icon="delete"
-          @click=${() => this.remove()}
-        ></mwc-icon-button>
+        <abbr
+          title="${get('tooltip.iconbutton.lnodewizard', {
+            tagName: get('voltagelevel.name'),
+          })}"
+        >
+          <mwc-icon-button
+            icon="account_tree"
+            @click=${() => this.openLNodeWizard()}
+          ></mwc-icon-button>
+        </abbr>
+        <abbr
+          title="${get('tooltip.iconbutton.edit', {
+            tagName: get('voltagelevel.name'),
+          })}"
+        >
+          <mwc-icon-button
+            icon="edit"
+            @click=${() => this.openEditWizard()}
+          ></mwc-icon-button>
+        </abbr>
+        <abbr
+          title="${get('tooltip.iconbutton.forward', {
+            parentTag: get('substation.name'),
+          })}"
+        >
+          <mwc-icon-button
+            icon="forward"
+            @click=${() =>
+              startMove(this, VoltageLevelEditor, SubstationEditor)}
+          ></mwc-icon-button>
+        </abbr>
+        <abbr
+          title="${get('tooltip.iconbutton.delete', {
+            tagName: get('voltagelevel.name'),
+          })}"
+        >
+          <mwc-icon-button
+            icon="delete"
+            @click=${() => this.remove()}
+          ></mwc-icon-button>
+        </abbr>
       </nav>
     </h2>`;
   }

--- a/src/editors/substation/voltage-level-editor.ts
+++ b/src/editors/substation/voltage-level-editor.ts
@@ -137,53 +137,33 @@ export class VoltageLevelEditor extends LitElement {
     return html`<h2>
       ${this.name} ${this.desc === null ? '' : html`&mdash;`} ${this.desc}
       ${this.voltage === null ? '' : html`(${this.voltage})`}
-      <abbr
-        title="${get('tooltip.iconbutton.add', {
-          childTag: get('bay.name'),
-        })}"
-      >
+      <abbr title="${translate('add')}">
         <mwc-icon-button
           icon="playlist_add"
           @click=${() => this.openBayWizard()}
         ></mwc-icon-button>
       </abbr>
       <nav>
-        <abbr
-          title="${get('tooltip.iconbutton.lnodewizard', {
-            tagName: get('voltagelevel.name'),
-          })}"
-        >
+        <abbr title="${translate('lnode.tooltip')}">
           <mwc-icon-button
             icon="account_tree"
             @click=${() => this.openLNodeWizard()}
           ></mwc-icon-button>
         </abbr>
-        <abbr
-          title="${get('tooltip.iconbutton.edit', {
-            tagName: get('voltagelevel.name'),
-          })}"
-        >
+        <abbr title="${translate('edit')}">
           <mwc-icon-button
             icon="edit"
             @click=${() => this.openEditWizard()}
           ></mwc-icon-button>
         </abbr>
-        <abbr
-          title="${get('tooltip.iconbutton.forward', {
-            parentTag: get('substation.name'),
-          })}"
-        >
+        <abbr title="${translate('move')}">
           <mwc-icon-button
             icon="forward"
             @click=${() =>
               startMove(this, VoltageLevelEditor, SubstationEditor)}
           ></mwc-icon-button>
         </abbr>
-        <abbr
-          title="${get('tooltip.iconbutton.delete', {
-            tagName: get('voltagelevel.name'),
-          })}"
-        >
+        <abbr title="${translate('remove')}">
           <mwc-icon-button
             icon="delete"
             @click=${() => this.remove()}

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -72,6 +72,7 @@ export const de: Translations = {
     },
   },
   voltagelevel: {
+    name: 'Spannungsebene',
     wizard: {
       nameHelper: 'Name der Spannungsebene',
       descHelper: 'Beschreibung der Spannungsebene',
@@ -85,6 +86,7 @@ export const de: Translations = {
     },
   },
   bay: {
+    name: 'Feld',
     wizard: {
       nameHelper: 'Feldname',
       descHelper: 'Beschreibung des Feldes',
@@ -95,6 +97,7 @@ export const de: Translations = {
     },
   },
   conductingequipment: {
+    name: 'Primärelement',
     wizard: {
       nameHelper: 'Name des Primärelements',
       descHelper: 'Beschreibung des Primärelements',
@@ -116,6 +119,15 @@ export const de: Translations = {
       placeholder:
         'Keine IEDs geladen. ' +
         'Bitte laden Sie eine SCL Datei, die IED Elemente enthält.',
+    },
+  },
+  tooltip: {
+    iconbutton: {
+      add: '{{childTag}} hinzufügen',
+      lnodewizard: 'Logische Knoten mit {{tagName}} verbinden',
+      edit: 'Attribute bearbeiten',
+      forward: 'In {{parentTag}} verschieben',
+      delete: '{{tagName}} löschen',
     },
   },
   add: 'Hinzufügen',

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -10,14 +10,14 @@ export const de: Translations = {
   menu: {
     name: 'Menü',
     open: 'Projekt öffnen',
-    new: 'Neues Project',
-    importIED: 'IED Importieren',
+    new: 'Neues Projekt',
+    importIED: 'IED importieren',
     save: 'Projekt speichern',
     validate: 'Projekt validieren',
     viewLog: 'Protokoll anzeigen',
   },
   openSCD: {
-    loading: 'Lade Project {{ name }}',
+    loading: 'Lade Projekt {{ name }}',
     loaded: '{{ name }} geladen',
     readError: '{{ name }} Lesefehler',
     readAbort: '{{ name }} Leseabbruch',
@@ -116,19 +116,9 @@ export const de: Translations = {
         selectLDs: 'Auswahl logische Geräte',
         selectLNs: 'Auswahl logische Knoten',
       },
-      placeholder:
-        'Keine IEDs geladen. ' +
-        'Bitte laden Sie eine SCL Datei, die IED Elemente enthält.',
+      placeholder: 'Bitte laden Sie eine SCL-Datei, die IED-Elemente enthält.',
     },
-  },
-  tooltip: {
-    iconbutton: {
-      add: '{{childTag}} hinzufügen',
-      lnodewizard: 'Logische Knoten mit {{tagName}} verbinden',
-      edit: 'Attribute bearbeiten',
-      forward: 'In {{parentTag}} verschieben',
-      delete: '{{tagName}} löschen',
-    },
+    tooltip: 'Referenz zi logischen Knoten erstellen',
   },
   add: 'Hinzufügen',
   edit: 'Bearbeiten',
@@ -140,4 +130,5 @@ export const de: Translations = {
   redo: 'Wiederholen',
   remove: 'Entfernen',
   filter: 'Filter',
+  move: 'Verschieben',
 };

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -17,14 +17,14 @@ export const en = {
   openSCD: {
     loading: 'Loading project {{ name }}',
     loaded: '{{ name }} loaded',
-    readError: '{{ name }} read error',
-    readAbort: '{{ name }} read aborted',
+    readError: 'Error reading {{ name }}',
+    readAbort: 'Aborted reading {{ name }}',
   },
   editing: {
-    created: '{{ name }} added',
-    deleted: '{{ name }} removed',
-    moved: '{{ name }} moved',
-    updated: '{{ name }} edited',
+    created: 'Added {{ name }}',
+    deleted: 'Removed {{ name }}',
+    moved: 'Moved {{ name }}',
+    updated: 'Edited {{ name }}',
     error: {
       create: 'Could not add {{ name }}',
       update: 'Could not edit {{ name }}',
@@ -55,53 +55,53 @@ export const en = {
   },
   substation: {
     name: 'Substation',
-    missing: 'No Substation',
+    missing: 'No substation',
     wizard: {
-      nameHelper: 'Substation Name',
-      descHelper: 'Substation Description',
+      nameHelper: 'Substation name',
+      descHelper: 'Substation sescription',
       title: {
-        add: 'Add Substation',
-        edit: 'Edit Substation',
+        add: 'Add substation',
+        edit: 'Edit substation',
       },
     },
     action: {
-      addvoltagelevel: 'Add Voltage Level',
+      addvoltagelevel: 'Add voltage level',
     },
   },
   voltagelevel: {
-    name: 'Voltage Level',
+    name: 'Voltage level',
     wizard: {
-      nameHelper: 'Voltage Level Name',
-      descHelper: 'Voltage Level Description',
-      nomFreqHelper: 'Nominal Frequency',
-      numPhaseHelper: 'Number of Phases',
-      voltageHelper: 'Nominal Voltage',
+      nameHelper: 'Voltage level name',
+      descHelper: 'Voltage level description',
+      nomFreqHelper: 'Nominal frequency',
+      numPhaseHelper: 'Number of phases',
+      voltageHelper: 'Nominal voltage',
       title: {
-        add: 'Add Voltage Level',
-        edit: 'Edit Voltage Level',
+        add: 'Add voltage level',
+        edit: 'Edit voltage level',
       },
     },
   },
   bay: {
     name: 'Bay',
     wizard: {
-      nameHelper: 'Bay Name',
-      descHelper: 'Bay Description',
+      nameHelper: 'Bay name',
+      descHelper: 'Bay description',
       title: {
-        add: 'Add Bay',
-        edit: 'Edit Bay',
+        add: 'Add bay',
+        edit: 'Edit bay',
       },
     },
   },
   conductingequipment: {
     name: 'Conducting Equipment',
     wizard: {
-      nameHelper: 'Conducting Equipment Name',
-      descHelper: 'Conducting Equipment Description',
-      typeHelper: 'Conducting Equipment Type',
+      nameHelper: 'Conducting equipment name',
+      descHelper: 'Conducting equipment description',
+      typeHelper: 'Conducting equipment type',
       title: {
-        add: 'Add Conducting Equipment',
-        edit: 'Edit Conducting Equipment',
+        add: 'Add conducting equipment',
+        edit: 'Edit conducting equipment',
       },
     },
     unknownType: 'Unknown type',
@@ -110,22 +110,12 @@ export const en = {
     wizard: {
       title: {
         selectIEDs: 'Select IEDs',
-        selectLDs: 'Select Logical Devices',
-        selectLNs: 'Select Logical Nodes',
+        selectLDs: 'Select logical devices',
+        selectLNs: 'Select logical nodes',
       },
-      placeholder:
-        'No IEDs loaded yet. ' +
-        'Please load a SCL file that contains IED elements first.',
+      placeholder: 'Please load an SCL file that contains IED elements.',
     },
-  },
-  tooltip: {
-    iconbutton: {
-      add: 'Add {{childTag}}',
-      lnodewizard: 'Connect logical nodes to {{tagName}}',
-      edit: 'Edit {{tagName}} attributes',
-      forward: 'Move to another {{parentTag}} or within the same {{parentTag}}',
-      delete: 'Delete {{tagName}}',
-    },
+    tooltip: 'Create logical nodes reference',
   },
   add: 'Add',
   edit: 'Edit',
@@ -136,5 +126,6 @@ export const en = {
   undo: 'Undo',
   redo: 'Redo',
   remove: 'Remove',
-  filter: 'filter',
+  filter: 'Filter',
+  move: 'Move',
 };

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -69,6 +69,7 @@ export const en = {
     },
   },
   voltagelevel: {
+    name: 'Voltage Level',
     wizard: {
       nameHelper: 'Voltage Level Name',
       descHelper: 'Voltage Level Description',
@@ -82,6 +83,7 @@ export const en = {
     },
   },
   bay: {
+    name: 'Bay',
     wizard: {
       nameHelper: 'Bay Name',
       descHelper: 'Bay Description',
@@ -92,6 +94,7 @@ export const en = {
     },
   },
   conductingequipment: {
+    name: 'Conducting Equipment',
     wizard: {
       nameHelper: 'Conducting Equipment Name',
       descHelper: 'Conducting Equipment Description',
@@ -113,6 +116,15 @@ export const en = {
       placeholder:
         'No IEDs loaded yet. ' +
         'Please load a SCL file that contains IED elements first.',
+    },
+  },
+  tooltip: {
+    iconbutton: {
+      add: 'Add {{childTag}}',
+      lnodewizard: 'Connect logical nodes to {{tagName}}',
+      edit: 'Edit {{tagName}} attributes',
+      forward: 'Move to another {{parentTag}} or within the same {{parentTag}}',
+      delete: 'Delete {{tagName}}',
     },
   },
   add: 'Add',


### PR DESCRIPTION
Limited to icon buttons in header of editors. Other icon buttons considered to be clear.  Decided to wait for further feedback
Closes #57 