### PR TITLE
fix(wizard-dialog): remove button actions only after action was successful

### DIFF
--- a/src/wizard-dialog.ts
+++ b/src/wizard-dialog.ts
@@ -79,8 +79,6 @@ export class WizardDialog extends LitElement {
   /** Commits `action` if all inputs are valid, reports validity otherwise. */
   async act(action?: WizardActor, primary = true): Promise<boolean> {
     if (action === undefined) return false;
-    if (primary) this.wizard[this.pageIndex].primary = undefined;
-    else this.wizard[this.pageIndex].secondary = undefined;
     const wizardInputs = Array.from(this.inputs);
     const wizardList = <List | null>(
       this.dialog?.querySelector('filtered-list,mwc-list')
@@ -93,6 +91,8 @@ export class WizardDialog extends LitElement {
 
     const wizardActions = action(wizardInputs, this, wizardList);
     if (wizardActions.length > 0) {
+      if (primary) this.wizard[this.pageIndex].primary = undefined;
+      else this.wizard[this.pageIndex].secondary = undefined;
       this.dispatchEvent(newWizardEvent());
     }
     wizardActions.forEach(wa =>

--- a/test/unit/wizard-dialog.test.ts
+++ b/test/unit/wizard-dialog.test.ts
@@ -3,7 +3,12 @@ import { html, fixture, expect } from '@open-wc/testing';
 import '../../src/wizard-textfield.js';
 import '../../src/wizard-dialog.js';
 import { WizardDialog } from '../../src/wizard-dialog.js';
-import { WizardInput } from '../../src/foundation.js';
+import {
+  EditorAction,
+  Wizard,
+  WizardActor,
+  WizardInput,
+} from '../../src/foundation.js';
 
 describe('wizard-dialog', () => {
   let element: WizardDialog;
@@ -166,6 +171,56 @@ describe('wizard-dialog', () => {
         await element.updateComplete;
         expect(element.dialog).to.have.property('heading', 'Page 1');
       });
+    });
+
+    it('removes primary action to prevent multiple trigger during wizard close', async () => {
+      element.wizard = [
+        {
+          title: 'Page 1',
+          content: [],
+          primary: {
+            icon: 'anchor',
+            action: (
+              inputs: WizardInput[],
+              wizard: Element
+            ): EditorAction[] => {
+              return [
+                {
+                  new: {
+                    parent: element,
+                    element: element,
+                    reference: null,
+                  },
+                },
+              ];
+            },
+            label: 'Test primary',
+          },
+        },
+      ];
+      await element.updateComplete;
+      await (<HTMLElement>(
+        element.shadowRoot!.querySelector('mwc-button[slot="primaryAction"]')
+      )).click();
+      expect(element.wizard[0].primary).to.not.exist;
+    });
+    it('does not remove primary action as long as no editor action is dispatched', async () => {
+      element.wizard = [
+        {
+          title: 'Page 1',
+          content: [],
+          primary: {
+            icon: 'anchor',
+            action: () => [],
+            label: 'Test primary',
+          },
+        },
+      ];
+      await element.updateComplete;
+      await (<HTMLElement>(
+        element.shadowRoot!.querySelector('mwc-button[slot="primaryAction"]')
+      )).click();
+      expect(element.wizard[0].primary).to.exist;
     });
   });
 });


### PR DESCRIPTION
Christian, 

The fix for the bug we found, when we don't want to close the wizard, for instance because a field was incorrect, and no WizardActions where returned, the action on the button should not be removed.
