### PR TITLE
fix(wizards/fcda): remove incorrect iedName from FCDA

### DIFF
--- a/src/wizards/fcda.ts
+++ b/src/wizards/fcda.ts
@@ -27,7 +27,6 @@ function newFCDA(parent: Element, path: string[]): Element | undefined {
   const ln = parent.ownerDocument.querySelector(selector(lnTag, lnId));
   if (!ln) return;
 
-  const iedName = ln.closest('IED')?.getAttribute('name');
   const ldInst = ln.closest('LDevice')?.getAttribute('inst');
   const prefix = ln.getAttribute('prefix') ?? '';
   const lnClass = ln.getAttribute('lnClass');
@@ -56,10 +55,9 @@ function newFCDA(parent: Element, path: string[]): Element | undefined {
     if (tagName === 'BDA') daName = daName + '.' + name;
   }
 
-  if (!iedName || !ldInst || !lnClass || !doName || !daName || !fc) return;
+  if (!ldInst || !lnClass || !doName || !daName || !fc) return;
 
   return createElement(parent.ownerDocument, 'FCDA', {
-    iedName,
     ldInst,
     prefix,
     lnClass,

--- a/test/integration/wizards/fcda-wizarding-editing-integration.test.ts
+++ b/test/integration/wizards/fcda-wizarding-editing-integration.test.ts
@@ -45,14 +45,14 @@ describe('FCDA editing wizarding integration', () => {
     it('adds a new FCDA on primary action', async () => {
       expect(
         doc.querySelector(
-          'DataSet > FCDA[iedName="IED1"][ldInst="CircuitBreaker_CB1"]' +
+          'DataSet > FCDA[ldInst="CircuitBreaker_CB1"]' +
             '[prefix=""][lnClass="LLN0"][lnInst=""][doName="Beh"][daName="stVal"][fc="ST"]'
         )
       ).to.not.exist;
       await primaryAction.click();
       expect(
         doc.querySelector(
-          'DataSet > FCDA[iedName="IED1"][ldInst="CircuitBreaker_CB1"]' +
+          'DataSet > FCDA[ldInst="CircuitBreaker_CB1"]' +
             '[prefix=""][lnClass="LLN0"][lnInst=""][doName="Beh"][daName="stVal"][fc="ST"]'
         )
       ).to.exist;
@@ -79,7 +79,7 @@ describe('FCDA editing wizarding integration', () => {
     it('adds a new FCDA on primary action', async () => {
       expect(
         doc.querySelector(
-          'DataSet > FCDA[iedName="IED1"][ldInst="Meas"]' +
+          'DataSet > FCDA[ldInst="Meas"]' +
             '[prefix="My"][lnClass="MMXU"][lnInst="1"]' +
             '[doName="A.phsA"][daName="cVal.mag.i"][fc="MX"]'
         )
@@ -87,7 +87,7 @@ describe('FCDA editing wizarding integration', () => {
       await primaryAction.click();
       expect(
         doc.querySelector(
-          'DataSet > FCDA[iedName="IED1"][ldInst="Meas"]' +
+          'DataSet > FCDA[ldInst="Meas"]' +
             '[prefix="My"][lnClass="MMXU"][lnInst="1"]' +
             '[doName="A.phsA"][daName="cVal.mag.i"][fc="MX"]'
         )

--- a/test/unit/wizards/fcda.test.ts
+++ b/test/unit/wizards/fcda.test.ts
@@ -82,7 +82,6 @@ describe('create wizard for FCDA element', () => {
         const newElement = <Element>(
           actionEvent.args[0][0].detail.action.new.element
         );
-        expect(newElement).to.have.attribute('iedName', 'IED1');
         expect(newElement).to.have.attribute('ldInst', 'CircuitBreaker_CB1');
         expect(newElement).to.have.attribute('prefix', '');
         expect(newElement).to.have.attribute('lnClass', 'LLN0');
@@ -120,7 +119,6 @@ describe('create wizard for FCDA element', () => {
         const newElement = <Element>(
           actionEvent.args[0][0].detail.action.new.element
         );
-        expect(newElement).to.have.attribute('iedName', 'IED1');
         expect(newElement).to.have.attribute('ldInst', 'Meas');
         expect(newElement).to.have.attribute('prefix', 'My');
         expect(newElement).to.have.attribute('lnClass', 'MMXU');


### PR DESCRIPTION
When creating a `FCDA` element, we add an `ìedName` attribute to this element which is not defined within `FCDA` and therefor is schema invalid.

Closes #445 