### PR TITLE
refactor(editors/substation/conductingequipment): add earth-switch symbol

### DIFF
--- a/src/editors/SingleLineDiagram.ts
+++ b/src/editors/SingleLineDiagram.ts
@@ -140,11 +140,13 @@ export default class SingleLineDiagramPlugin extends LitElement {
    * Draw all equipment and connections of the selected Substation.
    */
   private drawSubstation(): void {
-    const substationGroup = createSubstationElement(this.selectedSubstation!);
-    this.svg.appendChild(substationGroup);
+    if (this.selectedSubstation !== undefined) {
+      const substationGroup = createSubstationElement(this.selectedSubstation!);
+      this.svg.appendChild(substationGroup);
 
-    this.drawPowerTransformers(this.selectedSubstation!, substationGroup);
-    this.drawVoltageLevels(this.selectedSubstation!, substationGroup);
+      this.drawPowerTransformers(this.selectedSubstation!, substationGroup);
+      this.drawVoltageLevels(this.selectedSubstation!, substationGroup);
+    }
   }
 
   /**

--- a/src/editors/SingleLineDiagram.ts
+++ b/src/editors/SingleLineDiagram.ts
@@ -140,13 +140,11 @@ export default class SingleLineDiagramPlugin extends LitElement {
    * Draw all equipment and connections of the selected Substation.
    */
   private drawSubstation(): void {
-    if (this.selectedSubstation !== undefined) {
-      const substationGroup = createSubstationElement(this.selectedSubstation!);
-      this.svg.appendChild(substationGroup);
+    const substationGroup = createSubstationElement(this.selectedSubstation!);
+    this.svg.appendChild(substationGroup);
 
-      this.drawPowerTransformers(this.selectedSubstation!, substationGroup);
-      this.drawVoltageLevels(this.selectedSubstation!, substationGroup);
-    }
+    this.drawPowerTransformers(this.selectedSubstation!, substationGroup);
+    this.drawVoltageLevels(this.selectedSubstation!, substationGroup);
   }
 
   /**

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -455,66 +455,72 @@ export const voltageTransformerIcon = html`<svg
 </svg>`;
 
 export const earthSwitchIcon = html`<svg
-viewBox="0 0 25 25"
-version="1.1"
-xmlns="http://www.w3.org/2000/svg"
-xmlns:svg="http://www.w3.org/2000/svg">
-<line
-  x1="12.5"
-  y1="19.25"
-  x2="12.5"
-  y2="16.25"
-  stroke="currentColor"
-  stroke-width="1.5"
-  stroke-linecap="round" />
-<line
-  x1="12.5"
-  y1="1.25"
-  x2="12.5"
-  y2="6.25"
-  stroke="currentColor"
-  stroke-width="1.5"
-  stroke-linecap="round" />
-<line
-  x1="12.5"
-  y1="6.25"
-  x2="17"
-  y2="15.25"
-  stroke="currentColor"
-  stroke-width="1.5"
-  stroke-linecap="round" />
-<line
-  x1="13.5"
-  y1="16.25"
-  x2="11.5"
-  y2="16.25"
-  stroke="currentColor"
-  stroke-width="1.5"
-  stroke-linecap="round" />
-<line
-  x1="17"
-  y1="19.25"
-  x2="8"
-  y2="19.25"
-  stroke="currentColor"
-  stroke-width="1.5"
-  stroke-linecap="round" />>
-<line
-  x1="15.5"
-  y1="21.45"
-  x2="9.5"
-  y2="21.45"
-  stroke="currentColor"
-  stroke-width="1.5"
-  stroke-linecap="round" />
-<line
-  x1="14.5"
-  y1="23.5"
-  x2="10.5"
-  y2="23.5"
-  stroke="currentColor"
-  stroke-width="1.5"
-  stroke-linecap="round" />
+  viewBox="0 0 25 25"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <line
+    x1="12.5"
+    x2="12.5"
+    y1="19.2"
+    y2="16.2"
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-width="1.5"
+  />
+  <line
+    x1="12.5"
+    x2="12.5"
+    y1="1.25"
+    y2="6.25"
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-width="1.5"
+  />
+  <line
+    x1="12.5"
+    x2="8"
+    y1="16.2"
+    y2="7.25"
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-width="1.5"
+  />
+  <line
+    x1="13.5"
+    x2="11.5"
+    y1="6.25"
+    y2="6.25"
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-width="1.5"
+  />
+  <line
+    x1="17"
+    x2="8"
+    y1="19.2"
+    y2="19.2"
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-width="1.5"
+  />
+  <line
+    x1="15.5"
+    x2="9.5"
+    y1="21.4"
+    y2="21.4"
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-width="1.5"
+  />
+  <line
+    x1="14.5"
+    x2="10.5"
+    y1="23.5"
+    y2="23.5"
+    stroke="currentColor"
+    stroke-linecap="round"
+    stroke-width="1.5"
+  />
 </svg>`;
 
 export const generalConductingEquipmentIcon = html`<svg

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -456,7 +456,7 @@ export const voltageTransformerIcon = html`<svg
 
 export const earthSwitchIcon = html`<svg
   xmlns="http://www.w3.org/2000/svg"
-  viewBox="0 0 25 35"
+  viewBox="0 0 25 25"
 >  
   <line
     x1="12.5"

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -468,15 +468,6 @@ export const earthSwitchIcon = html`<svg
     stroke-linecap="round"
   />
   <line
-    x1="11"
-    y1="23.5"
-    x2="14"
-    y2="23.5"
-    stroke="currentColor"
-    stroke-width="1.5"
-    stroke-linecap="round"
-  />
-  <line
     x1="12.5"
     y1="23.5"
     x2="12.5"

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -455,73 +455,67 @@ export const voltageTransformerIcon = html`<svg
 </svg>`;
 
 export const earthSwitchIcon = html`<svg
-  xmlns="http://www.w3.org/2000/svg"
-  viewBox="0 0 25 25"
->  
-  <line
-    x1="12.5"
-    y1="5.5"
-    x2="12.5"
-    y2="8.5"
-    stroke="currentColor"
-    stroke-width="1.5"
-    stroke-linecap="round"
-  />
-  <line
-    x1="12.5"
-    y1="23.5"
-    x2="12.5"
-    y2="18.5"
-    stroke="currentColor"
-    stroke-width="1.5"
-    stroke-linecap="round"
-  />
-  <line
-    x1="12.5"
-    y1="18.5"
-    x2="8"
-    y2="9.5"
-    stroke="currentColor"
-    stroke-width="1.5"
-    stroke-linecap="round"
-  />
-  <line
-    x1="11.5"
-    y1="8.5"
-    x2="13.5"
-    y2="8.5"
-    stroke="currentColor"
-    stroke-width="1.5"
-    stroke-linecap="round"
-    />
-  <line
-    x1="8"
-    y1="5.5"
-    x2="17"
-    y2="5.5"
-    stroke="currentColor"
-    stroke-width="1.5"
-    stroke-linecap="round"
-    />
-  <line
-    x1="9.5"
-    y1="3.3"
-    x2="15.5"
-    y2="3.3"
-    stroke="currentColor"
-    stroke-width="1.5"
-    stroke-linecap="round"
-    />
-  <line
-    x1="10.5"
-    y1="1.25"
-    x2="14.5"
-    y2="1.25"
-    stroke="currentColor"
-    stroke-width="1.5"
-    stroke-linecap="round"
-  />     
-</svg> `;
+viewBox="0 0 25 25"
+version="1.1"
+xmlns="http://www.w3.org/2000/svg"
+xmlns:svg="http://www.w3.org/2000/svg">
+<line
+  x1="12.5"
+  y1="19.25"
+  x2="12.5"
+  y2="16.25"
+  stroke="currentColor"
+  stroke-width="1.5"
+  stroke-linecap="round" />
+<line
+  x1="12.5"
+  y1="1.25"
+  x2="12.5"
+  y2="6.25"
+  stroke="currentColor"
+  stroke-width="1.5"
+  stroke-linecap="round" />
+<line
+  x1="12.5"
+  y1="6.25"
+  x2="17"
+  y2="15.25"
+  stroke="currentColor"
+  stroke-width="1.5"
+  stroke-linecap="round" />
+<line
+  x1="13.5"
+  y1="16.25"
+  x2="11.5"
+  y2="16.25"
+  stroke="currentColor"
+  stroke-width="1.5"
+  stroke-linecap="round" />
+<line
+  x1="17"
+  y1="19.25"
+  x2="8"
+  y2="19.25"
+  stroke="currentColor"
+  stroke-width="1.5"
+  stroke-linecap="round" />>
+<line
+  x1="15.5"
+  y1="21.45"
+  x2="9.5"
+  y2="21.45"
+  stroke="currentColor"
+  stroke-width="1.5"
+  stroke-linecap="round" />
+<line
+  x1="14.5"
+  y1="23.5"
+  x2="10.5"
+  y2="23.5"
+  stroke="currentColor"
+  stroke-width="1.5"
+  stroke-linecap="round" />
+</svg>`;
 
 export const generalConductingEquipmentIcon = html`<svg
   xmlns="http://www.w3.org/2000/svg"

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -456,53 +456,80 @@ export const voltageTransformerIcon = html`<svg
 
 export const earthSwitchIcon = html`<svg
   xmlns="http://www.w3.org/2000/svg"
-  viewBox="0 0 25 25"
->
+  viewBox="0 0 25 35"
+>  
   <line
     x1="12.5"
-    y1="2"
+    y1="5.5"
     x2="12.5"
-    y2="8"
+    y2="8.5"
     stroke="currentColor"
     stroke-width="1.5"
     stroke-linecap="round"
   />
   <line
     x1="11"
-    y1="23"
+    y1="23.5"
     x2="14"
-    y2="23"
+    y2="23.5"
     stroke="currentColor"
     stroke-width="1.5"
     stroke-linecap="round"
   />
   <line
     x1="12.5"
-    y1="23"
+    y1="23.5"
     x2="12.5"
-    y2="18"
+    y2="18.5"
     stroke="currentColor"
     stroke-width="1.5"
     stroke-linecap="round"
   />
   <line
     x1="12.5"
-    y1="18"
+    y1="18.5"
     x2="8"
-    y2="9"
+    y2="9.5"
     stroke="currentColor"
     stroke-width="1.5"
     stroke-linecap="round"
   />
   <line
     x1="11.5"
-    y1="8"
+    y1="8.5"
     x2="13.5"
-    y2="8"
+    y2="8.5"
     stroke="currentColor"
     stroke-width="1.5"
     stroke-linecap="round"
-  />
+    />
+  <line
+    x1="8"
+    y1="5.5"
+    x2="17"
+    y2="5.5"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    />
+  <line
+    x1="9.5"
+    y1="3.3"
+    x2="15.5"
+    y2="3.3"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+    />
+  <line
+    x1="10.5"
+    y1="1.25"
+    x2="14.5"
+    y2="1.25"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+  />     
 </svg> `;
 
 export const generalConductingEquipmentIcon = html`<svg

--- a/src/wizards/conductingequipment.ts
+++ b/src/wizards/conductingequipment.ts
@@ -120,7 +120,7 @@ function containsEarthSwitchDefinition(condEq: Element): boolean {
     const swTypVal = getDataAttributeValue(lNode, 'SwTyp', undefined, 'stVal');
     return swTypVal ? ['Earthing Switch', 'High Speed Earthing Switch'].includes(swTypVal) : false;
   } else {
-  return false; 
+    return false; 
   }
 }
 

--- a/src/wizards/conductingequipment.ts
+++ b/src/wizards/conductingequipment.ts
@@ -7,6 +7,7 @@ import '@material/mwc-select';
 import '../wizard-textfield.js';
 import {
   createElement,
+  crossProduct,
   EditorAction,
   getValue,
   isPublic,
@@ -15,7 +16,6 @@ import {
   WizardInput,
 } from '../foundation.js';
 import { updateNamingAction } from './foundation/actions.js';
-import { getDirections } from '../editors/singlelinediagram/sld-drawing.js';
 
 const types: Partial<Record<string, string>> = {
   // standard
@@ -51,61 +51,69 @@ const types: Partial<Record<string, string>> = {
 };
 
 /**
- * Finds Logical Node from IED based on Logical Node in the Substation SCL section.
- * @param lNode - Logical Node in Substation SCL section.
- * @returns - Logical Node in the IED SCL section.
+ * Finds LN within IED based on LNode from Substation SCL section.
+ * @param lNode - LNode in Substation SCL section.
+ * @returns - LN in the IED SCL section.
  */
-function getLNodefromIED(lNode: Element | null): Element | null {
+function getLogicalNodeInstance(lNode: Element | null): Element | null {
   if (!lNode) return null;
-  const [iedName, ldInst, lnClass, lnInst, lnType] = [
+  const [lnInst, lnClass, iedName, ldInst, prefix, lnType] = [
+    'lnInst',
+    'lnClass',
     'iedName',
     'ldInst',
-    'lnClass',
-    'lnInst',
+    'prefix',
     'lnType',
-  ].map(attribute => lNode?.getAttribute(attribute));
-  return (<Element>lNode?.getRootNode()).querySelector(`IED[name='${iedName}'] > AccessPoint > Server > LDevice[inst='${ldInst}'] > LN[inst='${lnInst}'][lnType='${lnType}'][lnClass='${lnClass}']`);
+  ].map(attribute => lNode?.getAttribute(attribute) || '');
+  const iedSelector = [`IED[name="${iedName}"]`, 'IED'];
+  const lDevicePath = ['AccessPoint > Server'];
+  const lDeviceSelector = [
+    `LDevice[inst="${ldInst}"] > LN[inst="${lnInst}"][lnType="${lnType}"][lnClass="${lnClass}"]`,
+  ];
+  const lDevicePrefixSelector = [`[prefix="${prefix}"]`, ':not(prefix)'];
+  return lNode.ownerDocument.querySelector(
+    crossProduct(
+      iedSelector,
+      [' > '],
+      lDevicePath,
+      [' > '],
+      lDeviceSelector,
+      lDevicePrefixSelector
+    )
+      .map(strings => strings.join(''))
+      .join(',')
+  );
 }
 
 /**
- * Finds data attribute by inspecting an IED's logical node or types.
- * @param lNode - LNode within the IED section.
- * @param doName - name for data object (e.g. SwTyp).
- * @param sdName - id for sub data object.
- * @param daName - name for data attribute (e.g. stVal).
+ * Finds whether a logical node has the SwTyp:stVal data attribute.
+ * @param lN - logical node within the IED section.
  * @returns - value of type as a string.
  */
-function getDataAttributeValue(lNode: Element, doName: string, sdName: string | undefined, daName: string): string | undefined {
-  const sdDef = sdName ? ` > SDI[name='${sdName}']` : '';
-  const daInstantiated = lNode.querySelector(`DOI[name='${doName}']${sdDef} > DAI[name='${daName}'`);
-  if (daInstantiated) {
-    // data attribute is fully instantiated within a DOI/SDI, look for it within: DOI > ?SDI > DAI
+function getSwitchTypeValue(lN: Element): string | undefined {
+  const daInstantiated = lN.querySelector(
+    'DOI[name="SwTyp"] > DAI[name="stVal"'
+  );
+  // definition is on instantiated object
+  if (daInstantiated)
     return daInstantiated.querySelector('Val')?.innerHTML.trim();
-  } else {
-    const rootNode = <Element>lNode?.getRootNode();
-    const lNodeType = lNode.getAttribute('type');
-    const lnClass = lNode.getAttribute('lnClass');
-    if (sdName) {
-      // definition to be found on the subdata type
-      // this code path has not been tested but may be of use elsewhere
-      const sdo = rootNode.querySelector(`DataTypeTemplates > LNodeType[id=${lNodeType}][class=${lnClass}] > SDO[name=${doName}]`);
-      if (sdo) {
-        const sdoRef = sdo.getAttribute('type');
-        return rootNode.querySelector(`DataTypeTemplates > DOType[id=${sdoRef}] > DA[name='${daName}'] > Val`)?.innerHTML.trim();
-      }
-      // definition missing
-      return undefined;
-    } else {
-      // definition must be on the data object type
-      const doObj = rootNode.querySelector(`DataTypeTemplates > LNodeType[id=${lNodeType}][class=${lnClass}] > DO[name=${doName}]`);
-      if (doObj) {
-        const doRef = doObj.getAttribute('type');
-        return rootNode.querySelector(`DataTypeTemplates > DOType[id=${doRef}] > DA[name='${daName}'] > Val`)?.innerHTML.trim();
-      }
-      // definition missing
-      return undefined;
-    } 
+  const rootNode = lN?.ownerDocument;
+  const lNodeType = lN.getAttribute('type');
+  const lnClass = lN.getAttribute('lnClass');
+  // definition must be on the data object type
+  const doObj = rootNode.querySelector(
+    `DataTypeTemplates > LNodeType[id="${lNodeType}"][class="${lnClass}"] > DO[name="SwTyp"]`
+  );
+  if (doObj) {
+    const doRef = doObj.getAttribute('type');
+    return rootNode
+      .querySelector(
+        `DataTypeTemplates > DOType[id="${doRef}"] > DA[name="stVal"] > Val`
+      )
+      ?.innerHTML.trim();
   }
+  // definition missing
+  return undefined;
 }
 
 /**
@@ -114,26 +122,27 @@ function getDataAttributeValue(lNode: Element, doName: string, sdName: string | 
  * @returns if any terminal of the ConductingEquipment is grounded.
  */
 function containsGroundedTerminal(condEq: Element): boolean {
-  return (Array.from(condEq.querySelectorAll('Terminal'))
-    .map(t => t.getAttribute('cNodeName'))
-    .includes('grounded')
+  return Array.from(condEq.querySelectorAll('Terminal')).some(
+    t => t.getAttribute('cNodeName') === 'grounded'
   );
 }
 
 /**
- * Looks to see if the Conducting Equipment contains an XSWI logical node. If so, check if the XSWI definition
+ * Looks to see if the Conducting Equipment contains an XSWI LN. If so, check if the XSWI definition
  * includes SwTyp and if stVal indicates an Earth/Earthing Switch.
- * @param condEq - SCL ConductingEquipment
+ * @param condEq - SCL ConductingEquipment.
  * @returns true if an earth switch is found, false otherwise.
  */
 function containsEarthSwitchDefinition(condEq: Element): boolean {
-  const lNodeXSWI = condEq.querySelector("LNode[lnClass='XSWI']");
-  const lNode = getLNodefromIED(lNodeXSWI);
-  if (lNode) {
-    const swTypVal = getDataAttributeValue(lNode, 'SwTyp', undefined, 'stVal');
-    return swTypVal ? ['Earthing Switch', 'High Speed Earthing Switch'].includes(swTypVal) : false;
+  const lNXSWI = condEq.querySelector('LNode[lnClass="XSWI"]');
+  const lN = getLogicalNodeInstance(lNXSWI);
+  if (lN) {
+    const swTypVal = getSwitchTypeValue(lN);
+    return swTypVal
+      ? ['Earthing Switch', 'High Speed Earthing Switch'].includes(swTypVal)
+      : false;
   } else {
-    return false; 
+    return false;
   }
 }
 
@@ -143,7 +152,11 @@ function containsEarthSwitchDefinition(condEq: Element): boolean {
  * @returns  Three letter primary apparatus device type as defined in IEC 61850-6.
  */
 export function typeStr(condEq: Element): string {
-  if (containsGroundedTerminal(condEq) || (condEq.getAttribute('type') === 'DIS' && ( containsEarthSwitchDefinition (condEq)))) {
+  if (
+    containsGroundedTerminal(condEq) ||
+    (condEq.getAttribute('type') === 'DIS' &&
+      containsEarthSwitchDefinition(condEq))
+  ) {
     // these checks only carried out for a three phase system
     return 'ERS';
   } else {

--- a/src/wizards/conductingequipment.ts
+++ b/src/wizards/conductingequipment.ts
@@ -51,7 +51,9 @@ const types: Partial<Record<string, string>> = {
 
 function typeStr(condEq: Element): string {
   return condEq.getAttribute('type') === 'DIS' &&
-    condEq.querySelector('Terminal')?.getAttribute('cNodeName') === 'grounded'
+    Array.from(condEq.querySelectorAll('Terminal'))
+      .map(t => t.getAttribute('cNodeName'))
+      .includes('grounded')
     ? 'ERS'
     : condEq.getAttribute('type') ?? '';
 }

--- a/src/wizards/conductingequipment.ts
+++ b/src/wizards/conductingequipment.ts
@@ -50,6 +50,11 @@ const types: Partial<Record<string, string>> = {
   TCR: 'Thyristor Controlled Reactive Component',
 };
 
+/**
+ * Finds Logical Node from IED based on Logical Node in the Substation SCL section.
+ * @param lNode - Logical Node in Substation SCL section.
+ * @returns - Logical Node in the IED SCL section.
+ */
 function getLNodefromIED(lNode: Element | null): Element | null {
   if (!lNode) return null;
   const [iedName, ldInst, lnClass, lnInst, lnType] = [
@@ -62,6 +67,14 @@ function getLNodefromIED(lNode: Element | null): Element | null {
   return (<Element>lNode?.getRootNode()).querySelector(`IED[name='${iedName}'] > AccessPoint > Server > LDevice[inst='${ldInst}'] > LN[inst='${lnInst}'][lnType='${lnType}'][lnClass='${lnClass}']`);
 }
 
+/**
+ * Finds data attribute by inspecting an IED's logical node or types.
+ * @param lNode - LNode within the IED section.
+ * @param doName - name for data object (e.g. SwTyp).
+ * @param sdName - id for sub data object.
+ * @param daName - name for data attribute (e.g. stVal).
+ * @returns - value of type as a string.
+ */
 function getDataAttributeValue(lNode: Element, doName: string, sdName: string | undefined, daName: string): string | undefined {
   const sdDef = sdName ? ` > SDI[name='${sdName}']` : '';
   const daInstantiated = lNode.querySelector(`DOI[name='${doName}']${sdDef} > DAI[name='${daName}'`);

--- a/src/wizards/conductingequipment.ts
+++ b/src/wizards/conductingequipment.ts
@@ -87,6 +87,11 @@ function getLogicalNodeInstance(lNode: Element | null): Element | null {
   );
 }
 
+/**
+ * Searches DataTypeTemplates for SwTyp:stVal from an LN or LNode reference.
+ * @param lNorlNode - SCL IED Logical Node or LNode from Substation section.
+ * @returns - value of stVal data attribute if found.
+ */
 function getSwitchTypeValueFromDTT(lNorlNode: Element): string | undefined {
   const rootNode = lNorlNode?.ownerDocument;
   const lNodeType = lNorlNode.getAttribute('lnType');

--- a/src/zeroline/foundation.ts
+++ b/src/zeroline/foundation.ts
@@ -226,7 +226,9 @@ export function getIcon(condEq: Element): TemplateResult {
 function typeStr(condEq: Element): string {
   if (
     condEq.getAttribute('type') === 'DIS' &&
-    condEq.querySelector('Terminal')?.getAttribute('cNodeName') === 'grounded'
+      Array.from(condEq.querySelectorAll('Terminal'))
+        .map(t => t.getAttribute('cNodeName'))
+        .includes('grounded')
   ) {
     return 'ERS';
   } else {

--- a/src/zeroline/foundation.ts
+++ b/src/zeroline/foundation.ts
@@ -12,6 +12,7 @@ import {
 import { BayEditor } from './bay-editor.js';
 import { SubstationEditor } from './substation-editor.js';
 import { VoltageLevelEditor } from './voltage-level-editor.js';
+import { typeStr } from '../wizards/conductingequipment.js';
 
 function containsReference(element: Element, iedName: string): boolean {
   return Array.from(element.getElementsByTagName('LNode'))
@@ -221,19 +222,6 @@ export function startMove<E extends ElementEditor, P extends ElementEditor>(
  */
 export function getIcon(condEq: Element): TemplateResult {
   return typeIcons[typeStr(condEq)] ?? generalConductingEquipmentIcon;
-}
-
-function typeStr(condEq: Element): string {
-  if (
-    condEq.getAttribute('type') === 'DIS' &&
-      Array.from(condEq.querySelectorAll('Terminal'))
-        .map(t => t.getAttribute('cNodeName'))
-        .includes('grounded')
-  ) {
-    return 'ERS';
-  } else {
-    return condEq.getAttribute('type') ?? '';
-  }
 }
 
 const typeIcons: Partial<Record<string, TemplateResult>> = {

--- a/test/testfiles/conductingequipmentwizard.scd
+++ b/test/testfiles/conductingequipmentwizard.scd
@@ -47,12 +47,21 @@
 				</ConductingEquipment>
 				<ConnectivityNode name="L2" pathName="ERE/V220/B272/L2" />
 			</Bay>
+			<Bay name="B282" sxy:dir="vertical" sxy:x="6">
+				<ConductingEquipment name="ES289" sxy:dir="vertical" sxy:x="1" sxy:y="1" virtual="false" type="DIS">
+					<LNode iedName="None" ldInst="Application" lnClass="XSWI" lnInst="1" lnType="LNType_XSWI_Ctl" prefix="First"/>
+					<Terminal bayName="B282" cNodeName="L1" name="L1" substationName="ERE" voltageLevelName="V220" connectivityNode="ERE/V220/B282/L1" />
+					<Terminal bayName="B282" cNodeName="L2" name="L2" substationName="ERE" voltageLevelName="V220" connectivityNode="ERE/V220/B282/L2" />
+				</ConductingEquipment>
+				<ConnectivityNode name="L2" pathName="ERE/V220/B282/L2" />
+			</Bay>
 			<Bay name="Bus_A1" desc="Bus A1" sxy:x="0" sxy:y="3">
 				<ConnectivityNode name="L1_232" pathName="ERE/V220/B232/L1" />
 				<ConnectivityNode name="L1_242" pathName="ERE/V220/B242/L1" />
 				<ConnectivityNode name="L1_252" pathName="ERE/V220/B252/L1" />
 				<ConnectivityNode name="L1_262" pathName="ERE/V220/B262/L1" />
 				<ConnectivityNode name="L1_272" pathName="ERE/V220/B272/L1" />
+				<ConnectivityNode name="L1_282" pathName="ERE/V220/B282/L1" />
 			  </Bay>
 		</VoltageLevel>
 	</Substation>
@@ -123,7 +132,7 @@
 						</DOI>
 						<SettingControl numOfSGs="1" actSG="1"></SettingControl>
 					</LN0>
-					<LN lnClass="XSWI" inst="1" lnType="LNType_XSWI_Ctl" desc="Disconnector" prefix="">
+					<LN lnClass="XSWI" inst="1" lnType="LNType_XSWI_Ctl" desc="Disconnector" prefix="First">
 						<DOI name="Mod" desc="Mode (status only)" />
 						<DOI name="Beh" desc="Behavior" />
 						<DOI name="Health" desc="Health" />

--- a/test/testfiles/conductingequipmentwizard.scd
+++ b/test/testfiles/conductingequipmentwizard.scd
@@ -1,0 +1,697 @@
+<?xml version="1.0" encoding="utf-8"?>
+<SCL xmlns="http://www.iec.ch/61850/2003/SCL" xmlns:sxy="http://www.iec.ch/61850/2003/SCLcoordinates" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" version="2007" revision="B" release="4" xs:schemaLocation="SCL.xsd">
+	<Header id="header" nameStructure="IEDName" revision="R0.0" toolID="none" version="V0.0">
+		<History>
+			<Hitem revision="R0.1" version="V0.0" what="" when="Sat Jan 01 19:00:00 NZST 2022" who="Daniel" why="Testing" />
+		</History>
+	</Header>
+	<Substation name="ERE" sxy:dir="vertical" sxy:x="1" desc="Just a substation">
+		<VoltageLevel name="V220" sxy:dir="vertical" sxy:x="3">
+			<Bay name="B232" sxy:dir="vertical" sxy:x="1">
+				<ConductingEquipment name="ES239" sxy:dir="vertical" sxy:x="1" sxy:y="1" virtual="false" type="DIS">
+					<Terminal bayName="B232" cNodeName="L1" name="L1" substationName="ERE" voltageLevelName="V220" connectivityNode="ERE/V220/B232/L1" />
+					<Terminal bayName="B232" cNodeName="grounded" name="grounded" substationName="ERE" voltageLevelName="V220" connectivityNode="ERE/V220/B232/grounded" />
+				</ConductingEquipment>
+				<ConnectivityNode name="grounded" pathName="ERE/V220/B232/grounded" />
+			</Bay>
+			<Bay name="B242" sxy:dir="vertical" sxy:x="2">
+				<ConductingEquipment name="ES249" sxy:dir="vertical" sxy:x="1" sxy:y="1" virtual="false" type="DIS">
+					<Terminal bayName="B242" cNodeName="L1" name="L1" substationName="ERE" voltageLevelName="V220" connectivityNode="ERE/V220/B242/L1" />
+					<Terminal bayName="B242" cNodeName="grounded" name="grounded" substationName="ERE" voltageLevelName="V220" connectivityNode="ERE/V220/B242/grounded" />
+				</ConductingEquipment>
+				<ConnectivityNode name="grounded" pathName="ERE/V220/B242/grounded" />
+			</Bay>
+			<Bay name="B252" sxy:dir="vertical" sxy:x="3">
+				<ConductingEquipment name="ES259" sxy:dir="vertical" sxy:x="1" sxy:y="1" virtual="false" type="DIS">
+					<LNode iedName="BC1" ldInst="Application" lnClass="XSWI" lnInst="1" lnType="LNType_XSWI_Ctl" />
+					<Terminal bayName="B252" cNodeName="L1" name="L1" substationName="ERE" voltageLevelName="V220" connectivityNode="ERE/V220/B252/L1" />
+					<Terminal bayName="B252" cNodeName="L2" name="L2" substationName="ERE" voltageLevelName="V220" connectivityNode="ERE/V220/B252/L2" />
+				</ConductingEquipment>
+				<ConnectivityNode name="L2" pathName="ERE/V220/B252/L2" />
+			</Bay>
+			<Bay name="B262" sxy:dir="vertical" sxy:x="4">
+				<ConductingEquipment name="ES269" sxy:dir="vertical" sxy:x="1" sxy:y="1" virtual="false" type="DIS">
+					<LNode iedName="BC1" ldInst="Application" lnClass="XSWI" lnInst="2" lnType="LNType_XSWI_Ctl_2" />
+					<Terminal bayName="B262" cNodeName="L1" name="L1" substationName="ERE" voltageLevelName="V220" connectivityNode="ERE/V220/B262/L1" />
+					<Terminal bayName="B262" cNodeName="L2" name="L2" substationName="ERE" voltageLevelName="V220" connectivityNode="ERE/V220/B262/L2" />
+				</ConductingEquipment>
+				<ConnectivityNode name="L2" pathName="ERE/V220/B262/L2" />
+			</Bay>
+			<Bay name="B272" sxy:dir="vertical" sxy:x="5">
+				<ConductingEquipment name="ES279" sxy:dir="vertical" sxy:x="1" sxy:y="1" virtual="false" type="DIS">
+					<SubEquipment name="A" phase="A" virtual="false">
+						<LNode iedName="BC1" ldInst="Application" lnClass="XSWI" lnInst="1" lnType="LNType_XSWI_Ctl" />
+					</SubEquipment>
+					<Terminal bayName="B272" cNodeName="L1" name="L1" substationName="ERE" voltageLevelName="V220" connectivityNode="ERE/V220/B272/L1" />
+					<Terminal bayName="B272" cNodeName="L2" name="L2" substationName="ERE" voltageLevelName="V220" connectivityNode="ERE/V220/B272/L2" />
+				</ConductingEquipment>
+				<ConnectivityNode name="L2" pathName="ERE/V220/B272/L2" />
+			</Bay>
+			<Bay name="Bus_A1" desc="Bus A1" sxy:x="0" sxy:y="3">
+				<ConnectivityNode name="L1_232" pathName="ERE/V220/B232/L1" />
+				<ConnectivityNode name="L1_242" pathName="ERE/V220/B242/L1" />
+				<ConnectivityNode name="L1_252" pathName="ERE/V220/B252/L1" />
+				<ConnectivityNode name="L1_262" pathName="ERE/V220/B262/L1" />
+				<ConnectivityNode name="L1_272" pathName="ERE/V220/B272/L1" />
+			  </Bay>
+		</VoltageLevel>
+	</Substation>
+	<IED desc="ERS Bay Controller" name="BC1" type="ERS_Bay_Controller" manufacturer="FreedomInc" configVersion="V00.01.00" originalSclVersion="2007" originalSclRevision="B" owner="IEC station 1" originalSclRelease="4">
+		<Services nameLength="64">
+			<ClientServices goose="true" gsse="false" bufReport="false" unbufReport="false" readLog="false" sv="true" supportsLdName="true" maxGOOSE="128" maxSMV="32" rGOOSE="false" rSV="false" noIctBinding="false">
+				<TimeSyncProt sntp="true" c37_238="false" other="false" iec61850_9_3="true" />
+			</ClientServices>
+			<DynAssociation max="6" />
+			<SettingGroups>
+				<SGEdit resvTms="true" />
+			</SettingGroups>
+			<GetDirectory />
+			<GetDataObjectDefinition />
+			<DataObjectDirectory />
+			<GetDataSetValue />
+			<DataSetDirectory />
+			<ConfDataSet max="50" maxAttributes="100" modify="true" />
+			<DynDataSet max="30" maxAttributes="60" />
+			<ReadWrite />
+			<ConfReportControl max="60" bufMode="both" bufConf="true" />
+			<GetCBValues />
+			<ReportSettings cbName="Conf" datSet="Dyn" rptID="Dyn" optFields="Dyn" bufTime="Dyn" trgOps="Dyn" intgPd="Dyn" resvTms="true" />
+			<GSESettings cbName="Conf" datSet="Conf" appID="Conf" dataLabel="Fix" kdaParticipant="false" />
+			<ConfLNs fixPrefix="false" fixLnInst="false" />
+			<ConfLdName />
+			<GOOSE max="16" fixedOffs="false" goose="true" rGOOSE="false" />
+			<FileHandling />
+			<SupSubscription maxGo="0" maxSv="60" />
+			<ValueHandling setToRO="false" />
+			<RedProt hsr="true" prp="true" rstp="true" />
+			<CommProt ipv6="false" />
+		</Services>
+		<AccessPoint desc="" name="E" router="false" clock="false">
+			<Server timeout="0">
+				<Authentication none="true" />
+				<LDevice desc="Application" inst="Application">
+					<LN0 lnClass="LLN0" inst="" lnType="LNType_LLN0_Application" desc="General">
+						<DOI name="Mod" desc="Test mode" />
+						<DOI name="Beh" desc="Behavior" />
+						<DOI name="Health" desc="Health (61850 only)" />
+						<DOI name="NamPlt" desc="Name plate">
+							<DAI name="configRev">
+								<Val>2021-08-31 19:49:47</Val>
+							</DAI>
+							<DAI name="ldNs">
+								<Val>IEC 61850-7-4:2007B</Val>
+							</DAI>
+						</DOI>
+						<DOI name="LEDRs" desc="LED reset" />
+						<DOI name="LocKey" desc="Sw.authority key/set">
+							<DAI name="dataNs">
+								<Val>IEC 61850-7-4:2007B</Val>
+							</DAI>
+						</DOI>
+						<DOI name="LocSta" desc="Switching auth. station">
+							<DAI name="dataNs">
+								<Val>IEC 61850-7-4:2007B</Val>
+							</DAI>
+						</DOI>
+						<DOI name="MltLev" desc="Multiple sw.auth. levels">
+							<DAI name="setVal">
+								<Val>false</Val>
+							</DAI>
+							<DAI name="dataNs">
+								<Val>IEC 61850-7-4:2007B</Val>
+							</DAI>
+						</DOI>
+						<SettingControl numOfSGs="1" actSG="1"></SettingControl>
+					</LN0>
+					<LN lnClass="XSWI" inst="1" lnType="LNType_XSWI_Ctl" desc="Disconnector" prefix="">
+						<DOI name="Mod" desc="Mode (status only)" />
+						<DOI name="Beh" desc="Behavior" />
+						<DOI name="Health" desc="Health" />
+						<DOI name="NamPlt" desc="Name plate"/>
+						<DOI name="Loc" desc="Switching auth. local" />
+						<DOI name="OpCnt" desc="Op.ct." />
+						<DOI name="Pos" desc="Position">
+							<SDI name="pulseConfig">
+								<DAI name="cmdQual">
+									<Val>pulse</Val>
+								</DAI>
+								<DAI name="onDur">
+									<Val>10000</Val>
+								</DAI>
+								<DAI name="offDur">
+									<Val>0</Val>
+								</DAI>
+								<DAI name="numPls">
+									<Val>1</Val>
+								</DAI>
+							</SDI>
+						</DOI>
+						<DOI name="BlkOpn" desc="Block opening" />
+						<DOI name="BlkCls" desc="Block closing" />
+						<DOI name="SwTyp" desc="Switching-device type">
+							<DAI name="stVal">
+								<Val>Earthing Switch</Val>
+							</DAI>
+						</DOI>
+					</LN>
+					<LN lnClass="XSWI" inst="2" lnType="LNType_XSWI_Ctl_2" desc="Disconnector" prefix="">
+						<DOI name="Mod" desc="Mode (status only)" />
+						<DOI name="Beh" desc="Behavior" />
+						<DOI name="Health" desc="Health" />
+						<DOI name="NamPlt" desc="Name plate"/>
+						<DOI name="Loc" desc="Switching auth. local" />
+						<DOI name="OpCnt" desc="Op.ct." />
+						<DOI name="Pos" desc="Position">
+							<SDI name="pulseConfig">
+								<DAI name="cmdQual">
+									<Val>pulse</Val>
+								</DAI>
+								<DAI name="onDur">
+									<Val>10000</Val>
+								</DAI>
+								<DAI name="offDur">
+									<Val>0</Val>
+								</DAI>
+								<DAI name="numPls">
+									<Val>1</Val>
+								</DAI>
+							</SDI>
+						</DOI>
+						<DOI name="BlkOpn" desc="Block opening" />
+						<DOI name="BlkCls" desc="Block closing" />
+						<DOI name="SwTyp" desc="Switching-device type">
+							<DAI name="stVal">
+								<Val>Earthing Switch</Val>
+							</DAI>
+						</DOI>
+					</LN>
+				</LDevice>
+			</Server>
+		</AccessPoint>
+	</IED>
+	<DataTypeTemplates>
+		<LNodeType id="LNType_LLN0_Application" lnClass="LLN0">
+			<DO name="Mod" type="DOType_Mod_controllable_Test_with_InitVal" />
+			<DO name="Beh" type="DOType_ENS_Behavior" />
+			<DO name="Health" type="DOType_ENS_Health" />
+			<DO name="NamPlt" type="DOType_LPL_NamPlt_for_LLN0" />
+			<DO name="LEDRs" type="DOType_SPC_dir_with_nor_sec" />
+			<DO name="LocKey" type="DOType_SPS_with_dataNs" />
+			<DO name="LocSta" type="DOType_SPC_dir_with_nor_sec_and_dataNs" />
+			<DO name="MltLev" type="DOType_SPG_readOnly_with_dataNs" />
+		</LNodeType>
+		<LNodeType id="LNType_XSWI_Ctl" lnClass="XSWI">
+			<DO name="Mod" type="DOType_Mod_status_only_with_InitVal" />
+			<DO name="Beh" type="DOType_ENS_Behavior" />
+			<DO name="Health" type="DOType_ENS_Health" />
+			<DO name="NamPlt" type="DOType_LPL_NamPlt_for_Ed2_LN" />
+			<DO name="Loc" type="DOType_SPS" />
+			<DO name="OpCnt" type="DOType_INS_INT32" />
+			<DO name="Pos" type="DOType_DPC_XCBR_Pos" />
+			<DO name="BlkOpn" type="DOType_SPC_status_only" />
+			<DO name="BlkCls" type="DOType_SPC_status_only" />
+			<DO name="SwTyp" type="DOType_ENS_SwitchType" />
+		</LNodeType>
+		<LNodeType id="LNType_XSWI_Ctl_2" lnClass="XSWI">
+			<DO name="Mod" type="DOType_Mod_status_only_with_InitVal" />
+			<DO name="Beh" type="DOType_ENS_Behavior" />
+			<DO name="Health" type="DOType_ENS_Health" />
+			<DO name="NamPlt" type="DOType_LPL_NamPlt_for_Ed2_LN" />
+			<DO name="Loc" type="DOType_SPS" />
+			<DO name="OpCnt" type="DOType_INS_INT32" />
+			<DO name="Pos" type="DOType_DPC_XCBR_Pos" />
+			<DO name="BlkOpn" type="DOType_SPC_status_only" />
+			<DO name="BlkCls" type="DOType_SPC_status_only" />
+			<DO name="SwTyp" type="DOType_ENS_SwitchType_2" />
+		</LNodeType>
+		<DOType id="DOType_SPG_readOnly_with_dataNs" cdc="SPG">
+			<DA fc="SE" name="setVal" bType="BOOLEAN" valKind="RO" />
+			<DA fc="EX" name="dataNs" bType="VisString255" valKind="RO">
+				<Val>SIPROTEC5</Val>
+			</DA>
+		</DOType>
+		<DOType id="DOType_SPC_dir_with_nor_sec_and_dataNs" cdc="SPC">
+			<DA fc="ST" name="origin" bType="Struct" type="DAType_origin" />
+			<DA fc="ST" name="ctlNum" bType="INT8U" />
+			<DA dchg="true" fc="ST" name="stVal" bType="BOOLEAN" />
+			<DA qchg="true" fc="ST" name="q" bType="Quality" />
+			<DA fc="ST" name="t" bType="Timestamp" />
+			<DA dchg="true" fc="CF" name="ctlModel" bType="Enum" valKind="RO" type="Textlist_ctlModel_dir_with_nor_sec">
+				<Val>direct-with-normal-security</Val>
+			</DA>
+			<DA fc="EX" name="dataNs" bType="VisString255" valKind="RO">
+				<Val>SIPROTEC5</Val>
+			</DA>
+			<DA fc="CO" name="Oper" bType="Struct" type="DAType_Oper_Boolean" />
+		</DOType>
+		<DOType id="DOType_SPS_with_dataNs" cdc="SPS">
+			<DA dchg="true" fc="ST" name="stVal" bType="BOOLEAN" />
+			<DA qchg="true" fc="ST" name="q" bType="Quality" />
+			<DA fc="ST" name="t" bType="Timestamp" />
+			<DA fc="EX" name="dataNs" bType="VisString255" valKind="RO">
+				<Val>SIPROTEC5</Val>
+			</DA>
+		</DOType>
+		<DOType id="DOType_SPC_dir_with_nor_sec" cdc="SPC">
+			<DA fc="ST" name="origin" bType="Struct" type="DAType_origin" />
+			<DA fc="ST" name="ctlNum" bType="INT8U" />
+			<DA dchg="true" fc="ST" name="stVal" bType="BOOLEAN" />
+			<DA qchg="true" fc="ST" name="q" bType="Quality" />
+			<DA fc="ST" name="t" bType="Timestamp" />
+			<DA dchg="true" fc="CF" name="ctlModel" bType="Enum" valKind="RO" type="Textlist_ctlModel_dir_with_nor_sec">
+				<Val>direct-with-normal-security</Val>
+			</DA>
+			<DA fc="CO" name="Oper" bType="Struct" type="DAType_Oper_Boolean" />
+		</DOType>
+		<DOType id="DOType_LPL_NamPlt_for_LLN0" cdc="LPL">
+			<DA fc="DC" name="vendor" bType="VisString255" valKind="RO">
+				<Val>SIEMENS</Val>
+			</DA>
+			<DA fc="DC" name="swRev" bType="VisString255" valKind="RO" />
+			<DA fc="DC" name="d" bType="VisString255" valKind="RO" />
+			<DA fc="DC" name="configRev" bType="VisString255" valKind="RO" />
+			<DA fc="EX" name="ldNs" bType="VisString255" valKind="RO" />
+		</DOType>
+		<DOType id="DOType_ENS_Health" cdc="ENS">
+			<DA dchg="true" fc="ST" name="stVal" bType="Enum" type="Textlist_Health" />
+			<DA qchg="true" fc="ST" name="q" bType="Quality" />
+			<DA fc="ST" name="t" bType="Timestamp" />
+		</DOType>
+		<DOType id="DOType_ENS_Behavior" cdc="ENS">
+			<DA dchg="true" fc="ST" name="stVal" bType="Enum" type="Textlist_Behavior" />
+			<DA qchg="true" fc="ST" name="q" bType="Quality" />
+			<DA fc="ST" name="t" bType="Timestamp" />
+		</DOType>
+		<DOType id="DOType_Mod_controllable_Test_with_InitVal" cdc="ENC">
+			<DA fc="ST" name="origin" bType="Struct" type="DAType_origin" />
+			<DA fc="ST" name="ctlNum" bType="INT8U" />
+			<DA dchg="true" fc="ST" name="stVal" bType="Enum" type="Textlist_Behavior_SetTestMod" />
+			<DA qchg="true" fc="ST" name="q" bType="Quality" />
+			<DA fc="ST" name="t" bType="Timestamp" />
+			<DA dchg="true" fc="CF" name="ctlModel" bType="Enum" valKind="RO" type="Textlist_ctlModel_dir_with_nor_sec">
+				<Val>direct-with-normal-security</Val>
+			</DA>
+			<DA fc="CO" name="Oper" bType="Struct" type="DAType_Oper_Mod_OnTest" />
+		</DOType>
+		<DOType id="DOType_LPL_NamPlt_for_Ed2_LN" cdc="LPL">
+			<DA fc="DC" name="vendor" bType="VisString255" valKind="RO">
+				<Val>FreedomInc</Val>
+			</DA>
+			<DA fc="DC" name="swRev" bType="VisString255" valKind="RO" />
+			<DA fc="DC" name="d" bType="VisString255" valKind="RO" />
+			<DA fc="DC" name="configRev" bType="VisString255" valKind="RO" />
+			<DA fc="EX" name="lnNs" bType="VisString255" valKind="RO">
+				<Val>IEC 61850-7-4:2007B</Val>
+			</DA>
+		</DOType>
+		<DOType id="DOType_SPS" cdc="SPS">
+			<DA dchg="true" fc="ST" name="stVal" bType="BOOLEAN" />
+			<DA qchg="true" fc="ST" name="q" bType="Quality" />
+			<DA fc="ST" name="t" bType="Timestamp" />
+		</DOType>
+		<DOType id="DOType_Mod_status_only_with_InitVal" cdc="ENC">
+			<DA dchg="true" fc="ST" name="stVal" bType="Enum" type="Textlist_Behavior">
+				<Val>on</Val>
+			</DA>
+			<DA qchg="true" fc="ST" name="q" bType="Quality" />
+			<DA fc="ST" name="t" bType="Timestamp" />
+			<DA dchg="true" fc="CF" name="ctlModel" bType="Enum" valKind="RO" type="Textlist_ctlModel_status_only">
+				<Val>status-only</Val>
+			</DA>
+		</DOType>
+		<DOType id="DOType_SPC_status_only" cdc="SPC">
+			<DA dchg="true" fc="ST" name="stVal" bType="BOOLEAN" />
+			<DA qchg="true" fc="ST" name="q" bType="Quality" />
+			<DA fc="ST" name="t" bType="Timestamp" />
+			<DA dchg="true" fc="CF" name="ctlModel" bType="Enum" valKind="RO" type="Textlist_ctlModel_status_only">
+				<Val>status-only</Val>
+			</DA>
+		</DOType>
+		<DOType id="DOType_DPC_XCBR_Pos" cdc="DPC">
+			<DA fc="ST" name="origin" bType="Struct" type="DAType_origin" />
+			<DA fc="ST" name="ctlNum" bType="INT8U" />
+			<DA dchg="true" fc="ST" name="stVal" bType="Dbpos" />
+			<DA qchg="true" fc="ST" name="q" bType="Quality" />
+			<DA fc="ST" name="t" bType="Timestamp" />
+			<DA dchg="true" fc="ST" name="stSeld" bType="BOOLEAN" />
+			<DA fc="SV" name="subEna" bType="BOOLEAN" />
+			<DA fc="SV" name="subVal" bType="Dbpos" />
+			<DA fc="SV" name="subQ" bType="Quality" />
+			<DA fc="SV" name="subID" bType="VisString64" />
+			<DA fc="BL" name="blkEna" bType="BOOLEAN" />
+			<DA dchg="true" fc="CF" name="pulseConfig" bType="Struct" type="DAType_PulseConfig_XCBR" />
+			<DA dchg="true" fc="CF" name="ctlModel" bType="Enum" valKind="RO" type="Textlist_ctlModel_status_only">
+				<Val>status-only</Val>
+			</DA>
+		</DOType>
+		<DOType id="DOType_INS_INT32" cdc="INS">
+			<DA dchg="true" fc="ST" name="stVal" bType="INT32" />
+			<DA qchg="true" fc="ST" name="q" bType="Quality" />
+			<DA fc="ST" name="t" bType="Timestamp" />
+		</DOType>
+		<DOType id="DOType_Mod_controllable_with_InitVal" cdc="ENC">
+			<DA fc="ST" name="origin" bType="Struct" type="DAType_origin" />
+			<DA fc="ST" name="ctlNum" bType="INT8U" />
+			<DA dchg="true" fc="ST" name="stVal" bType="Enum" type="Textlist_Behavior" />
+			<DA qchg="true" fc="ST" name="q" bType="Quality" />
+			<DA fc="ST" name="t" bType="Timestamp" />
+			<DA dchg="true" fc="CF" name="ctlModel" bType="Enum" valKind="RO" type="Textlist_ctlModel_dir_with_nor_sec">
+				<Val>direct-with-normal-security</Val>
+			</DA>
+			<DA fc="CO" name="Oper" bType="Struct" type="DAType_Oper_Mod" />
+		</DOType>
+		<DOType id="DOType_SPC_statusOnly_and_dir_with_nor_sec" cdc="SPC">
+			<DA fc="ST" name="origin" bType="Struct" type="DAType_origin" />
+			<DA fc="ST" name="ctlNum" bType="INT8U" />
+			<DA dchg="true" fc="ST" name="stVal" bType="BOOLEAN" />
+			<DA qchg="true" fc="ST" name="q" bType="Quality" />
+			<DA fc="ST" name="t" bType="Timestamp" />
+			<DA dchg="true" fc="CF" name="ctlModel" bType="Enum" valKind="RO" type="Textlist_ctlModel_status_only_and_dir_with_nor_sec">
+				<Val>direct-with-normal-security</Val>
+			</DA>
+			<DA fc="CO" name="Oper" bType="Struct" type="DAType_Oper_Boolean" />
+		</DOType>
+		<DOType id="DOType_ENS_SwitchType" cdc="ENS">
+			<DA dchg="true" fc="ST" name="stVal" bType="Enum" type="EnType_SwitchType" />
+			<DA qchg="true" fc="ST" name="q" bType="Quality" />
+			<DA fc="ST" name="t" bType="Timestamp" />
+		</DOType>
+		<DOType id="DOType_ENS_SwitchType_2" cdc="ENS">
+			<DA dchg="true" fc="ST" name="stVal" bType="Enum" type="EnType_SwitchType">
+				<Val>Earthing Switch</Val>
+			</DA>
+			<DA qchg="true" fc="ST" name="q" bType="Quality" />
+			<DA fc="ST" name="t" bType="Timestamp" />
+		</DOType>
+		<DAType id="DAType_origin">
+			<BDA name="orCat" bType="Enum" type="Textlist_orCategory" />
+			<BDA name="orIdent" bType="Octet64" />
+		</DAType>
+		<DAType id="DAType_Oper_Boolean">
+			<BDA name="ctlVal" bType="BOOLEAN" />
+			<BDA name="origin" bType="Struct" type="DAType_origin" />
+			<BDA name="ctlNum" bType="INT8U" />
+			<BDA name="T" bType="Timestamp" />
+			<BDA name="Test" bType="BOOLEAN" />
+			<BDA name="Check" bType="Check" />
+			<ProtNs type="8-MMS">IEC 61850-8-1:2003</ProtNs>
+		</DAType>
+		<DAType id="DAType_Oper_Mod_OnTest">
+			<BDA name="ctlVal" bType="Enum" type="Textlist_Behavior_SetTestMod" />
+			<BDA name="origin" bType="Struct" type="DAType_origin" />
+			<BDA name="ctlNum" bType="INT8U" />
+			<BDA name="T" bType="Timestamp" />
+			<BDA name="Test" bType="BOOLEAN" />
+			<BDA name="Check" bType="Check" />
+			<ProtNs type="8-MMS">IEC 61850-8-1:2003</ProtNs>
+		</DAType>
+		<DAType id="DAType_Units_1">
+			<BDA name="SIUnit" bType="Enum" valKind="RO" type="EnType_SIUnit" />
+			<BDA name="multiplier" bType="Enum" valKind="RO" type="EnType_Multiplier" />
+		</DAType>
+		<DAType id="DAType_Cancel_Boolean">
+			<BDA name="ctlVal" bType="BOOLEAN" />
+			<BDA name="origin" bType="Struct" type="DAType_origin" />
+			<BDA name="ctlNum" bType="INT8U" />
+			<BDA name="T" bType="Timestamp" />
+			<BDA name="Test" bType="BOOLEAN" />
+			<ProtNs type="8-MMS">IEC 61850-8-1:2003</ProtNs>
+		</DAType>
+		<DAType id="DAType_CalendarTime">
+			<BDA name="occ" bType="INT16U" />
+			<BDA name="occType" bType="Enum" type="EnType_Cal_Occ_Type" />
+			<BDA name="occPer" bType="Enum" type="EnType_Cal_Occ_Period" />
+			<BDA name="weekDay" bType="Enum" type="EnType_Cal_WeekDay" />
+			<BDA name="month" bType="Enum" type="EnType_Cal_Month" />
+			<BDA name="day" bType="INT8U" />
+			<BDA name="hr" bType="INT8U" />
+			<BDA name="mn" bType="INT8U" />
+		</DAType>
+		<DAType id="DAType_PulseConfig_XCBR">
+			<BDA name="cmdQual" bType="Enum" valKind="RO" type="Textlist_PulseConfigCmdQual" />
+			<BDA name="onDur" bType="INT32U" valKind="RO" />
+			<BDA name="offDur" bType="INT32U" valKind="RO" />
+			<BDA name="numPls" bType="INT32U" valKind="RO" />
+		</DAType>
+		<DAType id="DAType_Oper_Mod">
+			<BDA name="ctlVal" bType="Enum" type="Textlist_Behavior" />
+			<BDA name="origin" bType="Struct" type="DAType_origin" />
+			<BDA name="ctlNum" bType="INT8U" />
+			<BDA name="T" bType="Timestamp" />
+			<BDA name="Test" bType="BOOLEAN" />
+			<BDA name="Check" bType="Check" />
+			<ProtNs type="8-MMS">IEC 61850-8-1:2003</ProtNs>
+		</DAType>
+		<DAType id="DAType_Vector">
+			<BDA name="mag" bType="Struct" type="DAType_AnalogValue_FLOAT32" />
+			<BDA name="ang" bType="Struct" type="DAType_AnalogValue_FLOAT32" />
+		</DAType>
+		<DAType id="DAType_AnalogValue_FLOAT32">
+			<BDA name="f" bType="FLOAT32" valKind="Set">
+				<Val>0</Val>
+			</BDA>
+		</DAType>
+		<DAType id="DAType_Vector_mag">
+			<BDA name="mag" bType="Struct" type="DAType_AnalogValue_FLOAT32" />
+		</DAType>
+		<DAType id="DAType_AnalogValue_FLOAT32_readOnly">
+			<BDA name="f" bType="FLOAT32" valKind="RO">
+				<Val>0</Val>
+			</BDA>
+		</DAType>
+		<DAType id="DAType_AnalogValue_INT32">
+			<BDA name="i" bType="INT32" />
+		</DAType>
+		<DAType id="DAType_ScaledValueConfig_readOnly_VisAsProperty">
+			<BDA name="scaleFactor" bType="FLOAT32" valKind="Set">
+				<Val>1</Val>
+			</BDA>
+			<BDA name="offset" bType="FLOAT32" valKind="Set">
+				<Val>0</Val>
+			</BDA>
+		</DAType>
+		<EnumType id="Textlist_orCategory">
+			<EnumVal ord="0">not-supported</EnumVal>
+			<EnumVal ord="1">bay-control</EnumVal>
+			<EnumVal ord="2">station-control</EnumVal>
+			<EnumVal ord="3">remote-control</EnumVal>
+			<EnumVal ord="4">automatic-bay</EnumVal>
+			<EnumVal ord="5">automatic-station</EnumVal>
+			<EnumVal ord="6">automatic-remote</EnumVal>
+			<EnumVal ord="7">maintenance</EnumVal>
+			<EnumVal ord="8">process</EnumVal>
+		</EnumType>
+		<EnumType id="Textlist_ctlModel_dir_with_nor_sec">
+			<EnumVal ord="1">direct-with-normal-security</EnumVal>
+		</EnumType>
+		<EnumType id="Textlist_Health">
+			<EnumVal ord="1">Ok</EnumVal>
+			<EnumVal ord="2">Warning</EnumVal>
+			<EnumVal ord="3">Alarm</EnumVal>
+		</EnumType>
+		<EnumType id="Textlist_Behavior">
+			<EnumVal ord="1">on</EnumVal>
+			<EnumVal ord="3">test</EnumVal>
+			<EnumVal ord="5">off</EnumVal>
+		</EnumType>
+		<EnumType id="Textlist_Behavior_SetTestMod">
+			<EnumVal ord="1">on</EnumVal>
+			<EnumVal ord="3">test</EnumVal>
+		</EnumType>
+		<EnumType id="EnType_SIUnit">
+			<EnumVal ord="-38">kV/mA</EnumVal>
+			<EnumVal ord="-37">kA/V</EnumVal>
+			<EnumVal ord="-36">ohm/m</EnumVal>
+			<EnumVal ord="-35">ppm/°C</EnumVal>
+			<EnumVal ord="-34">F/m</EnumVal>
+			<EnumVal ord="-33">H/m</EnumVal>
+			<EnumVal ord="-32">ms/kPa</EnumVal>
+			<EnumVal ord="-31">kPa</EnumVal>
+			<EnumVal ord="-30">ms/V</EnumVal>
+			<EnumVal ord="-29">ms/K</EnumVal>
+			<EnumVal ord="-28">V/s</EnumVal>
+			<EnumVal ord="-27">I/Ir*s</EnumVal>
+			<EnumVal ord="-26">1/week</EnumVal>
+			<EnumVal ord="-25">1/d</EnumVal>
+			<EnumVal ord="-24">1/h</EnumVal>
+			<EnumVal ord="-23">1/min</EnumVal>
+			<EnumVal ord="-22">periods</EnumVal>
+			<EnumVal ord="-21">GB</EnumVal>
+			<EnumVal ord="-19">cycle</EnumVal>
+			<EnumVal ord="-18">mile</EnumVal>
+			<EnumVal ord="-17">inch</EnumVal>
+			<EnumVal ord="-16">°F</EnumVal>
+			<EnumVal ord="-15">I/IrObj</EnumVal>
+			<EnumVal ord="-14">MB</EnumVal>
+			<EnumVal ord="-13">KB</EnumVal>
+			<EnumVal ord="-12">Bytes</EnumVal>
+			<EnumVal ord="-11">p.u.</EnumVal>
+			<EnumVal ord="-10">day(s)</EnumVal>
+			<EnumVal ord="-7">%</EnumVal>
+			<EnumVal ord="-4">F/mi</EnumVal>
+			<EnumVal ord="-3">ohm/mi</EnumVal>
+			<EnumVal ord="-2">F/km</EnumVal>
+			<EnumVal ord="-1">ohm/km</EnumVal>
+			<EnumVal ord="1" />
+			<EnumVal ord="2">m</EnumVal>
+			<EnumVal ord="3">kg</EnumVal>
+			<EnumVal ord="4">s</EnumVal>
+			<EnumVal ord="5">A</EnumVal>
+			<EnumVal ord="6">K</EnumVal>
+			<EnumVal ord="7">mol</EnumVal>
+			<EnumVal ord="8">cd</EnumVal>
+			<EnumVal ord="9">deg</EnumVal>
+			<EnumVal ord="10">rad</EnumVal>
+			<EnumVal ord="11">sr</EnumVal>
+			<EnumVal ord="21">Gy</EnumVal>
+			<EnumVal ord="23">°C</EnumVal>
+			<EnumVal ord="24">Sv</EnumVal>
+			<EnumVal ord="25">F</EnumVal>
+			<EnumVal ord="26">C</EnumVal>
+			<EnumVal ord="27">S</EnumVal>
+			<EnumVal ord="28">H</EnumVal>
+			<EnumVal ord="29">V</EnumVal>
+			<EnumVal ord="30">ohm</EnumVal>
+			<EnumVal ord="31">J</EnumVal>
+			<EnumVal ord="32">N</EnumVal>
+			<EnumVal ord="33">Hz</EnumVal>
+			<EnumVal ord="34">lx</EnumVal>
+			<EnumVal ord="35">Lm</EnumVal>
+			<EnumVal ord="36">Wb</EnumVal>
+			<EnumVal ord="37">T</EnumVal>
+			<EnumVal ord="38">W</EnumVal>
+			<EnumVal ord="39">Pa</EnumVal>
+			<EnumVal ord="41">m²</EnumVal>
+			<EnumVal ord="42">m³</EnumVal>
+			<EnumVal ord="43">m/s</EnumVal>
+			<EnumVal ord="44">m/s²</EnumVal>
+			<EnumVal ord="45">m³/s</EnumVal>
+			<EnumVal ord="46">m/m³</EnumVal>
+			<EnumVal ord="47">M</EnumVal>
+			<EnumVal ord="48">kg/m³</EnumVal>
+			<EnumVal ord="49">m²/s</EnumVal>
+			<EnumVal ord="50">W/m K</EnumVal>
+			<EnumVal ord="51">J/K</EnumVal>
+			<EnumVal ord="52">ppm</EnumVal>
+			<EnumVal ord="53">1/s</EnumVal>
+			<EnumVal ord="54">rad/s</EnumVal>
+			<EnumVal ord="55">W/m²</EnumVal>
+			<EnumVal ord="56">J/m²</EnumVal>
+			<EnumVal ord="57">S/m</EnumVal>
+			<EnumVal ord="58">K/s</EnumVal>
+			<EnumVal ord="59">Pa/s</EnumVal>
+			<EnumVal ord="60">J/kg K</EnumVal>
+			<EnumVal ord="61">VA</EnumVal>
+			<EnumVal ord="63">VAr</EnumVal>
+			<EnumVal ord="64">phi</EnumVal>
+			<EnumVal ord="65">cos(phi)</EnumVal>
+			<EnumVal ord="66">Vs</EnumVal>
+			<EnumVal ord="67">V²</EnumVal>
+			<EnumVal ord="68">As</EnumVal>
+			<EnumVal ord="69">A²</EnumVal>
+			<EnumVal ord="70">A²t</EnumVal>
+			<EnumVal ord="71">VAh</EnumVal>
+			<EnumVal ord="72">Wh</EnumVal>
+			<EnumVal ord="73">VArh</EnumVal>
+			<EnumVal ord="74">V/Hz</EnumVal>
+			<EnumVal ord="75">Hz/s</EnumVal>
+			<EnumVal ord="76">char</EnumVal>
+			<EnumVal ord="77">char/s</EnumVal>
+			<EnumVal ord="78">kgm²</EnumVal>
+			<EnumVal ord="79">dB</EnumVal>
+			<EnumVal ord="80">J/Wh</EnumVal>
+			<EnumVal ord="81">W/s</EnumVal>
+			<EnumVal ord="82">l/s</EnumVal>
+			<EnumVal ord="83">dBm</EnumVal>
+			<EnumVal ord="84">h</EnumVal>
+			<EnumVal ord="85">min</EnumVal>
+		</EnumType>
+		<EnumType id="EnType_Multiplier">
+			<EnumVal ord="-24">y</EnumVal>
+			<EnumVal ord="-21">z</EnumVal>
+			<EnumVal ord="-18">a</EnumVal>
+			<EnumVal ord="-15">f</EnumVal>
+			<EnumVal ord="-12">p</EnumVal>
+			<EnumVal ord="-9">n</EnumVal>
+			<EnumVal ord="-6">µ</EnumVal>
+			<EnumVal ord="-3">m</EnumVal>
+			<EnumVal ord="-2">c</EnumVal>
+			<EnumVal ord="-1">d</EnumVal>
+			<EnumVal ord="0" />
+			<EnumVal ord="1">da</EnumVal>
+			<EnumVal ord="2">h</EnumVal>
+			<EnumVal ord="3">k</EnumVal>
+			<EnumVal ord="6">M</EnumVal>
+			<EnumVal ord="9">G</EnumVal>
+			<EnumVal ord="12">T</EnumVal>
+			<EnumVal ord="15">P</EnumVal>
+			<EnumVal ord="18">E</EnumVal>
+			<EnumVal ord="21">Z</EnumVal>
+			<EnumVal ord="24">Y</EnumVal>
+		</EnumType>
+		<EnumType id="Textlist_ctlModel">
+			<EnumVal ord="0">status-only</EnumVal>
+			<EnumVal ord="1">direct-with-normal-security</EnumVal>
+			<EnumVal ord="2">sbo-with-normal-security</EnumVal>
+			<EnumVal ord="3">direct-with-enhanced-security</EnumVal>
+			<EnumVal ord="4">sbo-with-enhanced-security</EnumVal>
+		</EnumType>
+		<EnumType id="Textlist_ctlModel_status_only">
+			<EnumVal ord="0">status-only</EnumVal>
+		</EnumType>
+		<EnumType id="EnType_Cal_Occ_Type">
+			<EnumVal ord="0">Time</EnumVal>
+			<EnumVal ord="1">WeekDay</EnumVal>
+			<EnumVal ord="2">WeekOfYear</EnumVal>
+			<EnumVal ord="3">DayOfMonth</EnumVal>
+			<EnumVal ord="4">DayOfYear</EnumVal>
+		</EnumType>
+		<EnumType id="EnType_Cal_Occ_Period">
+			<EnumVal ord="0">Hour</EnumVal>
+			<EnumVal ord="1">Day</EnumVal>
+			<EnumVal ord="2">Week</EnumVal>
+			<EnumVal ord="3">Month</EnumVal>
+			<EnumVal ord="4">Year</EnumVal>
+		</EnumType>
+		<EnumType id="EnType_Cal_WeekDay">
+			<EnumVal ord="1">Monday</EnumVal>
+			<EnumVal ord="2">Tuesday</EnumVal>
+			<EnumVal ord="3">Wednesday</EnumVal>
+			<EnumVal ord="4">Thursday</EnumVal>
+			<EnumVal ord="5">Friday</EnumVal>
+			<EnumVal ord="6">Saturday</EnumVal>
+			<EnumVal ord="7">Sunday</EnumVal>
+		</EnumType>
+		<EnumType id="EnType_Cal_Month">
+			<EnumVal ord="1">January</EnumVal>
+			<EnumVal ord="2">February</EnumVal>
+			<EnumVal ord="3">March</EnumVal>
+			<EnumVal ord="4">April</EnumVal>
+			<EnumVal ord="5">May</EnumVal>
+			<EnumVal ord="6">June</EnumVal>
+			<EnumVal ord="7">July</EnumVal>
+			<EnumVal ord="8">August</EnumVal>
+			<EnumVal ord="9">September</EnumVal>
+			<EnumVal ord="10">October</EnumVal>
+			<EnumVal ord="11">November</EnumVal>
+			<EnumVal ord="12">December</EnumVal>
+		</EnumType>
+		<EnumType id="Textlist_PulseConfigCmdQual">
+			<EnumVal ord="0">pulse</EnumVal>
+			<EnumVal ord="1">persistent</EnumVal>
+		</EnumType>
+		<EnumType id="Textlist_ctlModel_status_only_and_dir_with_nor_sec">
+			<EnumVal ord="0">status-only</EnumVal>
+			<EnumVal ord="1">direct-with-normal-security</EnumVal>
+		</EnumType>
+		<EnumType id="Textlist_ctlModel_dir_with_enh_sec">
+			<EnumVal ord="3">direct-with-enhanced-security</EnumVal>
+		</EnumType>
+		<EnumType id="EnType_SwitchType">
+			<EnumVal ord="1">Load Break</EnumVal>
+			<EnumVal ord="2">Disconnector</EnumVal>
+			<EnumVal ord="3">Earthing Switch</EnumVal>
+			<EnumVal ord="4">High Speed Earthing Switch</EnumVal>
+		</EnumType>
+	</DataTypeTemplates>
+</SCL>

--- a/test/testfiles/conductingequipmentwizard.scd
+++ b/test/testfiles/conductingequipmentwizard.scd
@@ -9,13 +9,15 @@
 		<VoltageLevel name="V220" sxy:dir="vertical" sxy:x="3">
 			<Bay name="B232" sxy:dir="vertical" sxy:x="1">
 				<ConductingEquipment name="ES239" sxy:dir="vertical" sxy:x="1" sxy:y="1" virtual="false" type="DIS">
-					<Terminal bayName="B232" cNodeName="L1" name="L1" substationName="ERE" voltageLevelName="V220" connectivityNode="ERE/V220/B232/L1" />
+					<!-- first terminal grounded -->
 					<Terminal bayName="B232" cNodeName="grounded" name="grounded" substationName="ERE" voltageLevelName="V220" connectivityNode="ERE/V220/B232/grounded" />
+					<Terminal bayName="B232" cNodeName="L1" name="L1" substationName="ERE" voltageLevelName="V220" connectivityNode="ERE/V220/B232/L1" />
 				</ConductingEquipment>
 				<ConnectivityNode name="grounded" pathName="ERE/V220/B232/grounded" />
 			</Bay>
 			<Bay name="B242" sxy:dir="vertical" sxy:x="2">
 				<ConductingEquipment name="ES249" sxy:dir="vertical" sxy:x="1" sxy:y="1" virtual="false" type="DIS">
+					<!-- second terminal grounded -->
 					<Terminal bayName="B242" cNodeName="L1" name="L1" substationName="ERE" voltageLevelName="V220" connectivityNode="ERE/V220/B242/L1" />
 					<Terminal bayName="B242" cNodeName="grounded" name="grounded" substationName="ERE" voltageLevelName="V220" connectivityNode="ERE/V220/B242/grounded" />
 				</ConductingEquipment>
@@ -23,6 +25,7 @@
 			</Bay>
 			<Bay name="B252" sxy:dir="vertical" sxy:x="3">
 				<ConductingEquipment name="ES259" sxy:dir="vertical" sxy:x="1" sxy:y="1" virtual="false" type="DIS">
+					<!-- this IED has a DAI:stVal defining an "Earthing Switch" -->
 					<LNode iedName="BC1" ldInst="Application" lnClass="XSWI" lnInst="1" lnType="LNType_XSWI_Ctl" />
 					<Terminal bayName="B252" cNodeName="L1" name="L1" substationName="ERE" voltageLevelName="V220" connectivityNode="ERE/V220/B252/L1" />
 					<Terminal bayName="B252" cNodeName="L2" name="L2" substationName="ERE" voltageLevelName="V220" connectivityNode="ERE/V220/B252/L2" />
@@ -31,6 +34,7 @@
 			</Bay>
 			<Bay name="B262" sxy:dir="vertical" sxy:x="4">
 				<ConductingEquipment name="ES269" sxy:dir="vertical" sxy:x="1" sxy:y="1" virtual="false" type="DIS">
+					<!-- In this case, the SwTyp:stVal is defined via the DOType  -->
 					<LNode iedName="BC1" ldInst="Application" lnClass="XSWI" lnInst="2" lnType="LNType_XSWI_Ctl_2" />
 					<Terminal bayName="B262" cNodeName="L1" name="L1" substationName="ERE" voltageLevelName="V220" connectivityNode="ERE/V220/B262/L1" />
 					<Terminal bayName="B262" cNodeName="L2" name="L2" substationName="ERE" voltageLevelName="V220" connectivityNode="ERE/V220/B262/L2" />
@@ -39,17 +43,19 @@
 			</Bay>
 			<Bay name="B272" sxy:dir="vertical" sxy:x="5">
 				<ConductingEquipment name="ES279" sxy:dir="vertical" sxy:x="1" sxy:y="1" virtual="false" type="DIS">
-					<SubEquipment name="A" phase="A" virtual="false">
-						<LNode iedName="BC1" ldInst="Application" lnClass="XSWI" lnInst="1" lnType="LNType_XSWI_Ctl" />
-					</SubEquipment>
 					<Terminal bayName="B272" cNodeName="L1" name="L1" substationName="ERE" voltageLevelName="V220" connectivityNode="ERE/V220/B272/L1" />
 					<Terminal bayName="B272" cNodeName="L2" name="L2" substationName="ERE" voltageLevelName="V220" connectivityNode="ERE/V220/B272/L2" />
+					<SubEquipment name="A" phase="A" virtual="false">
+						<!-- Here we check that a definition inside a SubEquipment still to identify an ERS -->
+						<LNode iedName="BC1" ldInst="Application" lnClass="XSWI" lnInst="1" lnType="LNType_XSWI_Ctl" />
+					</SubEquipment>
 				</ConductingEquipment>
 				<ConnectivityNode name="L2" pathName="ERE/V220/B272/L2" />
 			</Bay>
 			<Bay name="B282" sxy:dir="vertical" sxy:x="6">
 				<ConductingEquipment name="ES289" sxy:dir="vertical" sxy:x="1" sxy:y="1" virtual="false" type="DIS">
-					<LNode iedName="None" ldInst="Application" lnClass="XSWI" lnInst="1" lnType="LNType_XSWI_Ctl" prefix="First"/>
+					<!-- This lnType is only defined in the data type templates, not within an IED section -->
+					<LNode iedName="None" ldInst="Application" lnClass="XSWI" lnInst="1" lnType="LNType_XSWI_Ctl_3"/>
 					<Terminal bayName="B282" cNodeName="L1" name="L1" substationName="ERE" voltageLevelName="V220" connectivityNode="ERE/V220/B282/L1" />
 					<Terminal bayName="B282" cNodeName="L2" name="L2" substationName="ERE" voltageLevelName="V220" connectivityNode="ERE/V220/B282/L2" />
 				</ConductingEquipment>
@@ -132,7 +138,7 @@
 						</DOI>
 						<SettingControl numOfSGs="1" actSG="1"></SettingControl>
 					</LN0>
-					<LN lnClass="XSWI" inst="1" lnType="LNType_XSWI_Ctl" desc="Disconnector" prefix="First">
+					<LN lnClass="XSWI" inst="1" lnType="LNType_XSWI_Ctl" desc="Disconnector" prefix="">
 						<DOI name="Mod" desc="Mode (status only)" />
 						<DOI name="Beh" desc="Behavior" />
 						<DOI name="Health" desc="Health" />
@@ -188,11 +194,7 @@
 						</DOI>
 						<DOI name="BlkOpn" desc="Block opening" />
 						<DOI name="BlkCls" desc="Block closing" />
-						<DOI name="SwTyp" desc="Switching-device type">
-							<DAI name="stVal">
-								<Val>Earthing Switch</Val>
-							</DAI>
-						</DOI>
+						<DOI name="SwTyp" desc="Switching-device type"/>
 					</LN>
 				</LDevice>
 			</Server>
@@ -222,6 +224,18 @@
 			<DO name="SwTyp" type="DOType_ENS_SwitchType" />
 		</LNodeType>
 		<LNodeType id="LNType_XSWI_Ctl_2" lnClass="XSWI">
+			<DO name="Mod" type="DOType_Mod_status_only_with_InitVal" />
+			<DO name="Beh" type="DOType_ENS_Behavior" />
+			<DO name="Health" type="DOType_ENS_Health" />
+			<DO name="NamPlt" type="DOType_LPL_NamPlt_for_Ed2_LN" />
+			<DO name="Loc" type="DOType_SPS" />
+			<DO name="OpCnt" type="DOType_INS_INT32" />
+			<DO name="Pos" type="DOType_DPC_XCBR_Pos" />
+			<DO name="BlkOpn" type="DOType_SPC_status_only" />
+			<DO name="BlkCls" type="DOType_SPC_status_only" />
+			<DO name="SwTyp" type="DOType_ENS_SwitchType_2" />
+		</LNodeType>
+		<LNodeType id="LNType_XSWI_Ctl_3" lnClass="XSWI">
 			<DO name="Mod" type="DOType_Mod_status_only_with_InitVal" />
 			<DO name="Beh" type="DOType_ENS_Behavior" />
 			<DO name="Health" type="DOType_ENS_Health" />

--- a/test/unit/editors/substation/conductingequipmentwizard.test.ts
+++ b/test/unit/editors/substation/conductingequipmentwizard.test.ts
@@ -1,0 +1,56 @@
+import { expect } from '@open-wc/testing';
+
+import { typeStr } from '../../../../src/wizards/conductingequipment.js';
+
+describe('conductingequipmentwizard', () => {
+
+  describe('recognises an earth switch in the conducting equipment wizard that', () => {
+    let doc: Document;
+    beforeEach(async () => {
+      doc = await fetch('/test/testfiles/conductingequipmentwizard.scd')
+        .then(response => response.text())
+        .then(str => new DOMParser().parseFromString(str, 'application/xml'));
+    });
+
+    it('has the first terminal grounded', () => {
+      expect(
+        typeStr(
+          doc.querySelector('ConductingEquipment[name="ES239"]')!
+        )
+      ).to.equal('ERS');
+    });
+
+    it('has the second terminal grounded', () => {
+      expect(
+        typeStr(
+          doc.querySelector('ConductingEquipment[name="ES249"]')!
+        )
+      ).to.equal('ERS');
+    });
+
+    it('has no grounded connectivityNodes but has an XSWI logicalNode and DOI:SWTyp > DAI:stVal defining an "Earthing Switch"', () => {
+      expect(
+        typeStr(
+          doc.querySelector('ConductingEquipment[name="ES259"]')!
+        )
+      ).to.equal('ERS');
+    });
+    
+    it('has no grounded connectivityNodes but has an XSWI logicalNode and DOI:SWTyp > DOType > DA:stVal defining an "Earthing Switch"', () => {
+      expect(
+        typeStr(
+          doc.querySelector('ConductingEquipment[name="ES269"]')!
+        )
+      ).to.equal('ERS');
+    });
+
+    it('has no grounded connectivityNodes but has an XSWI logicalNode within SubEquipment and DOI:SWTyp > DAI:stVal defining an "Earthing Switch"', () => {
+      expect(
+        typeStr(
+          doc.querySelector('ConductingEquipment[name="ES279"]')!
+        )
+      ).to.equal('ERS');
+    });
+
+  });
+});

--- a/test/unit/editors/substation/conductingequipmentwizard.test.ts
+++ b/test/unit/editors/substation/conductingequipmentwizard.test.ts
@@ -28,7 +28,7 @@ describe('conductingequipmentwizard', () => {
       ).to.equal('ERS');
     });
 
-    it('has no grounded connectivityNodes but has an XSWI logicalNode and DOI:SWTyp > DAI:stVal defining an "Earthing Switch"', () => {
+    it('has no grounded connectivityNodes but has an XSWI LN and DOI:SWTyp > DAI:stVal defining an "Earthing Switch"', () => {
       expect(
         typeStr(
           doc.querySelector('ConductingEquipment[name="ES259"]')!
@@ -36,7 +36,7 @@ describe('conductingequipmentwizard', () => {
       ).to.equal('ERS');
     });
     
-    it('has no grounded connectivityNodes but has an XSWI logicalNode and DOI:SWTyp > DOType > DA:stVal defining an "Earthing Switch"', () => {
+    it('has no grounded connectivityNodes but has an XSWI LN and DOI:SWTyp > DOType > DA:stVal defining an "Earthing Switch"', () => {
       expect(
         typeStr(
           doc.querySelector('ConductingEquipment[name="ES269"]')!
@@ -44,10 +44,18 @@ describe('conductingequipmentwizard', () => {
       ).to.equal('ERS');
     });
 
-    it('has no grounded connectivityNodes but has an XSWI logicalNode within SubEquipment and DOI:SWTyp > DAI:stVal defining an "Earthing Switch"', () => {
+    it('has no grounded connectivityNodes but has an XSWI LN within SubEquipment and DOI:SWTyp > DAI:stVal defining an "Earthing Switch"', () => {
       expect(
         typeStr(
           doc.querySelector('ConductingEquipment[name="ES279"]')!
+        )
+      ).to.equal('ERS');
+    });
+
+    it('has no grounded connectivityNodes but has an IED with name "None" and an XSWI LN with a prefix and DOI:SWTyp > DAI:stVal defining an "Earthing Switch"', () => {
+      expect(
+        typeStr(
+          doc.querySelector('ConductingEquipment[name="ES289"]')!
         )
       ).to.equal('ERS');
     });

--- a/test/unit/editors/substation/conductingequipmentwizard.test.ts
+++ b/test/unit/editors/substation/conductingequipmentwizard.test.ts
@@ -3,7 +3,6 @@ import { expect } from '@open-wc/testing';
 import { typeStr } from '../../../../src/wizards/conductingequipment.js';
 
 describe('conductingequipmentwizard', () => {
-
   describe('recognises an earth switch in the conducting equipment wizard that', () => {
     let doc: Document;
     beforeEach(async () => {
@@ -14,51 +13,38 @@ describe('conductingequipmentwizard', () => {
 
     it('has the first terminal grounded', () => {
       expect(
-        typeStr(
-          doc.querySelector('ConductingEquipment[name="ES239"]')!
-        )
+        typeStr(doc.querySelector('ConductingEquipment[name="ES239"]')!)
       ).to.equal('ERS');
     });
 
     it('has the second terminal grounded', () => {
       expect(
-        typeStr(
-          doc.querySelector('ConductingEquipment[name="ES249"]')!
-        )
+        typeStr(doc.querySelector('ConductingEquipment[name="ES249"]')!)
       ).to.equal('ERS');
     });
 
     it('has no grounded connectivityNodes but has an XSWI LN and DOI:SWTyp > DAI:stVal defining an "Earthing Switch"', () => {
       expect(
-        typeStr(
-          doc.querySelector('ConductingEquipment[name="ES259"]')!
-        )
+        typeStr(doc.querySelector('ConductingEquipment[name="ES259"]')!)
       ).to.equal('ERS');
     });
-    
-    it('has no grounded connectivityNodes but has an XSWI LN and DOI:SWTyp > DOType > DA:stVal defining an "Earthing Switch"', () => {
+
+    it('has no grounded connectivityNodes but has an XSWI LN and LNodeType > DOType > DA:stVal defining an "Earthing Switch"', () => {
       expect(
-        typeStr(
-          doc.querySelector('ConductingEquipment[name="ES269"]')!
-        )
+        typeStr(doc.querySelector('ConductingEquipment[name="ES269"]')!)
       ).to.equal('ERS');
     });
 
     it('has no grounded connectivityNodes but has an XSWI LN within SubEquipment and DOI:SWTyp > DAI:stVal defining an "Earthing Switch"', () => {
       expect(
-        typeStr(
-          doc.querySelector('ConductingEquipment[name="ES279"]')!
-        )
+        typeStr(doc.querySelector('ConductingEquipment[name="ES279"]')!)
       ).to.equal('ERS');
     });
 
-    it('has no grounded connectivityNodes but has an IED with name "None" and an XSWI LN with a prefix and DOI:SWTyp > DAI:stVal defining an "Earthing Switch"', () => {
+    it('has no grounded connectivityNodes but has an IED with name "None" and a definition in the DataTypeTemplates', () => {
       expect(
-        typeStr(
-          doc.querySelector('ConductingEquipment[name="ES289"]')!
-        )
+        typeStr(doc.querySelector('ConductingEquipment[name="ES289"]')!)
       ).to.equal('ERS');
     });
-
   });
 });


### PR DESCRIPTION
Closes #459 by providing an earth switch icon and using this in the various editors and wizards.

The logic for ESR detection shouldn't be in multiple places but it may be like this for a very good reason so I have not modified it.

In the SLD:

![image](https://user-images.githubusercontent.com/674783/147638528-78288fe5-f0bd-43cb-af85-3aa40f365601.png)

In the Substation Editor:

![image](https://user-images.githubusercontent.com/674783/147638620-fe3f8120-9e35-4f3d-81d0-660d8ec08162.png)

I'll be happy to take a review and make modifications.

I've tried to keep the icon square while retaining the stroke width but happy to take some feedback as to whether this is visually acceptable. Another option to introduce spacing might be to make the switch portion smaller or the earth symbol smaller.

