### PR TITLE
feat(logging): add tooltip to make long string readable

### DIFF
--- a/src/Logging.ts
+++ b/src/Logging.ts
@@ -153,22 +153,24 @@ export function Logging<TBase extends LitElementConstructor>(Base: TBase) {
       index: number,
       history: LogEntry[]
     ): TemplateResult {
-      return html`<mwc-list-item
-        graphic="icon"
-        style="--mdc-theme-text-icon-on-background:var(${ifDefined(
-          colors[entry.kind]
-        )})"
-        ?twoline=${entry.message}
-        ?activated=${this.currentAction == history.length - index - 1}
-      >
-        <span>
-          <!-- FIXME: replace tt with mwc-chip asap -->
-          <tt>${entry.time.toLocaleTimeString()}</tt>
-          ${entry.title}</span
+      return html` <abbr title="${entry.title}">
+        <mwc-list-item
+          graphic="icon"
+          style="--mdc-theme-text-icon-on-background:var(${ifDefined(
+            colors[entry.kind]
+          )})"
+          ?twoline=${entry.message}
+          ?activated=${this.currentAction == history.length - index - 1}
         >
-        <span slot="secondary">${entry.message}</span>
-        <mwc-icon slot="graphic">${icons[entry.kind]}</mwc-icon>
-      </mwc-list-item>`;
+          <span>
+            <!-- FIXME: replace tt with mwc-chip asap -->
+            <tt>${entry.time.toLocaleTimeString()}</tt>
+            ${entry.title}</span
+          >
+          <span slot="secondary">${entry.message}</span>
+          <mwc-icon slot="graphic">${icons[entry.kind]}</mwc-icon>
+        </mwc-list-item></abbr
+      >`;
     }
 
     renderHistory(): TemplateResult[] | TemplateResult {


### PR DESCRIPTION
I needed the log from the schema validator and found it very disturbing that long messaged were cut off. The tooltip is a quick solution. We might discuss how we want to solve this on a long run.