### PR TITLE
feat(SingleLineDiagram): add PowerTransformer to the SLD

### DIFF
--- a/__snapshots__/Single Line Diagram drawing.md
+++ b/__snapshots__/Single Line Diagram drawing.md
@@ -1,0 +1,68 @@
+# `Single Line Diagram drawing`
+
+## `creates a group element for every given PowerTransformer element that`
+
+####   `looks like its latest snapshot`
+
+```html
+<g
+  id="AA1>TA1"
+  sxy:x="1"
+  sxy:y="9"
+  type="PowerTransformer"
+>
+  <line
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-width="1.5"
+    transform="translate(64,576) scale(1.5)"
+    x1="12.5"
+    x2="12.5"
+    y1="2"
+    y2="5"
+  >
+  </line>
+  <circle
+    cx="12.5"
+    cy="10"
+    fill="transparent"
+    r="5"
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-width="1.5"
+    transform="translate(64,576) scale(1.5)"
+  >
+  </circle>
+  <circle
+    cx="12.5"
+    cy="15"
+    fill="transparent"
+    r="5"
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-width="1.5"
+    transform="translate(64,576) scale(1.5)"
+  >
+  </circle>
+  <line
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-width="1.5"
+    transform="translate(64,576) scale(1.5)"
+    x1="12.5"
+    x2="12.5"
+    y1="20"
+    y2="23"
+  >
+  </line>
+  <text
+    style="font-family: Roboto, sans-serif; font-weight: 300; font-size: x-small"
+    x="49"
+    y="606"
+  >
+    TA1
+  </text>
+</g>
+
+```
+

--- a/src/editors/SingleLineDiagram.ts
+++ b/src/editors/SingleLineDiagram.ts
@@ -7,12 +7,13 @@ import {
   TemplateResult,
 } from 'lit-element';
 
+import { identity } from '../foundation.js';
+
 import panzoom from 'panzoom';
 
 import { Side } from '../../public/js/ortho-connector.js';
 import {
   getAbsolutePosition,
-  getParentElementName,
   getAbsolutePositionWithCustomCoordinates,
   SVG_GRID_SIZE,
   drawRoute,
@@ -25,7 +26,6 @@ import {
   createConnectivityNodeElement,
 } from './singlelinediagram/sld-drawing.js';
 import {
-  getNameAttribute,
   getSCLCoordinates,
   isBusBar,
   calculateConnectivityNodeSclCoordinates,
@@ -91,7 +91,7 @@ export default class SingleLineDiagramPlugin extends LitElement {
     this.bays.forEach(bay => {
       const bayElement = createBayElement(bay);
 
-      this.addElementToGroup(bayElement, getParentElementName(bay)!);
+      this.addElementToGroup(bayElement, identity(bay.parentElement));
     });
   }
 
@@ -110,7 +110,7 @@ export default class SingleLineDiagramPlugin extends LitElement {
       .forEach(equipment => {
         const eqElement = createConductingEquipmentElement(equipment);
 
-        this.addElementToGroup(eqElement, getParentElementName(equipment)!);
+        this.addElementToGroup(eqElement, identity(equipment.parentElement));
       });
   }
 
@@ -129,7 +129,7 @@ export default class SingleLineDiagramPlugin extends LitElement {
             cNodePosition
           );
 
-          this.addElementToGroup(cNodeElement, getParentElementName(cNode)!);
+          this.addElementToGroup(cNodeElement, identity(cNode.parentElement));
         });
     });
   }
@@ -144,7 +144,7 @@ export default class SingleLineDiagramPlugin extends LitElement {
         this.biggestVoltageLevelXCoordinate
       );
 
-      this.addElementToGroup(busBarElement, getParentElementName(busBar)!);
+      this.addElementToGroup(busBarElement, identity(busBar.parentElement));
     });
   }
 
@@ -195,11 +195,7 @@ export default class SingleLineDiagramPlugin extends LitElement {
                 terminalElement!
               );
               this.svg
-                .querySelectorAll(
-                  `g[id="${getNameAttribute(bay)}"] > g[id="${getNameAttribute(
-                    element
-                  )}"]`
-                )
+                .querySelectorAll(`g[id="${identity(element)}"]`)
                 .forEach(eq => eq.appendChild(terminal));
             });
         });
@@ -251,11 +247,7 @@ export default class SingleLineDiagramPlugin extends LitElement {
             terminalElement!
           );
           this.svg
-            .querySelectorAll(
-              `g[id="${getNameAttribute(
-                element.parentElement!
-              )}"] > g[id="${getNameAttribute(element)}"]`
-            )
+            .querySelectorAll(` g[id="${identity(element)}"]`)
             .forEach(eq => eq.appendChild(terminal));
         });
     });
