### PR TITLE
first draft of a working drag and drop implementation

### DIFF
--- a/__snapshots__/bay-editor.md
+++ b/__snapshots__/bay-editor.md
@@ -4,7 +4,7 @@
 
 ```html
 <section tabindex="0">
-  <h3>
+  <h3 draggable="true">
     COUPLING_BAY — Bay
     <abbr title="[add]">
       <mwc-icon-button icon="playlist_add">
@@ -57,7 +57,7 @@
 
 ```html
 <section tabindex="0">
-  <h3>
+  <h3 draggable="true">
     COUPLING_BAY — Bay
   </h3>
   <div>

--- a/__snapshots__/conducting-equipment-editor.md
+++ b/__snapshots__/conducting-equipment-editor.md
@@ -4,6 +4,7 @@
 
 ```html
 <div
+  draggable="true"
   id="container"
   tabindex="0"
 >
@@ -44,6 +45,7 @@
 
 ```html
 <div
+  draggable="true"
   id="container"
   tabindex="0"
 >

--- a/__snapshots__/substation-editor.md
+++ b/__snapshots__/substation-editor.md
@@ -4,7 +4,7 @@
 
 ```html
 <section tabindex="0">
-  <h1>
+  <h1 draggable="true">
     AA1 — Substation
     <abbr title="[add]">
       <mwc-icon-button icon="playlist_add">
@@ -47,7 +47,7 @@
 
 ```html
 <section tabindex="0">
-  <h1>
+  <h1 draggable="true">
     AA1 — Substation
   </h1>
   <voltage-level-editor readonly="">

--- a/__snapshots__/voltage-level-editor.md
+++ b/__snapshots__/voltage-level-editor.md
@@ -4,7 +4,7 @@
 
 ```html
 <section tabindex="0">
-  <h2>
+  <h2 draggable="true">
     E1 — Voltage Level
       (110.0 kV)
     <abbr title="[add]">
@@ -50,7 +50,7 @@
 
 ```html
 <section tabindex="0">
-  <h2>
+  <h2 draggable="true">
     E1 — Voltage Level
       (110.0 kV)
   </h2>

