### PR TITLE
feat(wizards/reportcontrol): test new UI variant

### DIFF
--- a/src/wizard-selector.ts
+++ b/src/wizard-selector.ts
@@ -1,0 +1,211 @@
+import {
+  customElement,
+  css,
+  queryAll,
+  LitElement,
+  property,
+  internalProperty,
+  TemplateResult,
+  html,
+  query,
+  state,
+} from 'lit-element';
+import { get, translate } from 'lit-translate';
+
+import '@material/mwc-button';
+import '@material/mwc-dialog';
+import '@material/mwc-icon-button-toggle';
+import { Dialog } from '@material/mwc-dialog';
+import { List } from '@material/mwc-list';
+
+import 'ace-custom-element';
+import {
+  newActionEvent,
+  Wizard,
+  WizardInput,
+  WizardPage,
+  newWizardEvent,
+  WizardActor,
+  wizardInputSelector,
+  isWizard,
+  checkValidity,
+  reportValidity,
+  Delete,
+  Create,
+  identity,
+  SCLTag,
+  selector,
+} from './foundation.js';
+import { FilteredList } from './filtered-list.js';
+import { wizards } from './wizards/wizard-library.js';
+import { ListItem } from '@material/mwc-list/mwc-list-item';
+
+/** A wizard style dialog consisting of several pages committing some
+ * [[`EditorAction`]] on completion and aborting on dismissal. */
+@customElement('wizard-selector')
+export class WizardSelector extends LitElement {
+  @property({ type: Object })
+  scope!: Element | XMLDocument;
+
+  @property({ type: String })
+  targetTag!: string;
+
+  @property({ type: Array })
+  childTags: string[] = [];
+
+  @state()
+  get targets(): Element[] {
+    return Array.from(this.scope.querySelectorAll(this.targetTag));
+  }
+
+  @state()
+  get element(): Element | null {
+    if (!this.list) return null;
+    const identity = (<ListItem>this?.list?.selected).value ?? '';
+    return this.scope.querySelector(selector(<SCLTag>this.targetTag, identity));
+  }
+
+  @query('filtered-list') list!: FilteredList;
+  /** Commits `action` if all inputs are valid, reports validity otherwise. */
+  async act(action?: WizardActor, primary = true): Promise<boolean> {
+    /* if (action === undefined) return false;
+    const wizardInputs = Array.from(this.inputs);
+    const wizardList = <List | null>(
+      this.dialog?.querySelector('filtered-list,mwc-list')
+    );
+    if (!this.checkValidity()) {
+      wizardInputs.map(reportValidity);
+      return false;
+    }
+
+    const wizardActions = action(wizardInputs, this, wizardList);
+    if (wizardActions.length > 0) {
+      if (primary) this.wizard[this.pageIndex].primary = undefined;
+      else this.wizard[this.pageIndex].secondary = undefined;
+      this.dispatchEvent(newWizardEvent());
+    }
+    wizardActions.forEach(wa =>
+      isWizard(wa)
+        ? this.dispatchEvent(newWizardEvent(wa()))
+        : this.dispatchEvent(newActionEvent(wa))
+    ); */
+    return true;
+  }
+
+  private onClosed(ae: CustomEvent<{ action: string } | null>): void {
+    if (!(ae.target instanceof Dialog && ae.detail?.action)) return;
+    if (ae.detail.action === 'close') this.dispatchEvent(newWizardEvent());
+  }
+
+  constructor() {
+    super();
+
+    this.act = this.act.bind(this);
+  }
+
+  updated(changedProperties: Map<string | number | symbol, unknown>): void {
+    /* if (changedProperties.has('wizard')) {
+      while (
+        this.wizard.findIndex(page => page.initial) > this.pageIndex &&
+        dialogValid(this.dialog)
+      ) {
+        this.dialog?.close();
+      }
+      this.dialog?.show();
+    }
+    if (this.wizard[this.pageIndex]?.primary?.auto) {
+      this.updateComplete.then(() =>
+        this.act(this.wizard[this.pageIndex].primary!.action)
+      );
+    } */
+  }
+
+  renderChildWizards(childTag: string): TemplateResult {
+    const child = this?.element?.querySelector(childTag);
+    const wizard = child ? wizards[<SCLTag>childTag].edit(child) : undefined;
+    return wizard
+      ? html`${wizard.map(
+          page =>
+            html`<div class="column">
+              <h4>${page.title}</h4>
+              ${wizard[0].content}
+            </div>`
+        )}</div>`
+      : html``;
+  }
+
+  renderTargetWizard(): TemplateResult {
+    const wizard = this.element
+      ? wizards[<SCLTag>this.targetTag].edit(this.element)
+      : undefined;
+    return wizard
+      ? html`${wizard.map(
+          page =>
+            html`<div class="column">
+              <h4>${page.title}</h4>
+              ${wizard[0].content}
+            </div>`
+        )}</div>`
+      : html``;
+  }
+
+  renderTargetList(): TemplateResult {
+    return html`<div class="column">
+      <filtered-list activatable @selected=${() => this.requestUpdate()}>
+        ${this.targets.map(
+          target =>
+            html`<mwc-list-item twoline value="${identity(target)}"
+              ><span>${target.getAttribute('name')}</span
+              ><span slot="secondary">${identity(target)}</span>
+            </mwc-list-item>`
+        )}</filtered-list
+      >
+    </div>`;
+  }
+
+  render(): TemplateResult {
+    return html`<mwc-dialog
+      defaultAction="close"
+      heading="Manage reports"
+      @closed=${this.onClosed}
+      ><div id="wizard-content">
+        ${this.renderTargetList()}${this.renderTargetWizard()}${this.childTags.map(
+          tag => this.renderChildWizards(tag)
+        )}
+      </div>
+    </mwc-dialog> `;
+  }
+
+  static styles = css`
+    mwc-dialog {
+      --mdc-dialog-max-width: 92vw;
+    }
+
+    mwc-dialog > mwc-icon-button-toggle {
+      position: absolute;
+      top: 8px;
+      right: 14px;
+      color: var(--base00);
+    }
+
+    mwc-dialog > mwc-icon-button-toggle[on] {
+      color: var(--mdc-theme-primary);
+    }
+
+    #wizard-content {
+      display: flex;
+      flex-direction: row;
+      overflow: auto;
+    }
+
+    div.column {
+      display: flex;
+      flex-direction: column;
+      padding: 12px;
+    }
+
+    *[iconTrailing='search'] {
+      --mdc-shape-small: 28px;
+    }
+  `;
+}

