### PR TITLE
style(zeroline/ied-editor): allow longer IED name

### DIFF
--- a/src/action-icon.ts
+++ b/src/action-icon.ts
@@ -157,7 +157,7 @@ export class ActionIcon extends LitElement {
       margin: 0px;
       text-align: center;
       align-self: center;
-      max-width: 64px;
+      max-width: 120px;
       direction: rtl;
     }
 

--- a/src/action-icon.ts
+++ b/src/action-icon.ts
@@ -157,7 +157,7 @@ export class ActionIcon extends LitElement {
       margin: 0px;
       text-align: center;
       align-self: center;
-      max-width: 120px;
+      max-width: 100%;
       direction: rtl;
     }
 

--- a/src/zeroline-pane.ts
+++ b/src/zeroline-pane.ts
@@ -175,7 +175,7 @@ export class ZerolinePane extends LitElement {
       grid-gap: 12px;
       padding: 8px 12px 16px;
       box-sizing: border-box;
-      grid-template-columns: repeat(auto-fit, minmax(64px, auto));
+      grid-template-columns: repeat(auto-fit, minmax(128px, auto));
     }
   `;
 }


### PR DESCRIPTION
I wanted to allow a longer IED name in the substation editor (about 12 characters). In my experience, IED names can be long, and not all substations have primary equipment in the SCD file and the substation editor is an important entry point in open-scd.

See comments in #375.

Result:

![image](https://user-images.githubusercontent.com/674783/146670486-a815afef-c229-44bd-a1fa-c949fa9b443f.png)

I'm not very up with modern CSS frameworks and so I may be breaking a host of rules here in which case this PR can be closed without me being very concerned :wink: 