--- a/src/foundation.ts
+++ b/src/foundation.ts
@@ -1353,10 +1353,10 @@ const sCLTags = [
 
 export type SCLTag = typeof sCLTags[number];
 
-const tagSet = new Set<string>(sCLTags);
+export const SCLTagSet = new Set<string>(sCLTags);
 
 function isSCLTag(tag: string): tag is SCLTag {
-  return tagSet.has(tag);
+  return SCLTagSet.has(tag);
 }
 
 const tBaseNameSequence = ['Text', 'Private'] as const;

--- a/src/zeroline/bay-editor.ts
+++ b/src/zeroline/bay-editor.ts
@@ -24,7 +24,6 @@ import { wizards } from '../wizards/wizard-library.js';
 
 import { VoltageLevelEditor } from './voltage-level-editor.js';
 import './conducting-equipment-editor.js';
-import { IedEditor } from './ied-editor.js';
 import { ConductingEquipmentEditor } from './conducting-equipment-editor.js';
 
 /** [[`SubstationEditor`]] subeditor for a `Bay` element. */
@@ -140,9 +139,9 @@ export class BayEditor extends LitElement {
     return html`<section
       tabindex="0"
       @dragover="${(e: DragEvent) =>
-        dragOver(this, e, ConductingEquipmentEditor, BayEditor)}"
+        dragOver(this, e, "ConductingEquipment", "Bay")}"
       @drop="${(e: DragEvent) =>
-        drop(this, e, ConductingEquipmentEditor, BayEditor)}"
+        drop(this, e)}"
       @dragleave="${() => dragLeave(this)}"
       @dragend="${() => dragEnd(this)}"
     >

--- a/src/zeroline/bay-editor.ts
+++ b/src/zeroline/bay-editor.ts
@@ -8,13 +8,24 @@ import {
 } from 'lit-element';
 import { translate } from 'lit-translate';
 
-import { startMove, styles, cloneSubstationElement } from './foundation.js';
+import {
+  startMove,
+  styles,
+  cloneSubstationElement,
+  dragOver,
+  dragStart,
+  drop,
+  dragLeave,
+  dragEnd,
+} from './foundation.js';
 import { newActionEvent, newWizardEvent } from '../foundation.js';
 
 import { wizards } from '../wizards/wizard-library.js';
 
 import { VoltageLevelEditor } from './voltage-level-editor.js';
 import './conducting-equipment-editor.js';
+import { IedEditor } from './ied-editor.js';
+import { ConductingEquipmentEditor } from './conducting-equipment-editor.js';
 
 /** [[`SubstationEditor`]] subeditor for a `Bay` element. */
 @customElement('bay-editor')
@@ -77,7 +88,10 @@ export class BayEditor extends LitElement {
   }
 
   renderHeader(): TemplateResult {
-    return html`<h3>
+    return html`<h3
+      draggable="true"
+      @dragstart="${(e: DragEvent) => dragStart(this, e)}"
+    >
       ${this.name} ${this.desc === null ? '' : html`&mdash;`} ${this.desc}
       ${this.readonly
         ? html``
@@ -123,7 +137,15 @@ export class BayEditor extends LitElement {
   }
 
   render(): TemplateResult {
-    return html`<section tabindex="0">
+    return html`<section
+      tabindex="0"
+      @dragover="${(e: DragEvent) =>
+        dragOver(this, e, ConductingEquipmentEditor, BayEditor)}"
+      @drop="${(e: DragEvent) =>
+        drop(this, e, ConductingEquipmentEditor, BayEditor)}"
+      @dragleave="${() => dragLeave(this)}"
+      @dragend="${() => dragEnd(this)}"
+    >
       ${this.renderHeader()}
       <div>
         ${this.renderIedContainer()}
@@ -133,9 +155,9 @@ export class BayEditor extends LitElement {
               ':root > Substation > VoltageLevel > Bay > ConductingEquipment'
             ) ?? []
           ).map(
-            voltageLevel =>
+            conductingEquipment =>
               html`<conducting-equipment-editor
-                .element=${voltageLevel}
+                .element=${conductingEquipment}
                 ?readonly=${this.readonly}
               ></conducting-equipment-editor>`
           )}

--- a/src/zeroline/conducting-equipment-editor.ts
+++ b/src/zeroline/conducting-equipment-editor.ts
@@ -7,7 +7,14 @@ import {
   TemplateResult,
 } from 'lit-element';
 
-import { startMove } from './foundation.js';
+import {
+  startMove,
+  dragStart,
+  dragEnd,
+  dragOver,
+  drop,
+  dragLeave,
+} from './foundation.js';
 import { newActionEvent, newWizardEvent } from '../foundation.js';
 
 import {
@@ -81,7 +88,18 @@ export class ConductingEquipmentEditor extends LitElement {
 
   render(): TemplateResult {
     return html`
-      <div id="container" tabindex="0">
+      <div
+        id="container"
+        tabindex="0"
+        draggable="true"
+        @dragstart="${(e: DragEvent) => dragStart(this, e)}"
+        @dragover="${(e: DragEvent) =>
+          dragOver(this, e, BayEditor, ConductingEquipmentEditor)}"
+        @drop="${(e: DragEvent) =>
+          drop(this, e, BayEditor, ConductingEquipmentEditor)}"
+        @dragleave="${() => dragLeave(this)}"
+        @dragend="${() => dragEnd(this)}"
+      >
         ${typeIcon(this.element)}
         ${this.readonly
           ? html``

--- a/src/zeroline/conducting-equipment-editor.ts
+++ b/src/zeroline/conducting-equipment-editor.ts
@@ -94,9 +94,9 @@ export class ConductingEquipmentEditor extends LitElement {
         draggable="true"
         @dragstart="${(e: DragEvent) => dragStart(this, e)}"
         @dragover="${(e: DragEvent) =>
-          dragOver(this, e, BayEditor, ConductingEquipmentEditor)}"
+          dragOver(this, e, "Bay", "ConductingEquipment")}"
         @drop="${(e: DragEvent) =>
-          drop(this, e, BayEditor, ConductingEquipmentEditor)}"
+          drop(this, e)}"
         @dragleave="${() => dragLeave(this)}"
         @dragend="${() => dragEnd(this)}"
       >

--- a/src/zeroline/foundation.ts
+++ b/src/zeroline/foundation.ts
@@ -6,6 +6,7 @@ import {
   identity,
   SCLTagSet,
   selector,
+  SCLTag,
 } from '../foundation.js';
 
 import { BayEditor } from './bay-editor.js';