--- a/src/wizards/optfields.ts
+++ b/src/wizards/optfields.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit-html';
+import { html, TemplateResult } from 'lit-element';
 import { get } from 'lit-translate';
 
 import '@material/mwc-list/mwc-list-item';
@@ -49,6 +49,33 @@ function updateOptFieldsAction(element: Element): WizardActor {
 
     return [{ old: { element }, new: { element: newElement } }];
   };
+}
+
+export function renderOptFields(element: Element): TemplateResult[] {
+  const optFields = [
+    'seqNum',
+    'timeStamp',
+    'dataSet',
+    'reasonCode',
+    'dataRef',
+    'entryID',
+    'configRef',
+    'bufOvfl',
+  ];
+
+  return optFields.map(
+    optField =>
+      html`<wizard-select
+        label="${optField}"
+        .maybeValue=${element.getAttribute(optField)}
+        nullable
+        required
+        >${['true', 'false'].map(
+          option =>
+            html`<mwc-list-item value="${option}">${option}</mwc-list-item>`
+        )}</wizard-select
+      >`
+  );
 }
 
 export function editOptFieldsWizard(element: Element): Wizard {

--- a/src/wizards/reportcontrol.ts
+++ b/src/wizards/reportcontrol.ts
@@ -10,11 +10,14 @@ import '../filtered-list.js';
 import {
   cloneElement,
   createElement,
+  Delete,
   EditorAction,
   getReference,
   getValue,
   identity,
   isPublic,
+  newActionEvent,
+  newWizardEvent,
   SimpleAction,
   Wizard,
   WizardActor,
@@ -229,15 +232,75 @@ export function selectReportControlWizard(element: Element): Wizard {
     {
       title: get('wizard.title.select', { tagName: 'ReportControl' }),
       content: [
-        html`<filtered-list
-          >${reportControls.map(
+        html`<filtered-list activatable
+          ><style>
+            .actions {
+              display: flex;
+              flex-direction: column;
+              align-items: flex-end;
+              max-height: 0;
+              margin-right: 12px;
+              transition: max-height 200ms linear;
+            }
+
+            .actions > mwc-button {
+              opacity: 0;
+              transition: opacity 200ms linear;
+            }
+
+            mwc-list-item[activated] + .actions {
+              max-height: 500px;
+            }
+
+            mwc-list-item[activated] + .actions > mwc-button {
+              opacity: 1;
+            }
+          </style>
+          ${reportControls.map(
             reportControl =>
-              html`<mwc-list-item twoline value="${identity(reportControl)}"
-                ><span>${reportControl.getAttribute('name')}</span
-                ><span slot="secondary"
-                  >${identity(reportControl)}</span
-                ></mwc-list-item
-              >`
+              html` <mwc-list-item twoline value="${identity(reportControl)}"
+                  ><span>${reportControl.getAttribute('name')}</span
+                  ><span slot="secondary">${identity(reportControl)}</span>
+                </mwc-list-item>
+                <div class="actions">
+                  <mwc-button
+                    label="Attributes"
+                    icon="edit"
+                    trailingIcon
+                    @click=${(e: MouseEvent) => {
+                      e.target?.dispatchEvent(newWizardEvent());
+                      e.target?.dispatchEvent(
+                        newWizardEvent(editReportControlWizard(reportControl))
+                      );
+                    }}
+                  ></mwc-button
+                  ><mwc-button
+                    label="Trigger Options"
+                    icon="edit"
+                    trailingIcon
+                  ></mwc-button
+                  ><mwc-button
+                    label="Optional Fields"
+                    icon="edit"
+                    trailingIcon
+                  ></mwc-button
+                  ><mwc-button
+                    label="DataSet"
+                    icon="edit"
+                    trailingIcon
+                  ></mwc-button
+                  ><mwc-button label="Data" icon="add" trailingIcon></mwc-button
+                  ><mwc-button
+                    label="Data"
+                    icon="add"
+                    trailingIcon
+                  ></mwc-button>
+                  <mwc-button
+                    label="Remove"
+                    icon="delete"
+                    trailingIcon
+                  ></mwc-button>
+                </div>`
           )}</filtered-list
         >`,
       ],

--- a/src/wizards/wizard-library.ts
+++ b/src/wizards/wizard-library.ts
@@ -9,6 +9,7 @@ import { editConnectivityNodeWizard } from './connectivitynode.js';
 import { createFCDAsWizard } from './fcda.js';
 import { lNodeWizard } from './lnode.js';
 import { editOptFieldsWizard } from './optfields.js';
+import { editReportControlWizard } from './reportcontrol.js';
 import { createSubstationWizard, substationEditWizard } from './substation.js';
 import { editTerminalWizard } from './terminal.js';
 import { editTrgOpsWizard } from './trgops.js';
@@ -371,7 +372,7 @@ export const wizards: Record<
     create: emptyWizard,
   },
   ReportControl: {
-    edit: emptyWizard,
+    edit: editReportControlWizard,
     create: emptyWizard,
   },
   ReportSettings: {

--- a/src/zeroline-pane.ts
+++ b/src/zeroline-pane.ts
@@ -16,14 +16,17 @@ import { IconButtonToggle } from '@material/mwc-icon-button-toggle';
 
 import './zeroline/substation-editor.js';
 import './zeroline/ied-editor.js';
+import './wizard-selector.js';
 import { Settings } from './Setting.js';
 import { communicationMappingWizard } from './wizards/commmap-wizards.js';
 import { gooseIcon, reportIcon } from './icons.js';
-import { isPublic, newWizardEvent } from './foundation.js';
+import { isPublic, newWizardEvent, Wizard } from './foundation.js';
 import { selectGseControlWizard } from './wizards/gsecontrol.js';
 import { wizards } from './wizards/wizard-library.js';
 import { getAttachedIeds } from './zeroline/foundation.js';
 import { selectReportControlWizard } from './wizards/reportcontrol.js';
+import { WizardSelector } from './wizard-selector.js';
+import { Dialog } from '@material/mwc-dialog';
 
 function shouldShowIEDs(): boolean {
   return localStorage.getItem('showieds') === 'on';
@@ -50,6 +53,7 @@ export class ZerolinePane extends LitElement {
   @query('#gsecontrol') gsecontrol!: IconButton;
   @query('#reportcontrol') reportcontrol!: IconButton;
   @query('#createsubstation') createsubstation!: IconButton;
+  @query('wizard-selector') wizardSelector!: WizardSelector;
 
   openCommunicationMapping(): void {
     const wizard = communicationMappingWizard(this.doc);
@@ -63,8 +67,11 @@ export class ZerolinePane extends LitElement {
   }
 
   openReportControlSelection(): void {
-    const wizard = selectReportControlWizard(this.doc.documentElement);
-    if (wizard) this.dispatchEvent(newWizardEvent(wizard));
+    (<Dialog>(
+      (<unknown>this.wizardSelector.shadowRoot?.querySelector('mwc-dialog'))
+    )).open = true;
+    /* const wizard = selectReportControlWizard(this.doc.documentElement);
+    if (wizard) this.dispatchEvent(newWizardEvent(wizard)); */
   }
 
   openGseControlSelection(): void {
@@ -135,6 +142,11 @@ export class ZerolinePane extends LitElement {
           >
         </nav>
       </h1>
+      <wizard-selector
+        .scope=${this.doc}
+        targetTag="ReportControl"
+        .childTags=${['OptFields', 'TrgOps']}
+      ></wizard-selector>
       ${this.renderIedContainer()}
       ${this.doc?.querySelector(':root > Substation')
         ? html`<section>


### PR DESCRIPTION
@ca-d and I were discussing the user-friendliness with the `GSEControl ` wizards. Here you have to do 3 of clicks to get for example to the wizards to add some data. We were thinking to maybe change the access to the wizards and reduce the number of click. This is an experiment that does this directly in the filtered list with `ReportControl` elements. 

I would love you to test and hope for some feedback. :) Maybe you can have a look as well @danyill 

In order to test, compare the filtered lists of Report `R` and GOOSE `G`. 