@@ -310,11 +302,11 @@ export default class SingleLineDiagramPlugin extends LitElement {
   /**
    * Add an element to a specific <g> element.
    * @param elementToAdd - The element to add.
-   * @param groupName - The name of the group
+   * @param groupName - Identity sting if the element
    */
-  addElementToGroup(elementToAdd: Element, groupName: string): void {
+  addElementToGroup(elementToAdd: Element, identity: string | number): void {
     this.svg
-      .querySelectorAll(`g[id="${groupName}"]`)
+      .querySelectorAll(`g[id="${identity}"]`)
       .forEach(group => group.appendChild(elementToAdd));
   }
 

--- a/src/editors/SingleLineDiagram.ts
+++ b/src/editors/SingleLineDiagram.ts
@@ -24,6 +24,7 @@ import {
   createConductingEquipmentElement,
   createConnectivityNodeElement,
   getAbsolutePositionConnectivityNode,
+  getBusBarLength,
 } from './singlelinediagram/sld-drawing.js';
 import {
   isBusBar,
@@ -139,7 +140,7 @@ export default class SingleLineDiagramPlugin extends LitElement {
     this.busBars.forEach(busBar => {
       const busBarElement = createBusBarElement(
         busBar,
-        this.biggestVoltageLevelXCoordinate
+        getBusBarLength(busBar.parentElement ?? this.doc)
       );
 
       this.addElementToGroup(busBarElement, identity(busBar.parentElement));
@@ -259,38 +260,6 @@ export default class SingleLineDiagramPlugin extends LitElement {
 
     this.drawConnectivityNodeConnections();
     this.drawBusBarConnections();
-  }
-
-  /**
-   * Calculate the absolute X coordinate for the bus bar.
-   */
-  get biggestVoltageLevelXCoordinate(): number {
-    let biggestXOfBay = 0;
-    let finalX = 0;
-
-    // First get the Bay with the 'biggest' x (otherwise all bays/elements are being processed)
-    Array.from(this.doc.querySelectorAll('Bay')).forEach(
-      bay =>
-        (biggestXOfBay = Math.max(biggestXOfBay, getSCLCoordinates(bay).x!))
-    );
-
-    // Then, get the 'biggest' x available in this particular bay.
-    Array.from(this.doc.querySelectorAll('Bay'))
-      .filter(bay => getSCLCoordinates(bay).x! == biggestXOfBay)
-      .forEach(bay => {
-        // Also, an extra SVG_GRID_SIZE is added for making it a bit longer.
-        bay
-          .querySelectorAll('ConductingEquipment')
-          .forEach(
-            equipment =>
-              (finalX = Math.max(
-                finalX,
-                getAbsolutePosition(equipment).x! + SVG_GRID_SIZE
-              ))
-          );
-      });
-
-    return finalX;
   }
 
   /**

--- a/src/editors/SingleLineDiagram.ts
+++ b/src/editors/SingleLineDiagram.ts
@@ -25,6 +25,7 @@ import {
   createConnectivityNodeElement,
   getAbsolutePositionConnectivityNode,
   getBusBarLength,
+  createPowerTransformerElement,
 } from './singlelinediagram/sld-drawing.js';
 import {
   isBusBar,
@@ -95,6 +96,27 @@ export default class SingleLineDiagramPlugin extends LitElement {
   }
 
   /**
+   * Draw all available `PowerTransformer`s of this SCL document.
+   * Should only be a <g> element.
+   */
+  drawPowerTransformers(): void {
+    Array.from(this.doc.querySelectorAll('PowerTransformer')).forEach(
+      powerTransformer => {
+        const powerTransformerElement =
+          createPowerTransformerElement(powerTransformer);
+
+        if (powerTransformer.parentElement?.tagName === 'Substation')
+          this.svg.appendChild(powerTransformerElement);
+        else
+          this.addElementToGroup(
+            powerTransformerElement,
+            identity(powerTransformer.parentElement)
+          );
+      }
+    );
+  }
+
+  /**
    * Draw all available Conducting Equipments of this SCL document.
    * Should only be a <g> element.
    */
@@ -154,7 +176,9 @@ export default class SingleLineDiagramPlugin extends LitElement {
         .forEach(cNode => {
           const cnPosition = getAbsolutePositionConnectivityNode(cNode);
 
-          Array.from(this.doc.querySelectorAll('ConductingEquipment'))
+          Array.from(
+            this.doc.querySelectorAll('ConductingEquipment, PowerTransformer')
+          )
             .filter(element =>
               element.querySelector(
                 `Terminal[connectivityNode="${cNode.getAttribute('pathName')}"]`
@@ -255,6 +279,7 @@ export default class SingleLineDiagramPlugin extends LitElement {
     this.drawVoltageLevels();
     this.drawBays();
     this.drawConductingEquipments();
+    this.drawPowerTransformers();
     this.drawConnectivityNodes();
     this.drawBusBars();
 

--- a/src/editors/SingleLineDiagram.ts
+++ b/src/editors/SingleLineDiagram.ts
@@ -14,7 +14,6 @@ import panzoom from 'panzoom';
 import { Side } from '../../public/js/ortho-connector.js';
 import {
   getAbsolutePosition,
-  getAbsolutePositionWithCustomCoordinates,
   SVG_GRID_SIZE,
   drawRoute,
   DEFAULT_ELEMENT_SIZE,
@@ -24,11 +23,10 @@ import {
   createBayElement,
   createConductingEquipmentElement,
   createConnectivityNodeElement,
+  getAbsolutePositionConnectivityNode,
 } from './singlelinediagram/sld-drawing.js';
 import {
-  getSCLCoordinates,
   isBusBar,
-  calculateConnectivityNodeSclCoordinates,
   getConnectedTerminals,
   getPathNameAttribute,
 } from './singlelinediagram/foundation.js';
@@ -123,7 +121,7 @@ export default class SingleLineDiagramPlugin extends LitElement {
         .filter(cNode => cNode.getAttribute('name') !== 'grounded')
         .filter(cNode => getConnectedTerminals(cNode).length > 0)
         .forEach(cNode => {
-          const cNodePosition = calculateConnectivityNodeSclCoordinates(cNode);
+          const cNodePosition = getAbsolutePositionConnectivityNode(cNode);
           const cNodeElement = createConnectivityNodeElement(
             cNode,
             cNodePosition
@@ -153,11 +151,7 @@ export default class SingleLineDiagramPlugin extends LitElement {
       Array.from(bay.querySelectorAll('ConnectivityNode'))
         .filter(cNode => cNode.getAttribute('name') !== 'grounded')
         .forEach(cNode => {
-          const position = calculateConnectivityNodeSclCoordinates(cNode);
-          const cnPosition = getAbsolutePositionWithCustomCoordinates(
-            cNode,
-            position
-          );
+          const cnPosition = getAbsolutePositionConnectivityNode(cNode);
 
           Array.from(this.doc.querySelectorAll('ConductingEquipment'))
             .filter(element =>

--- a/src/editors/singlelinediagram/sld-drawing.ts
+++ b/src/editors/singlelinediagram/sld-drawing.ts
@@ -4,7 +4,10 @@ import {
 } from '../../../public/js/ortho-connector.js';
 import { identity } from '../../foundation.js';
 import { getIcon } from '../../zeroline/foundation.js';
-import { connectivityNodeIcon } from '../../icons.js';
+import {
+  connectivityNodeIcon,
+  powerTransformerTwoWindingIcon,
+} from '../../icons.js';
 
 import {
   getRelativeCoordinates,
@@ -94,7 +97,7 @@ export function getParentElementName(
  * @param element - The element.
  * @returns The <g> element.
  */
-export function createGroupElement(element: Element): SVGElement {
+function createGroupElement(element: Element): SVGElement {
   const finalElement = document.createElementNS(
     'http://www.w3.org/2000/svg',
     'g'
@@ -274,6 +277,39 @@ export function createConductingEquipmentElement(
 
   const text = createTextElement(
     getNameAttribute(equipmentElement)!,
+    { x: absolutePosition.x! - 15, y: absolutePosition.y! + 30 },
+    'x-small'
+  );
+  groupElement.appendChild(text);
+
+  return groupElement;
+}
+
+/**
+ * Create a PowerTransformer element.
+ * @param powerTransformerElement - The SCL PowerTransformer element
+ * @returns The Power Transformer SVG element.
+ */
+export function createPowerTransformerElement(
+  powerTransformerElement: Element
+): SVGElement {
+  const groupElement = createGroupElement(powerTransformerElement);
+
+  const absolutePosition = getAbsolutePosition(powerTransformerElement);
+  const parsedIcon = new DOMParser().parseFromString(
+    powerTransformerTwoWindingIcon.strings[0],
+    'application/xml'
+  );
+  parsedIcon.querySelectorAll('circle,path,line').forEach(icon => {
+    icon.setAttribute(
+      'transform',
+      `translate(${absolutePosition.x},${absolutePosition.y}) scale(1.5)`
+    );
+    groupElement.appendChild(icon);
+  });
+
+  const text = createTextElement(
+    getNameAttribute(powerTransformerElement)!,
     { x: absolutePosition.x! - 15, y: absolutePosition.y! + 30 },
     'x-small'
   );

--- a/src/editors/singlelinediagram/sld-drawing.ts
+++ b/src/editors/singlelinediagram/sld-drawing.ts
@@ -3,8 +3,8 @@ import {
   Side,
 } from '../../../public/js/ortho-connector.js';
 import { identity } from '../../foundation.js';
-
 import { getIcon } from '../../zeroline/foundation.js';
+import { connectivityNodeIcon } from '../../icons.js';
 
 import {
   getSCLCoordinates,
@@ -333,7 +333,7 @@ export function createConnectivityNodeElement(
   );
 
   const parsedIcon = new DOMParser().parseFromString(
-    getIcon(cNodeElement).strings[0],
+    connectivityNodeIcon.strings[0],
     'application/xml'
   );
   parsedIcon.querySelectorAll('circle').forEach(icon => {

--- a/src/editors/singlelinediagram/sld-drawing.ts
+++ b/src/editors/singlelinediagram/sld-drawing.ts
@@ -2,6 +2,7 @@ import {
   OrthogonalConnector,
   Side,
 } from '../../../public/js/ortho-connector.js';
+import { identity } from '../../foundation.js';
 
 import { getIcon } from '../../zeroline/foundation.js';
 
@@ -132,8 +133,12 @@ export function createGroupElement(element: Element): SVGElement {
     'http://www.w3.org/2000/svg',
     'g'
   );
-  finalElement.tabIndex = 0;
-  finalElement.setAttribute('id', getNameAttribute(element)!);
+  finalElement.setAttribute(
+    'id',
+    typeof identity(element) === 'string'
+      ? <string>identity(element)
+      : 'unidentifiable'
+  );
   finalElement.setAttribute('type', element.tagName);
 
   const description = getDescriptionAttribute(element);
@@ -208,6 +213,11 @@ export function createTerminalElement(
 ): SVGElement {
   const groupElement = createGroupElement(terminalElement);
 
+  const terminalIdentity =
+    typeof identity(terminalElement) === 'string'
+      ? <string>identity(terminalElement)
+      : 'unidentifiable';
+
   const terminalName = getNameAttribute(terminalElement)!;
   const pointToDrawTerminalOn = getAbsolutePositionTerminal(
     elementPosition,
@@ -216,7 +226,7 @@ export function createTerminalElement(
 
   // TODO: Add this to the icons.ts file.
   const icon = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
-  icon.setAttribute('id', `${terminalName}`);
+  icon.setAttribute('id', `${terminalIdentity}`);
   icon.setAttribute('cx', `${pointToDrawTerminalOn.x}`);
   icon.setAttribute('cy', `${pointToDrawTerminalOn.y}`);
   icon.setAttribute('r', '2');

--- a/src/editors/singlelinediagram/sld-drawing.ts
+++ b/src/editors/singlelinediagram/sld-drawing.ts
@@ -448,3 +448,18 @@ function getAbsolutePositionTerminal(
     }
   }
 }
+
+/**
+ * Calculate length of the busbar that is depending on the most far right equipment
+ * @param root - Either the whole SCL file or the voltage level where the bus bar resides
+ * @returns - the length of the bus bar
+ */
+export function getBusBarLength(root: Element | XMLDocument): number {
+  return (
+    Math.max(
+      ...Array.from(
+        root.querySelectorAll('ConductingEquipment, PowerTransformer')
+      ).map(equipment => getAbsolutePosition(equipment).x!)
+    ) + SVG_GRID_SIZE
+  );
+}

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -561,14 +561,58 @@ export const generalConductingEquipmentIcon = html`<svg
 </svg>`;
 
 export const connectivityNodeIcon = html`<svg
-  xmlns="http://www.w3.org/2000/svg">
-    <circle
-      stroke="currentColor"
-      fill="none"
-      stroke-width="1"
-      cx="12.5"
-      cy="12.5"
-      r="4"/>
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <circle
+    stroke="currentColor"
+    fill="none"
+    stroke-width="1"
+    cx="12.5"
+    cy="12.5"
+    r="4"
+  />
+</svg>`;
+
+export const powerTransformerTwoWindingIcon = html`<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 25 25"
+>
+  <line
+    x1="12.5"
+    y1="2"
+    x2="12.5"
+    y2="5"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+  />
+  <circle
+    cx="12.5"
+    cy="10"
+    r="5"
+    stroke="currentColor"
+    fill="transparent"
+    stroke-width="1.5"
+    stroke-linecap="round"
+  />
+  <circle
+    cx="12.5"
+    cy="15"
+    r="5"
+    stroke="currentColor"
+    fill="transparent"
+    stroke-width="1.5"
+    stroke-linecap="round"
+  />
+  <line
+    x1="12.5"
+    y1="20"
+    x2="12.5"
+    y2="23"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+  />
 </svg>`;
 
 export const openSCDIcon = html` <svg

--- a/src/zeroline/foundation.ts
+++ b/src/zeroline/foundation.ts
@@ -1,10 +1,14 @@
 import { css, TemplateResult } from 'lit-element';
 
+import { newActionEvent, isPublic } from '../foundation.js';
 import {
-  newActionEvent,
-  isPublic,
-} from '../foundation.js';
-import { circuitBreakerIcon, disconnectorIcon, currentTransformerIcon, voltageTransformerIcon, earthSwitchIcon, generalConductingEquipmentIcon, connectivityNodeIcon } from '../icons.js';
+  circuitBreakerIcon,
+  disconnectorIcon,
+  currentTransformerIcon,
+  voltageTransformerIcon,
+  earthSwitchIcon,
+  generalConductingEquipmentIcon,
+} from '../icons.js';
 import { BayEditor } from './bay-editor.js';
 import { SubstationEditor } from './substation-editor.js';
 import { VoltageLevelEditor } from './voltage-level-editor.js';
@@ -212,7 +216,7 @@ export function startMove<E extends ElementEditor, P extends ElementEditor>(
 
 /**
  * Get the correct icon for a specific Conducting Equipment.
- * @param condEq The Conducting Equipment to search the icon for.
+ * @param condEq - The Conducting Equipment to search the icon for.
  * @returns The icon.
  */
 export function getIcon(condEq: Element): TemplateResult {
@@ -220,11 +224,11 @@ export function getIcon(condEq: Element): TemplateResult {
 }
 
 function typeStr(condEq: Element): string {
-  if (condEq.getAttribute('type') === 'DIS' &&
-    condEq.querySelector('Terminal')?.getAttribute('cNodeName') === 'grounded') {
+  if (
+    condEq.getAttribute('type') === 'DIS' &&
+    condEq.querySelector('Terminal')?.getAttribute('cNodeName') === 'grounded'
+  ) {
     return 'ERS';
-  } else if (condEq.tagName == 'ConnectivityNode') {
-    return 'CN';
   } else {
     return condEq.getAttribute('type') ?? '';
   }
@@ -236,7 +240,6 @@ const typeIcons: Partial<Record<string, TemplateResult>> = {
   CTR: currentTransformerIcon,
   VTR: voltageTransformerIcon,
   ERS: earthSwitchIcon,
-  CN: connectivityNodeIcon
 };
 
 // Substation element hierarchy

--- a/test/testfiles/valid2007B4withSubstationXY.scd
+++ b/test/testfiles/valid2007B4withSubstationXY.scd
@@ -7,7 +7,6 @@
 		</History>
 	</Header>
 	<Substation name="AA1" desc="Substation">
-        <Private type="ABBPCMInternalObjRef">0f6c4a8e-0904-4f41-9b01-03444ba9efc7</Private>
         <VoltageLevel sxy:x="1" sxy:y="3" name="J1" desc="Voltage Level">
             <Private type="ABBPCMInternalObjRef">b80686f1-a514-477b-a83b-78f1cbe8a582</Private>
             <Voltage unit="V" multiplier="k">20</Voltage>

--- a/test/testfiles/valid2007B4withSubstationXY.scd
+++ b/test/testfiles/valid2007B4withSubstationXY.scd
@@ -7,6 +7,13 @@
 		</History>
 	</Header>
 	<Substation name="AA1" desc="Substation">
+		<PowerTransformer name="TA1" sxy:x="1" sxy:y="9" type="PTR">
+      		<TransformerWinding name="W1" type="PTW">
+        		<Terminal bayName="BusBar B" cNodeName="L1" name="T1" substationName="AA1" voltageLevelName="J1" connectivityNode="AA1/J1/BusBar B/L1"/>
+      		</TransformerWinding>
+      		<TransformerWinding name="W2" type="PTW">
+      		</TransformerWinding>
+    	</PowerTransformer>
         <VoltageLevel sxy:x="1" sxy:y="3" name="J1" desc="Voltage Level">
             <Private type="ABBPCMInternalObjRef">b80686f1-a514-477b-a83b-78f1cbe8a582</Private>
             <Voltage unit="V" multiplier="k">20</Voltage>

--- a/test/unit/editors/singlelinediagram/foundation.test.ts
+++ b/test/unit/editors/singlelinediagram/foundation.test.ts
@@ -1,89 +1,120 @@
-import { expect } from "@open-wc/testing";
-import { getSCLCoordinates, getDescriptionAttribute, getNameAttribute, getPathNameAttribute, isBusBar, getConnectedTerminals, calculateConnectivityNodeSclCoordinates } from "../../../../src/editors/singlelinediagram/foundation";
+import { expect } from '@open-wc/testing';
+import {
+  getRelativeCoordinates,
+  getDescriptionAttribute,
+  getNameAttribute,
+  getPathNameAttribute,
+  isBusBar,
+  getConnectedTerminals,
+  calculateConnectivityNodeCoordinates,
+} from '../../../../src/editors/singlelinediagram/foundation.js';
 
 describe('Single Line Diagram foundation', () => {
-    let doc: Document;
-    beforeEach(async () => {
-        doc = await fetch('/base/test/testfiles/valid2007B4withSubstationXY.scd')
-        .then(response => response.text())
-        .then(str => new DOMParser().parseFromString(str, 'application/xml'));
-    });
+  let doc: Document;
+  beforeEach(async () => {
+    doc = await fetch('/base/test/testfiles/valid2007B4withSubstationXY.scd')
+      .then(response => response.text())
+      .then(str => new DOMParser().parseFromString(str, 'application/xml'));
+  });
 
-    describe('defines a getNameAttribute function that', () => {
-        it('returns the correct name for an element.', () => {
-            const element = doc.querySelector('Bay[desc="Feld A"]');
-            expect(getNameAttribute(element!)).to.eql('Bay A');
-        });
-        it('returns undefined for an element without a name.', () => {
-            const element = doc.querySelector('VoltageLevel[name="J1"] > Voltage');
-            expect(getNameAttribute(element!)).to.be.undefined;
-        });
+  describe('defines a getNameAttribute function that', () => {
+    it('returns the correct name for an element.', () => {
+      const element = doc.querySelector('Bay[desc="Feld A"]');
+      expect(getNameAttribute(element!)).to.eql('Bay A');
     });
+    it('returns undefined for an element without a name.', () => {
+      const element = doc.querySelector('VoltageLevel[name="J1"] > Voltage');
+      expect(getNameAttribute(element!)).to.be.undefined;
+    });
+  });
 
-    describe('defines a getDescriptionAttribute function that', () => {
-        it('returns the correct description for an element.', () => {
-            const element = doc.querySelector('Bay[name="Bay A"]');
-            expect(getDescriptionAttribute(element!)).to.eql('Feld A');
-        });
-        it('returns undefined for an element without a description.', () => {
-            const element = doc.querySelector('VoltageLevel[name="J1"] > Voltage');
-            expect(getDescriptionAttribute(element!)).to.be.undefined;
-        });
+  describe('defines a getDescriptionAttribute function that', () => {
+    it('returns the correct description for an element.', () => {
+      const element = doc.querySelector('Bay[name="Bay A"]');
+      expect(getDescriptionAttribute(element!)).to.eql('Feld A');
     });
+    it('returns undefined for an element without a description.', () => {
+      const element = doc.querySelector('VoltageLevel[name="J1"] > Voltage');
+      expect(getDescriptionAttribute(element!)).to.be.undefined;
+    });
+  });
 
-    describe('defines a getPathName function that', () => {
-        it('returns the correct path name for an element.', () => {
-            const element = doc.querySelector('Bay[name="Bay A"] > ConnectivityNode[name="L1"]');
-            expect(getPathNameAttribute(element!)).to.eql('AA1/J1/Bay A/L1');
-        });
-        it('returns undefined for an element without a pathName.', () => {
-            const element = doc.querySelector('VoltageLevel[name="J1"] > Voltage');
-            expect(getPathNameAttribute(element!)).to.be.undefined;
-        });
+  describe('defines a getPathName function that', () => {
+    it('returns the correct path name for an element.', () => {
+      const element = doc.querySelector(
+        'Bay[name="Bay A"] > ConnectivityNode[name="L1"]'
+      );
+      expect(getPathNameAttribute(element!)).to.eql('AA1/J1/Bay A/L1');
     });
+    it('returns undefined for an element without a pathName.', () => {
+      const element = doc.querySelector('VoltageLevel[name="J1"] > Voltage');
+      expect(getPathNameAttribute(element!)).to.be.undefined;
+    });
+  });
 
-    describe('defines a getSCLCoordinates function that', () => {
-        it('returns the correct x and y coordinates for an element.', () => {
-            const element = doc.querySelector('Bay[name="Bay A"] > ConductingEquipment[name="QB1"]');
-            expect(getSCLCoordinates(element!)).to.eql({x: 1, y: 1});
-        });
-        it('returns {x: 0, y: 0} coordinates for an element that hasn\'t got any coordinates.', () => {
-            const element = doc.querySelector('Bay[name="Bay A"] > ConnectivityNode[name="L1"]');
-            expect(getSCLCoordinates(element!)).to.eql({x: 0, y: 0});
-        });
+  describe('defines a getRelativeCoordinates function that', () => {
+    it('returns the correct x and y coordinates for an element.', () => {
+      const element = doc.querySelector(
+        'Bay[name="Bay A"] > ConductingEquipment[name="QB1"]'
+      );
+      expect(getRelativeCoordinates(element!)).to.eql({ x: 1, y: 1 });
     });
+    it("returns {x: 0, y: 0} coordinates for an element that hasn't got any coordinates.", () => {
+      const element = doc.querySelector(
+        'Bay[name="Bay A"] > ConnectivityNode[name="L1"]'
+      );
+      expect(getRelativeCoordinates(element!)).to.eql({ x: 0, y: 0 });
+    });
+  });
 
-    describe('defines an isBusBar function that', () => {
-        it('returns true if an element is a bus bar.', () => {
-            const element = doc.querySelector('Bay[name="BusBar A"]');
-            expect(isBusBar(element!)).to.be.true;
-        });
-        it('returns false if an element is not a bus bar.', () => {
-            const element = doc.querySelector('Bay[name="Bay A"]');
-            expect(isBusBar(element!)).to.be.false;
-        });
+  describe('defines an isBusBar function that', () => {
+    it('returns true if an element is a bus bar.', () => {
+      const element = doc.querySelector('Bay[name="BusBar A"]');
+      expect(isBusBar(element!)).to.be.true;
     });
+    it('returns false if an element is not a bus bar.', () => {
+      const element = doc.querySelector('Bay[name="Bay A"]');
+      expect(isBusBar(element!)).to.be.false;
+    });
+  });
 
-    describe('defines a getConnectedTerminals function that', () => {
-        it('calculates the total number of connected terminals for a single element within the same bay.', () => {
-            const element = doc.querySelector('Bay[name="Bay A"] > ConnectivityNode[name="L1"]');
-            expect(getConnectedTerminals(element!).length).to.eql(3);
-        });
-        it('calculates the total number of connected terminals for a single element connected to multiple bays.', () => {
-            const element = doc.querySelector('Bay[name="BusBar A"] > ConnectivityNode[name="L1"]');
-            expect(getConnectedTerminals(element!).length).to.eql(4);
-        });
+  describe('defines a getConnectedTerminals function that', () => {
+    it('calculates the total number of connected terminals for a single element within the same bay.', () => {
+      const element = doc.querySelector(
+        'Bay[name="Bay A"] > ConnectivityNode[name="L1"]'
+      );
+      expect(getConnectedTerminals(element!).length).to.eql(3);
     });
+    it('calculates the total number of connected terminals for a single element connected to multiple bays.', () => {
+      const element = doc.querySelector(
+        'Bay[name="BusBar A"] > ConnectivityNode[name="L1"]'
+      );
+      expect(getConnectedTerminals(element!).length).to.eql(4);
+    });
+  });
 
-    describe('defines a calculateConnectivityNodeCoordinates function that', () => {
-        it('calculates the x and y coordinates of an element without defined coordinates,' +
-            'based on the coordinates of connected elements.', () => {
-            const element = doc.querySelector('Bay[name="Bay A"] > ConnectivityNode[name="L1"]');
-            expect(calculateConnectivityNodeSclCoordinates(element!)).to.eql({x: 2, y: 2});
+  describe('defines a calculateConnectivityNodeCoordinates function that', () => {
+    it(
+      'calculates the x and y coordinates of an element without defined coordinates,' +
+        'based on the coordinates of connected elements.',
+      () => {
+        const element = doc.querySelector(
+          'Bay[name="Bay A"] > ConnectivityNode[name="L1"]'
+        );
+        expect(calculateConnectivityNodeCoordinates(element!)).to.eql({
+          x: Math.round((4 + 5 + 4) / 3),
+          y: Math.round((10 + 10 + 12) / 3),
         });
-        it('returns a default {x:0, y:0} for elements that aren\'t Connectivity Nodes', () => {
-            const element = doc.querySelector('Bay[name="Bay A"] > ConductingEquipment[name="QB1"]');
-            expect(calculateConnectivityNodeSclCoordinates(element!)).to.eql({x: 0, y: 0});
-        });
+      }
+    );
+    it("returns a default {x:0, y:0} for elements that aren't Connectivity Nodes", () => {
+      const element = doc.querySelector(
+        'Bay[name="Bay A"] > ConductingEquipment[name="QB1"]'
+      );
+      expect(calculateConnectivityNodeCoordinates(element!)).to.eql({
+        x: 0,
+        y: 0,
+      });
     });
+  });
 });

--- a/test/unit/editors/singlelinediagram/sld-drawing.test.ts
+++ b/test/unit/editors/singlelinediagram/sld-drawing.test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@open-wc/testing';
 import {
   getAbsolutePosition,
-  getAbsolutePositionWithCustomCoordinates,
   getParentElementName,
   SVG_GRID_SIZE,
 } from '../../../../src/editors/singlelinediagram/sld-drawing.js';
@@ -26,6 +25,7 @@ describe('Single Line Diagram drawing', () => {
         y: 10 * SVG_GRID_SIZE,
       });
     });
+
     it('returns the correct absolute position for an element with a VoltageLevel as parent.', () => {
       const element = doc.querySelector('Bay[name="BusBar A"]');
       // Absolute position of Busbar A should be x=(1 + 1), and y=(1 + 3), if looking at the coordinates of all the parents.
@@ -35,32 +35,24 @@ describe('Single Line Diagram drawing', () => {
         y: 4 * SVG_GRID_SIZE,
       });
     });
-    it('returns the default 0,0 position for elements without legal parent.', () => {
+
+    it('returns relative position elements without legal parent.', () => {
       const element = doc.querySelector('VoltageLevel[name="J1"]');
+      const copiedElement = <Element>element?.cloneNode();
 
-      expect(getAbsolutePosition(element!)).to.eql({ x: 0, y: 0 });
+      expect(getAbsolutePosition(copiedElement!)).to.eql({
+        x: 1 * SVG_GRID_SIZE,
+        y: 3 * SVG_GRID_SIZE,
+      });
     });
-  });
 
-  describe('defines a getAbsolutePositionWithCustomCoordinates function that', () => {
-    it('returns the correct absolute position for an element with custom SCL coordinates and a Bay as parent.', () => {
-      const element = doc.querySelector(
-        'Bay[name="Bay A"] > ConnectivityNode[name="L2"]'
-      );
-      const customPosition = { x: 5, y: 1 };
-      // Absolute position of L2 should be x=(1 + 1 + 5), and y=(3 + 6 + 1), if looking at the coordinates of all the parents.
-      // Times the SVG_GRID_SIZE to get the absolute position on the svg.
-      expect(
-        getAbsolutePositionWithCustomCoordinates(element!, customPosition)
-      ).to.eql({ x: 7 * SVG_GRID_SIZE, y: 10 * SVG_GRID_SIZE });
-    });
-    it('returns the default 0,0 position for elements without legal parent.', () => {
-      const element = doc.querySelector('VoltageLevel[name="J1"]');
-      const customPosition = { x: 15, y: 4 };
+    it('returns default for invalid elements.', () => {
+      const element = doc.querySelector('LDevice');
 
-      expect(
-        getAbsolutePositionWithCustomCoordinates(element!, customPosition)
-      ).to.eql({ x: 0, y: 0 });
+      expect(getAbsolutePosition(element!)).to.eql({
+        x: 0,
+        y: 0,
+      });
     });
   });
 

--- a/test/unit/editors/singlelinediagram/sld-drawing.test.ts
+++ b/test/unit/editors/singlelinediagram/sld-drawing.test.ts
@@ -1,6 +1,7 @@
 import { expect } from '@open-wc/testing';
 import {
   getAbsolutePosition,
+  getBusBarLength,
   getParentElementName,
   SVG_GRID_SIZE,
 } from '../../../../src/editors/singlelinediagram/sld-drawing.js';
@@ -66,6 +67,18 @@ describe('Single Line Diagram drawing', () => {
     it('returns undefined for an element without a parent.', () => {
       const element = doc.querySelector('Substation');
       expect(getParentElementName(element!)).to.be.undefined;
+    });
+  });
+
+  describe('defines a getBusBarLength function that', () => {
+    it('returns a correct length for the bus bar given voltage level as root', () => {
+      const element = doc.querySelector('VoltageLevel[name="J1"]') ?? doc;
+      expect(getBusBarLength(element)).to.eql(
+        18 * SVG_GRID_SIZE + SVG_GRID_SIZE
+      );
+    });
+    it('returns a correct length for the bus bar given XMLDocument as root', () => {
+      expect(getBusBarLength(doc)).to.eql(18 * SVG_GRID_SIZE + SVG_GRID_SIZE);
     });
   });
 });

--- a/test/unit/editors/singlelinediagram/sld-drawing.test.ts
+++ b/test/unit/editors/singlelinediagram/sld-drawing.test.ts
@@ -1,5 +1,6 @@
 import { expect } from '@open-wc/testing';
 import {
+  createPowerTransformerElement,
   getAbsolutePosition,
   getBusBarLength,
   getParentElementName,
@@ -79,6 +80,13 @@ describe('Single Line Diagram drawing', () => {
     });
     it('returns a correct length for the bus bar given XMLDocument as root', () => {
       expect(getBusBarLength(doc)).to.eql(18 * SVG_GRID_SIZE + SVG_GRID_SIZE);
+    });
+  });
+
+  describe('creates a group element for every given PowerTransformer element that', () => {
+    it('looks like its latest snapshot', () => {
+      const pTrans = doc.querySelector('PowerTransformer')!;
+      expect(createPowerTransformerElement(pTrans)).to.equalSnapshot();
     });
   });
 });


### PR DESCRIPTION
The PR contains some steps:

First, I exchanged the name in the `<g>` element with the identity string. The first is a global identifier, the second not. @Flurb this was a great idea from you to write them into the `<g>` as we can make use of the selector functions that - with the `tagName` and `identifier` - can give the element in the doc. This allows us to very, very simple add user interaction. E.g. we even could reuse all the wizards that we use in the Substation plug-in editor to edit create manipulate add LNode and all the beautiful things we do :)

Also I 

1.) I decoupled the connectivity node icon from the conducting equipment icons
2.) added a two winding power transformer icon
3.) realized that substation must be valid parent as PowerTransformer can be direct child of Substation: triggered by this did a refactor of the get...Coordinates/get...Position handling. In this PR I propose to call x and y in the SCL as coordinates and x and y in the SCL as position. Also I tried to use absolute - with parent position - and relative -without.
4.) Did another refactor to get bus bar length: Triggered as relative position is required here. With the getAbsolutePosition the function became very slim
5.) Finally added the PowerTransformer related function.

I think we can test most sld-drawing related function very clean with snapshot tests. I did this as a beginning to the createPowerTransformer...


My allegories for this big PR!