@@ -148,7 +149,7 @@ export function dragStart<E extends ElementEditor>(
 ) {
   editor.classList.add('moving');
   event.dataTransfer?.setData(
-    editor.tagName,
+    editor.element.tagName,
     identity(editor.element).toString()
   );
 }
@@ -156,11 +157,11 @@ export function dragStart<E extends ElementEditor>(
 export function dragOver<E extends ElementEditor>(
   editor: E,
   event: DragEvent,
-  ...allowedEditorTypes: (new () => ElementEditor)[]
-) {
+  ...allowedEditorTypes: SCLTag[]
+) {  
   const types = event.dataTransfer?.types;
   if (
-    allowedEditorTypes.some(t => types?.includes(new t().tagName.toLowerCase()))
+    allowedEditorTypes.some(t => types?.includes(t.toLowerCase()))
   ) {
     event.preventDefault();
     editor.classList.add('dragOver');
@@ -178,17 +179,13 @@ export function dragEnd<E extends ElementEditor>(editor: E) {
 
 export function drop<E extends ElementEditor>(
   targetEditor: E,
-  event: DragEvent,
-  ...allowedEditorTypes: (new () => ElementEditor)[]
+  event: DragEvent  
 ) {
   const tag = event.dataTransfer?.items[0].type!;
   const identity = event.dataTransfer?.getData(tag)!;
-  const xmlTag = Array.from(SCLTagSet)
-    .reduce((acc, x) => acc.set(x.toLowerCase(), x), new Map())
-    .get(
-      // TODO: is there a better solution to convert an editor tag to a SCL tag?
-      tag.slice(0, tag.lastIndexOf('-')).replace('-', '')
-    );
+  
+  // the manual search for the SCL tag is necessary as all types in the DragEvent dataTransfer get converted to lower case automatically 
+  const xmlTag = Array.from(SCLTagSet).find(x => x.toLowerCase() == tag)
 
   if (xmlTag) {
     const element = targetEditor.element.ownerDocument.querySelector(

--- a/src/zeroline/foundation.ts
+++ b/src/zeroline/foundation.ts
@@ -157,11 +157,11 @@ export function dragStart<E extends ElementEditor>(
 export function dragOver<E extends ElementEditor>(
   editor: E,
   event: DragEvent,
-  ...allowedEditorTypes: SCLTag[]
+  ...allowedSCLTags: SCLTag[]
 ) {  
   const types = event.dataTransfer?.types;
   if (
-    allowedEditorTypes.some(t => types?.includes(t.toLowerCase()))
+    allowedSCLTags.some(t => types?.includes(t.toLowerCase()))
   ) {
     event.preventDefault();
     editor.classList.add('dragOver');
@@ -183,7 +183,7 @@ export function drop<E extends ElementEditor>(
 ) {
   const tag = event.dataTransfer?.items[0].type!;
   const identity = event.dataTransfer?.getData(tag)!;
-  
+
   // the manual search for the SCL tag is necessary as all types in the DragEvent dataTransfer get converted to lower case automatically 
   const xmlTag = Array.from(SCLTagSet).find(x => x.toLowerCase() == tag)
 

--- a/src/zeroline/substation-editor.ts
+++ b/src/zeroline/substation-editor.ts
@@ -148,9 +148,9 @@ export class SubstationEditor extends LitElement {
       <section
         tabindex="0"
         @dragover="${(e: DragEvent) =>
-          dragOver(this, e, VoltageLevelEditor, SubstationEditor)}"
+          dragOver(this, e, "VoltageLevel", "Substation")}"
         @drop="${(e: DragEvent) =>
-          drop(this, e, VoltageLevelEditor, SubstationEditor)}"
+          drop(this, e)}"
         @dragleave="${() => dragLeave(this)}"
         @dragend="${() => dragEnd(this)}"
       >

--- a/src/zeroline/substation-editor.ts
+++ b/src/zeroline/substation-editor.ts
@@ -12,12 +12,18 @@ import { wizards } from '../wizards/wizard-library.js';
 
 import {
   cloneSubstationElement,
-  selectors,
   startMove,
   styles,
+  dragOver,
+  drop,
+  selectors,
+  dragLeave,
+  dragEnd,
+  dragStart,
 } from './foundation.js';
 
 import './voltage-level-editor.js';
+import { VoltageLevelEditor } from './voltage-level-editor.js';
 
 /** [[`Substation`]] plugin subeditor for editing `Substation` sections. */
 @customElement('substation-editor')
@@ -86,7 +92,8 @@ export class SubstationEditor extends LitElement {
 
   renderHeader(): TemplateResult {
     return html`
-        <h1>
+        <h1 draggable="true" @dragstart="${(event: DragEvent) =>
+          dragStart(this, event)}">
           ${this.name} ${this.desc === null ? '' : html`&mdash;`} ${this.desc}
           ${
             this.readonly
@@ -138,7 +145,15 @@ export class SubstationEditor extends LitElement {
 
   render(): TemplateResult {
     return html`
-      <section tabindex="0">
+      <section
+        tabindex="0"
+        @dragover="${(e: DragEvent) =>
+          dragOver(this, e, VoltageLevelEditor, SubstationEditor)}"
+        @drop="${(e: DragEvent) =>
+          drop(this, e, VoltageLevelEditor, SubstationEditor)}"
+        @dragleave="${() => dragLeave(this)}"
+        @dragend="${() => dragEnd(this)}"
+      >
         ${this.renderHeader()} ${this.renderIedContainer()}
         ${Array.from(this.element.querySelectorAll(selectors.VoltageLevel)).map(
           voltageLevel =>

--- a/src/zeroline/voltage-level-editor.ts
+++ b/src/zeroline/voltage-level-editor.ts
@@ -149,8 +149,8 @@ export class VoltageLevelEditor extends LitElement {
     return html`<section
       tabindex="0"
       @dragover="${(e: DragEvent) =>
-        dragOver(this, e, BayEditor, VoltageLevelEditor)}"
-      @drop="${(e: DragEvent) => drop(this, e, BayEditor, VoltageLevelEditor)}"
+        dragOver(this, e, "Bay", "VoltageLevel")}"
+      @drop="${(e: DragEvent) => drop(this, e)}"
       @dragleave="${() => dragLeave(this)}"
       @dragend="${() => dragEnd(this)}"
     >

--- a/src/zeroline/voltage-level-editor.ts
+++ b/src/zeroline/voltage-level-editor.ts
@@ -13,11 +13,17 @@ import {
   startMove,
   styles,
   cloneSubstationElement,
+  dragOver,
+  dragStart,
+  drop,
+  dragLeave,
+  dragEnd,
 } from './foundation.js';
 import './bay-editor.js';
 import { SubstationEditor } from './substation-editor.js';
 import { wizards } from '../wizards/wizard-library.js';
-import { newActionEvent, newWizardEvent } from '../foundation.js';
+import { newActionEvent, newWizardEvent, selector } from '../foundation.js';
+import { BayEditor } from './bay-editor.js';
 
 /** [[`Substation`]] subeditor for a `VoltageLevel` element. */
 @customElement('voltage-level-editor')
@@ -89,7 +95,10 @@ export class VoltageLevelEditor extends LitElement {
   }
 
   renderHeader(): TemplateResult {
-    return html`<h2>
+    return html`<h2
+      draggable="true"
+      @dragstart="${(e: DragEvent) => dragStart(this, e)}"
+    >
       ${this.name} ${this.desc === null ? '' : html`&mdash;`} ${this.desc}
       ${this.voltage === null ? '' : html`(${this.voltage})`}
       ${this.readonly
@@ -137,7 +146,14 @@ export class VoltageLevelEditor extends LitElement {
   }
 
   render(): TemplateResult {
-    return html`<section tabindex="0">
+    return html`<section
+      tabindex="0"
+      @dragover="${(e: DragEvent) =>
+        dragOver(this, e, BayEditor, VoltageLevelEditor)}"
+      @drop="${(e: DragEvent) => drop(this, e, BayEditor, VoltageLevelEditor)}"
+      @dragleave="${() => dragLeave(this)}"
+      @dragend="${() => dragEnd(this)}"
+    >
       ${this.renderHeader()} ${this.renderIedContainer()}
       <div id="bayContainer">
         ${Array.from(this.element?.querySelectorAll(selectors.Bay) ?? []).map(


### PR DESCRIPTION
This is a working drag and drop implementation for the substation editor. Still missing things like unit tests and a review. Currently follows the same semantic as the current move implementation. 

I'm not too happy about the current drop implementation as it relies on the fact that the current editor tags have a direct relation to the SCL tags. An explicit way to specify that e.g. the voltage-level-editor edits the "VoltageLevel" SCL element would be better. 