### PR TITLE
fix(logging): remove superfluous invisible reset filter

### DIFF
--- a/__snapshots__/open-scd.md
+++ b/__snapshots__/open-scd.md
@@ -392,11 +392,6 @@
     on=""
   >
   </mwc-icon-button-toggle>
-  <mwc-icon-button-toggle
-    id="resetfilter"
-    on=""
-  >
-  </mwc-icon-button-toggle>
   <mwc-list
     id="content"
     wrapfocus=""

--- a/src/Logging.ts
+++ b/src/Logging.ts
@@ -23,7 +23,6 @@ const icons = {
   warning: 'warning',
   error: 'report',
   action: 'history',
-  reset: 'none',
 };
 
 /**


### PR DESCRIPTION
The "reset" LogEvent kind accidentally introduced a new filter `mwc-icon-button` to the log dialog, which was invisible (no icon), but prevented users from filtering for only "info" kind log entries.