### PR TITLE
Added terminal and Connectivity Node information

### DIFF
--- a/src/editors/SingleLineDiagram.ts
+++ b/src/editors/SingleLineDiagram.ts
@@ -149,10 +149,9 @@ export default class SingleLineDiagramPlugin extends LitElement {
           const cNodePosition = getAbsolutePositionConnectivityNode(cNode);
           const cNodeElement = createConnectivityNodeElement(
             cNode,
-            cNodePosition
+            cNodePosition,
+            () => this.openEditWizard(cNode)
           );
-
-          cNodeElement.addEventListener('click', () => this.openEditWizard(cNode));
 
           this.addElementToGroup(cNodeElement, identity(cNode.parentElement));
         });
@@ -236,10 +235,9 @@ export default class SingleLineDiagramPlugin extends LitElement {
               const terminal = createTerminalElement(
                 cEquipmentAbsolutePosition,
                 sideToDrawTerminalOn,
-                terminalElement!
+                terminalElement!,
+                () => this.openEditWizard(terminalElement!)
               );
-
-              terminal.addEventListener('click', () => this.openEditWizard(terminalElement!));
 
               this.svg
                 .querySelectorAll(`g[id="${identity(cEquipment)}"]`)
@@ -306,10 +304,9 @@ export default class SingleLineDiagramPlugin extends LitElement {
           const terminal = createTerminalElement(
             cEquipmentAbsolutePosition,
             sideToDrawTerminalOn,
-            terminalElement!
+            terminalElement!,
+            () => this.openEditWizard(terminalElement!)
           );
-
-          terminal.addEventListener('click', () => this.openEditWizard(terminalElement!));
 
           this.svg
             .querySelectorAll(`g[id="${identity(cEquipment)}"]`)
@@ -344,6 +341,10 @@ export default class SingleLineDiagramPlugin extends LitElement {
       .forEach(group => group.appendChild(elementToAdd));
   }
 
+  /**
+   * Open an Edit wizard for an element.
+   * @param element - The element to show the wizard for.
+   */
   openEditWizard(element: Element): void {
     const wizard = wizards[<SCLTag>(element.tagName)].edit(element);
     if (wizard) this.dispatchEvent(newWizardEvent(wizard));

--- a/src/editors/SingleLineDiagram.ts
+++ b/src/editors/SingleLineDiagram.ts
@@ -7,7 +7,7 @@ import {
   TemplateResult,
 } from 'lit-element';
 
-import { identity } from '../foundation.js';
+import { identity, newWizardEvent, SCLTag } from '../foundation.js';
 
 import panzoom from 'panzoom';
 
@@ -33,6 +33,7 @@ import {
   getPathNameAttribute,
   getNameAttribute,
 } from './singlelinediagram/foundation.js';
+import { wizards } from '../wizards/wizard-library.js';
 
 /**
  * Main class plugin for Single Line Diagram editor.
@@ -145,11 +146,14 @@ export default class SingleLineDiagramPlugin extends LitElement {
         .filter(cNode => cNode.getAttribute('name') !== 'grounded')
         .filter(cNode => getConnectedTerminals(cNode).length > 0)
         .forEach(cNode => {
+          console.log(cNode)
           const cNodePosition = getAbsolutePositionConnectivityNode(cNode);
           const cNodeElement = createConnectivityNodeElement(
             cNode,
             cNodePosition
           );
+
+          cNodeElement.addEventListener('click', () => this.openEditWizard(cNode));
 
           this.addElementToGroup(cNodeElement, identity(cNode.parentElement));
         });
@@ -236,6 +240,8 @@ export default class SingleLineDiagramPlugin extends LitElement {
                 terminalElement!
               );
 
+              terminal.addEventListener('click', () => this.openEditWizard(terminalElement!));
+
               this.svg
                 .querySelectorAll(`g[id="${identity(cEquipment)}"]`)
                 .forEach(eq => eq.appendChild(terminal));
@@ -304,8 +310,10 @@ export default class SingleLineDiagramPlugin extends LitElement {
             terminalElement!
           );
 
+          terminal.addEventListener('click', () => this.openEditWizard(terminalElement!));
+
           this.svg
-            .querySelectorAll(` g[id="${identity(cEquipment)}"]`)
+            .querySelectorAll(`g[id="${identity(cEquipment)}"]`)
             .forEach(eq => eq.appendChild(terminal));
         });
     });
@@ -321,7 +329,7 @@ export default class SingleLineDiagramPlugin extends LitElement {
     this.drawPowerTransformers();
     this.drawConnectivityNodes();
     this.drawBusBars();
-
+    
     this.drawConnectivityNodeConnections();
     this.drawBusBarConnections();
   }
@@ -335,6 +343,11 @@ export default class SingleLineDiagramPlugin extends LitElement {
     this.svg
       .querySelectorAll(`g[id="${identity}"]`)
       .forEach(group => group.appendChild(elementToAdd));
+  }
+
+  openEditWizard(element: Element): void {
+    const wizard = wizards[<SCLTag>(element.tagName)].edit(element);
+    if (wizard) this.dispatchEvent(newWizardEvent(wizard));
   }
 
   firstUpdated(): void {
@@ -359,6 +372,16 @@ export default class SingleLineDiagramPlugin extends LitElement {
   static styles = css`
     .sldContainer {
       overflow: hidden;
+    }
+
+    g[type='ConnectivityNode']:hover {
+      outline: 2px dashed var(--mdc-theme-primary);
+      transition: transform 200ms linear, box-shadow 250ms linear;
+    }
+
+    g[type='Terminal']:hover {
+      outline: 2px dashed var(--mdc-theme-primary);
+      transition: transform 200ms linear, box-shadow 250ms linear;
     }
   `;
 }

--- a/src/editors/SingleLineDiagram.ts
+++ b/src/editors/SingleLineDiagram.ts
@@ -146,7 +146,6 @@ export default class SingleLineDiagramPlugin extends LitElement {
         .filter(cNode => cNode.getAttribute('name') !== 'grounded')
         .filter(cNode => getConnectedTerminals(cNode).length > 0)
         .forEach(cNode => {
-          console.log(cNode)
           const cNodePosition = getAbsolutePositionConnectivityNode(cNode);
           const cNodeElement = createConnectivityNodeElement(
             cNode,

--- a/src/editors/SingleLineDiagram.ts
+++ b/src/editors/SingleLineDiagram.ts
@@ -374,12 +374,7 @@ export default class SingleLineDiagramPlugin extends LitElement {
       overflow: hidden;
     }
 
-    g[type='ConnectivityNode']:hover {
-      outline: 2px dashed var(--mdc-theme-primary);
-      transition: transform 200ms linear, box-shadow 250ms linear;
-    }
-
-    g[type='Terminal']:hover {
+    g[type='ConnectivityNode']:hover, g[type='Terminal']:hover {
       outline: 2px dashed var(--mdc-theme-primary);
       transition: transform 200ms linear, box-shadow 250ms linear;
     }

--- a/src/editors/singlelinediagram/sld-drawing.ts
+++ b/src/editors/singlelinediagram/sld-drawing.ts
@@ -173,12 +173,14 @@ export function createTextElement(
  * @param elementPosition - The position of the element belonging to the terminal/
  * @param sideToDraw - The side of the element the terminal must be drawn on.
  * @param terminalElement - The terminal element to extract information from.
+ * @param clickAction - The action to execute when the terminal is being clicked.
  * @returns The terminal SVG element.
  */
 export function createTerminalElement(
   elementPosition: Point,
   sideToDraw: Side,
-  terminalElement: Element
+  terminalElement: Element,
+  clickAction: () => void
 ): SVGElement {
   const groupElement = createGroupElement(terminalElement);
 
@@ -187,7 +189,6 @@ export function createTerminalElement(
       ? <string>identity(terminalElement)
       : 'unidentifiable';
 
-  const terminalName = getNameAttribute(terminalElement)!;
   const pointToDrawTerminalOn = getAbsolutePositionTerminal(
     elementPosition,
     sideToDraw
@@ -201,6 +202,8 @@ export function createTerminalElement(
   icon.setAttribute('r', '2');
 
   groupElement.appendChild(icon);
+
+  groupElement.addEventListener('click', clickAction);
 
   return groupElement;
 }
@@ -314,11 +317,13 @@ export function createPowerTransformerElement(
  * Create a Connectivity Node element.
  * @param cNodeElement - The name of the busbar
  * @param position - The SCL position of the Connectivity Node.
+ * @param clickAction - The action to execute when the terminal is being clicked.
  * @returns The Connectivity Node SVG element.
  */
 export function createConnectivityNodeElement(
   cNodeElement: Element,
-  position: Point
+  position: Point,
+  clickAction: () => void
 ): SVGElement {
   const groupElement = createGroupElement(cNodeElement);
 
@@ -330,6 +335,8 @@ export function createConnectivityNodeElement(
     icon.setAttribute('transform', `translate(${position.x},${position.y})`);
     groupElement.appendChild(icon);
   });
+
+  groupElement.addEventListener('click', clickAction);
 
   return groupElement;
 }

--- a/src/editors/singlelinediagram/sld-drawing.ts
+++ b/src/editors/singlelinediagram/sld-drawing.ts
@@ -200,15 +200,7 @@ export function createTerminalElement(
   icon.setAttribute('cy', `${pointToDrawTerminalOn.y}`);
   icon.setAttribute('r', '2');
 
-  // Also add a text element.
-  const textElementPosition =
-    sideToDraw == 'bottom' || sideToDraw == 'top'
-      ? { x: pointToDrawTerminalOn.x! + 5, y: pointToDrawTerminalOn.y! + 5 }
-      : { x: pointToDrawTerminalOn.x! - 5, y: pointToDrawTerminalOn.y! - 5 };
-  const text = createTextElement(terminalName, textElementPosition, 'xx-small');
-
   groupElement.appendChild(icon);
-  groupElement.appendChild(text);
 
   return groupElement;
 }
@@ -409,7 +401,10 @@ export function drawRouteBetweenElements(
   line.setAttribute('stroke', 'currentColor');
   line.setAttribute('stroke-width', '1.5');
 
-  svgToDrawOn.appendChild(line);
+  // Inserting elements like this works kind of like z-index (not supported in SVG yet),
+  // these elements are placed behind all other elements.
+  // By doing it like this, all other elements are hoverable for example.
+  svgToDrawOn.insertAdjacentElement('afterbegin', line);
 
   return sides;
 }

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -569,7 +569,7 @@ export const connectivityNodeIcon = html`<svg
     stroke-width="1"
     cx="12.5"
     cy="12.5"
-    r="5"
+    r="4"
   />
 </svg>`;
 

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -565,11 +565,11 @@ export const connectivityNodeIcon = html`<svg
 >
   <circle
     stroke="currentColor"
-    fill="none"
+    fill="currentColor"
     stroke-width="1"
     cx="12.5"
     cy="12.5"
-    r="4"
+    r="5"
   />
 </svg>`;
 

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -196,6 +196,29 @@ export const de: Translations = {
     },
     unknownType: 'Unbekannter Typ',
   },
+  connectivitynode: {
+    name: '????',
+    wizard: {
+      nameHelper: '????',
+      pathNameHelper: '????',
+      title: {
+        add: '????',
+        edit: '????',
+      },
+    },
+  },
+  terminal: {
+    name: '????',
+    wizard: {
+      nameHelper: '????',
+      connectivityNodeHelper: '????',
+      cNodeNameHelper: '????',
+      title: {
+        add: '????',
+        edit: '????',
+      },
+    },
+  },
   templates: {
     name: 'Data Type Templates',
     missing: 'DataTypeTemplates fehlen',

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -197,25 +197,25 @@ export const de: Translations = {
     unknownType: 'Unbekannter Typ',
   },
   connectivitynode: {
-    name: '????',
+    name: 'Verbindungsknoten',
     wizard: {
-      nameHelper: '????',
-      pathNameHelper: '????',
+      nameHelper: 'Verbindungsknoten Name',
+      pathNameHelper: 'Verbindungsknoten Beschreibung',
       title: {
-        add: '????',
-        edit: '????',
+        add: 'Verbindungsknoten hinzufügen',
+        edit: 'Verbindungsknoten bearbeiten',
       },
     },
   },
   terminal: {
-    name: '????',
+    name: 'Anschluss',
     wizard: {
-      nameHelper: '????',
-      connectivityNodeHelper: '????',
-      cNodeNameHelper: '????',
+      nameHelper: 'Anschluss Name',
+      connectivityNodeHelper: 'Anschluss Verbindungsknoten',
+      cNodeNameHelper: 'Anschluss Verbindungsknoten Name',
       title: {
-        add: '????',
-        edit: '????',
+        add: 'Anschlussknoten hinzufügen',
+        edit: 'Anschlussknoten bearbeiten',
       },
     },
   },

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -193,6 +193,29 @@ export const en = {
     },
     unknownType: 'Unknown type',
   },
+  connectivitynode: {
+    name: 'Connectivity Node',
+    wizard: {
+      nameHelper: 'Connectivity node name',
+      pathNameHelper: 'Connectivity node pathname',
+      title: {
+        add: 'Add Connectivity node',
+        edit: 'Edit Connectivity node',
+      },
+    },
+  },
+  terminal: {
+    name: 'Terminal',
+    wizard: {
+      nameHelper: 'Terminal name',
+      connectivityNodeHelper: 'Terminal connectivity node',
+      cNodeNameHelper: 'Terminal connectivity node name',
+      title: {
+        add: 'Add Terminal',
+        edit: 'Edit Terminal',
+      },
+    },
+  },
   templates: {
     name: 'Data Type Templates',
     missing: 'DataTypeTemplates missing',

--- a/src/wizards/connectivitynode.ts
+++ b/src/wizards/connectivitynode.ts
@@ -1,0 +1,55 @@
+import { html, TemplateResult } from 'lit-element';
+import { get, translate } from 'lit-translate';
+
+import {
+  isPublic,
+  Wizard,
+} from '../foundation.js';
+
+function render(
+  name: string | null,
+  pathName: string | null,
+  reservedNames: string[]
+): TemplateResult[] {
+  return [
+    html`<wizard-textfield
+      label="name"
+      .maybeValue=${name}
+      helper="${translate('connectivitynode.wizard.nameHelper')}"
+      required
+      validationMessage="${translate('textfield.required')}"
+      dialogInitialFocus
+      .reservedValues=${reservedNames}
+      readonly
+    ></wizard-textfield>`,
+    html`<wizard-textfield
+      label="pathName"
+      .maybeValue=${pathName}
+      helper="${translate('connectivitynode.wizard.pathNameHelper')}"
+      required
+      validationMessage="${translate('textfield.required')}"
+      readonly
+    ></wizard-textfield>`,
+  ];
+}
+
+export function editConnectivityNodeWizard(element: Element): Wizard {
+  const reservedNames = Array.from(
+    element.parentNode!.querySelectorAll('ConnectivityNode')
+  )
+    .filter(isPublic)
+    .map(cNode => cNode.getAttribute('name') ?? '')
+    .filter(name => name !== element.getAttribute('name'));
+
+  return [
+    {
+      title: get('connectivitynode.wizard.title.edit'),
+      element,
+      content: render(
+        element.getAttribute('name'),
+        element.getAttribute('pathName'),
+        reservedNames
+      ),
+    },
+  ];
+}

--- a/src/wizards/terminal.ts
+++ b/src/wizards/terminal.ts
@@ -1,0 +1,65 @@
+import { html, TemplateResult } from 'lit-element';
+import { get, translate } from 'lit-translate';
+
+import {
+  isPublic,
+  Wizard,
+} from '../foundation.js';
+
+function render(
+  name: string | null,
+  connectivityNode: string | null,
+  cNodeName: string | null,
+  reservedNames: string[]
+): TemplateResult[] {
+  return [
+    html`<wizard-textfield
+      label="name"
+      .maybeValue=${name}
+      helper="${translate('terminal.wizard.nameHelper')}"
+      required
+      validationMessage="${translate('textfield.required')}"
+      dialogInitialFocus
+      .reservedValues=${reservedNames}
+      readonly
+    ></wizard-textfield>`,
+    html`<wizard-textfield
+      label="connectivityNode"
+      .maybeValue=${connectivityNode}
+      helper="${translate('terminal.wizard.connectivityNodeHelper')}"
+      required
+      validationMessage="${translate('textfield.required')}"
+      readonly
+    ></wizard-textfield>`,
+    html`<wizard-textfield
+      label="cNodeName"
+      .maybeValue=${cNodeName}
+      helper="${translate('terminal.wizard.cNodeNameHelper')}"
+      required
+      validationMessage="${translate('textfield.required')}"
+      readonly
+    ></wizard-textfield>`,
+  ];
+}
+
+export function editTerminalWizard(element: Element): Wizard {
+  const reservedNames = Array.from(
+    element.parentNode!.querySelectorAll('ConnectivityNode')
+  )
+    .filter(isPublic)
+    .map(cNode => cNode.getAttribute('name') ?? '')
+    .filter(name => name !== element.getAttribute('name'));
+
+  return [
+    {
+      title: get('terminal.wizard.title.edit'),
+      element,
+      content: render(
+        element.getAttribute('name'),
+        element.getAttribute('connectivityNode'),
+        element.getAttribute('cNodeName'),
+        reservedNames
+      ),
+    },
+  ];
+}

--- a/src/wizards/wizard-library.ts
+++ b/src/wizards/wizard-library.ts
@@ -5,9 +5,11 @@ import {
   createConductingEquipmentWizard,
   editConductingEquipmentWizard,
 } from './conductingequipment.js';
+import { editConnectivityNodeWizard } from './connectivitynode.js';
 import { createFCDAsWizard } from './fcda.js';
 import { lNodeWizard } from './lnode.js';
 import { createSubstationWizard, substationEditWizard } from './substation.js';
+import { editTerminalWizard } from './terminal.js';
 import {
   voltageLevelCreateWizard,
   voltageLevelEditWizard,
@@ -111,7 +113,7 @@ export const wizards: Record<
     create: emptyWizard,
   },
   ConnectivityNode: {
-    edit: emptyWizard,
+    edit: editConnectivityNodeWizard,
     create: emptyWizard,
   },
   DA: {
@@ -483,7 +485,7 @@ export const wizards: Record<
     create: emptyWizard,
   },
   Terminal: {
-    edit: emptyWizard,
+    edit: editTerminalWizard,
     create: emptyWizard,
   },
   Text: {


### PR DESCRIPTION
Information is read-only.

Saving is disabled, because you can't just change the pathName of a Connectivity Node for example.
Because then, you have to change the terminals as well of connected Conducting Equipments for example.

So editing is disabled, just viewing.
However, with Pro mode you can edit of course.
But I assume people using Pro mode know what they are doing.