### PR TITLE
feat(editors/SingleLineDiagram) Allow movement of bays

### DIFF
--- a/src/editors/SingleLineDiagram.ts
+++ b/src/editors/SingleLineDiagram.ts
@@ -22,6 +22,7 @@ import {
   createBusBarElement,
   createVoltageLevelElement,
   createBayElement,
+  createBayOutlineElement,
   createConductingEquipmentElement,
   createConnectivityNodeElement,
   getBusBarLength,
@@ -204,6 +205,22 @@ export default class SingleLineDiagramPlugin extends LitElement {
   }
 
   /**
+   * Draw outline rectangle for Bay and include name in <g> element
+   * Should only be a <g> element.
+   * @param bayGroup - The SVG <g> element containing all Bay icons/elements.
+   * @param bayElement - The Bay which the rectangle represents.
+   * */
+  private drawBayOutline(bayGroup: SVGGraphicsElement, bayElement: Element): void {
+    const outlineElement = createBayOutlineElement(bayGroup, 
+      bayElement, 
+      (event: Event) => this.openEditWizard(event, bayElement!));
+    if (bayGroup.parentNode !== null) {
+      // must be prepended as SVG z-order is based on element order in DOM
+      bayGroup.parentNode.prepend(outlineElement);
+    }
+  }
+
+  /**
    * Draw all available Bays of the passed Voltage Level Element.
    * Should only be a <g> element.
    * @param voltageLevelElement - The Voltage Level containing the bays.
@@ -214,10 +231,11 @@ export default class SingleLineDiagramPlugin extends LitElement {
       .forEach(bayElement => {
         const bayGroup = createBayElement(bayElement);
         voltageLevelGroup.appendChild(bayGroup);
-
+        
         this.drawPowerTransformers(bayElement, bayGroup);
         this.drawConductingEquipments(bayElement, bayGroup);
         this.drawConnectivityNodes(bayElement, bayGroup);
+        this.drawBayOutline(bayGroup, bayElement);
       });
   }
 
@@ -535,6 +553,12 @@ export default class SingleLineDiagramPlugin extends LitElement {
       pointer-events: bounding-box;
     }
 
+    .bayOutline {
+      fill: var(--mdc-theme-surface);
+      fill-opacity: 0.5;
+    }
+
+    text.bayName:hover,
     g[type='Busbar']:hover,
     g[type='ConductingEquipment']:hover,
     g[type='ConnectivityNode']:hover,

--- a/src/editors/singlelinediagram/sld-drawing.ts
+++ b/src/editors/singlelinediagram/sld-drawing.ts
@@ -174,7 +174,7 @@ export function getConnectivityNodesDrawingPosition(
  * @param element - The element.
  * @returns The <g> element.
  */
-function createGroupElement(element: Element): SVGElement {
+function createGroupElement(element: Element): SVGGraphicsElement {
   const finalElement = document.createElementNS(
     'http://www.w3.org/2000/svg',
     'g'
@@ -207,7 +207,6 @@ function createGroupElement(element: Element): SVGElement {
 export function createSubstationElement(substation: Element): SVGElement {
   return createGroupElement(substation);
 }
-
 /**
  * Create a Voltage Level <g> element.
  * @param voltageLevel - The Voltage Level from the SCL document to use.
@@ -222,8 +221,40 @@ export function createVoltageLevelElement(voltageLevel: Element): SVGElement {
  * @param bay - The Bay from the SCL document to use.
  * @returns A Bay <g> element.
  */
-export function createBayElement(bay: Element): SVGElement {
+export function createBayElement(bay: Element): SVGGraphicsElement {
   return createGroupElement(bay);
+}
+
+/**
+ * Create an outline rect and name for bays and add to the <g> element
+ * @param groupElement - The SVG group element with the SVG data comprising the bay.
+ * @param bayElement - The SCL element Bay.
+ * @returns The bay SVG objects <g> element including outline and the title.
+ */
+ export function createBayOutlineElement(
+  groupElement: SVGGraphicsElement,
+  bayElement: Element,
+  clickAction?: (event: Event) => void
+): SVGGraphicsElement {
+  const outlineGroup = createGroupElement(groupElement);
+  const boundingBox = groupElement.getBBox();
+  
+  const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+  rect.setAttribute('x', `${boundingBox.x}`);
+  rect.setAttribute('width', `${boundingBox.width}`);
+  rect.setAttribute('height', `${boundingBox.height}`);
+  rect.setAttribute('rx', '5');
+  rect.setAttribute('class', 'bayOutline');
+  outlineGroup.appendChild(rect);
+  
+  const text = createTextElement(bayElement.getAttribute('name') || 'Unknown Bay', 
+    { x: boundingBox.x, y: boundingBox.y - 18 },
+    'small');
+  text.setAttribute('class', 'bayName');
+  outlineGroup.appendChild(text);
+  
+  if (clickAction) text.addEventListener('click', clickAction);
+  return outlineGroup;
 }
 
 /**


### PR DESCRIPTION
Allow movement of bays, see #456 

I will be very happy to take a review and make corrections. I will be happy to be educated. Perhaps I could convince @dlabordus to take a look (hi! :wink:).

Note that I have used `SVGGraphicsElement` instead of `SVGElement` because many methods associated with graphical objects are not available in the TS types for `SVGElement` (see [MDN](https://developer.mozilla.org/en-US/docs/Web/API/SVGGraphicsElement)). I have resisted the urge to replace this more widely than required to satisfy the compiler.

It seemed for the time being that the best way to access bay properties was on the bay text rather than the rectangle drawn for the bay as this overlaps other objects. This is not consistent with what is done elsewhere where we click on the graphic. Happy to take some ideas about a better approach.

The `ssd` file included on the issue might be helpful for tests.

https://user-images.githubusercontent.com/674783/147298144-cfeb23db-4afd-404e-892e-cbc1d0299c75.mp4

I'm not sure how to write a test but I'm happy to have a go.


