### PR TITLE
fix(wizard/commap): neglect ExtRef without valid source

### DIFF
--- a/src/wizards/commmap-wizards.ts
+++ b/src/wizards/commmap-wizards.ts
@@ -76,11 +76,6 @@ export function communicationMappingWizard(
       if (!connections.has(key)) connections.set(key, []);
       connections.get(key)?.push(element);
     });
-    if (controlBlocks.size === 0) {
-      const key = ' |  | ' + iedName;
-      if (!connections.has(key)) connections.set(key, []);
-      connections.get(key)?.push(element);
-    }
   });
 
   return [


### PR DESCRIPTION
This fix for now is to ignore all `ExtRefs` that have no valid source. 
Closes #297 