### PR TITLE
feat(foundation): allow danamic wiazrds

### DIFF
--- a/src/Wizarding.ts
+++ b/src/Wizarding.ts
@@ -3,8 +3,8 @@ import {
   ifImplemented,
   LitElementConstructor,
   Mixin,
-  Wizard,
   WizardEvent,
+  WizardFactory,
 } from './foundation.js';
 
 import './wizard-dialog.js';
@@ -18,13 +18,12 @@ export function Wizarding<TBase extends LitElementConstructor>(Base: TBase) {
   class WizardingElement extends Base {
     /** FIFO queue of [[`Wizard`]]s to display. */
     @internalProperty()
-    workflow: Wizard[] = [];
+    workflow: WizardFactory[] = [];
 
     @query('wizard-dialog') wizardUI!: WizardDialog;
 
     private onWizard(we: WizardEvent) {
       const wizard = we.detail.wizard;
-      if (wizard?.length === 0) return;
       if (wizard === null) this.workflow.shift();
       else if (we.detail.subwizard) this.workflow.unshift(wizard);
       else this.workflow.push(wizard);
@@ -49,7 +48,7 @@ export function Wizarding<TBase extends LitElementConstructor>(Base: TBase) {
 
     render(): TemplateResult {
       return html`${ifImplemented(super.render())}
-        <wizard-dialog .wizard=${this.workflow[0] ?? []}></wizard-dialog>`;
+        <wizard-dialog .wizard=${this.workflow[0]?.() ?? []}></wizard-dialog>`;
     }
   }
 

--- a/src/wizard-dialog.ts
+++ b/src/wizard-dialog.ts
@@ -25,7 +25,7 @@ import {
   newWizardEvent,
   WizardActor,
   wizardInputSelector,
-  isWizard,
+  isWizardFactory,
   checkValidity,
   reportValidity,
   Delete,
@@ -143,8 +143,8 @@ export class WizardDialog extends LitElement {
       this.dispatchEvent(newWizardEvent());
     }
     wizardActions.forEach(wa =>
-      isWizard(wa)
-        ? this.dispatchEvent(newWizardEvent(wa()))
+      isWizardFactory(wa)
+        ? this.dispatchEvent(newWizardEvent(wa))
         : this.dispatchEvent(newActionEvent(wa))
     );
     return true;

--- a/test/integration/editors/substation/guess-wizarding-editing.test.ts
+++ b/test/integration/editors/substation/guess-wizarding-editing.test.ts
@@ -16,7 +16,9 @@ describe('guess-wizard-integration', () => {
       .then(str => new DOMParser().parseFromString(str, 'application/xml'));
     validSCL.querySelector('Substation')!.innerHTML = '';
     element = <MockWizard>await fixture(html`<mock-wizard></mock-wizard>`);
-    element.workflow.push(guessVoltageLevel(validSCL));
+
+    const wizard = guessVoltageLevel(validSCL);
+    element.workflow.push(() => wizard);
     await element.requestUpdate();
   });
 
@@ -78,8 +80,11 @@ describe('guess-wizarding-editing-integration', () => {
     element = <MockWizardEditor>(
       await fixture(html`<mock-wizard-editor></mock-wizard-editor>`)
     );
-    element.workflow.push(guessVoltageLevel(validSCL));
+
+    const wizard = guessVoltageLevel(validSCL);
+    element.workflow.push(() => wizard);
     await element.requestUpdate();
+
     (<HTMLElement>(
       element.wizardUI.dialog!.querySelector(
         '#ctlModelList > mwc-check-list-item:nth-child(5)'

--- a/test/integration/editors/substation/lnodewizard.test.ts
+++ b/test/integration/editors/substation/lnodewizard.test.ts
@@ -21,7 +21,8 @@ describe('lnodewizard', () => {
     element = <MockWizardEditor>(
       await fixture(html`<mock-wizard-editor></mock-wizard-editor>`)
     );
-    element.workflow.push(lNodeWizard(doc.querySelector('Bay')!));
+    const wizard = lNodeWizard(doc.querySelector('Bay')!);
+    element.workflow.push(() => wizard);
     await element.requestUpdate();
   });
 

--- a/test/integration/wizards/dataset-wizarding-editing-integration.test.ts
+++ b/test/integration/wizards/dataset-wizarding-editing-integration.test.ts
@@ -25,7 +25,7 @@ describe('dataset wizards', () => {
       const wizard = editDataSetWizard(
         doc.querySelector('IED[name="IED2"] DataSet[name="GooseDataSet1"]')!
       );
-      element.workflow.push(wizard);
+      element.workflow.push(() => wizard);
       await element.requestUpdate();
       primaryAction = <HTMLElement>(
         element.wizardUI.dialog?.querySelector(

--- a/test/integration/wizards/fcda-wizarding-editing-integration.test.ts
+++ b/test/integration/wizards/fcda-wizarding-editing-integration.test.ts
@@ -19,7 +19,7 @@ describe('FCDA editing wizarding integration', () => {
       .then(str => new DOMParser().parseFromString(str, 'application/xml'));
 
     const wizard = createFCDAsWizard(doc.querySelector('DataSet')!);
-    element.workflow.push(wizard!);
+    element.workflow.push(() => wizard!);
     await element.requestUpdate();
 
     finder = element.wizardUI.dialog!.querySelector<FinderList>('finder-list')!;

--- a/test/integration/wizards/gse-wizarding-editing-integration.test.ts
+++ b/test/integration/wizards/gse-wizarding-editing-integration.test.ts
@@ -25,7 +25,7 @@ describe('gse wizarding editing integration', () => {
       const wizard = editGseWizard(
         doc.querySelector('GSE[ldInst="CircuitBreaker_CB1"][cbName="GCB"]')!
       );
-      element.workflow.push(wizard);
+      element.workflow.push(() => wizard);
       await element.requestUpdate();
       primaryAction = <HTMLElement>(
         element.wizardUI.dialog?.querySelector(

--- a/test/integration/wizards/gsecontrolwizarding-editing.test.ts
+++ b/test/integration/wizards/gsecontrolwizarding-editing.test.ts
@@ -29,7 +29,7 @@ describe('gsecontrol wizarding editing integration', () => {
 
     beforeEach(async () => {
       const wizard = selectGseControlWizard(doc.documentElement);
-      element.workflow.push(wizard);
+      element.workflow.push(() => wizard);
       await element.requestUpdate();
       gseControlList = <FilteredList>(
         element.wizardUI.dialog?.querySelector('filtered-list')
@@ -66,7 +66,7 @@ describe('gsecontrol wizarding editing integration', () => {
       beforeEach(async () => {
         gseControl = doc.querySelector('GSEControl[name="GCB"]')!;
         const wizard = editGseControlWizard(gseControl);
-        element.workflow.push(wizard);
+        element.workflow.push(() => wizard);
         await element.requestUpdate();
         nameField = element.wizardUI.dialog!.querySelector(
           'wizard-textfield[label="name"]'
@@ -157,7 +157,7 @@ describe('gsecontrol wizarding editing integration', () => {
       beforeEach(async () => {
         gseControl = doc.querySelector('GSEControl[name="GCB2"]')!;
         const wizard = editGseControlWizard(gseControl);
-        element.workflow.push(wizard);
+        element.workflow.push(() => wizard);
         await element.requestUpdate();
       });
 
@@ -177,7 +177,7 @@ describe('gsecontrol wizarding editing integration', () => {
           'IED[name="IED2"] GSEControl[name="GCB"]'
         )!;
         const wizard = editGseControlWizard(gseControl);
-        element.workflow.push(wizard);
+        element.workflow.push(() => wizard);
         await element.requestUpdate();
       });
 

--- a/test/unit/Wizarding.test.ts
+++ b/test/unit/Wizarding.test.ts
@@ -19,23 +19,23 @@ describe('WizardingElement', () => {
   it('shows no wizard-dialog', async () =>
     await expect(element).shadowDom.to.be.empty);
 
-  it('adds a wizard to the workflow on non-null WizardEvent', () => {
+  it('adds a wizard factory to the workflow on non-null WizardEvent', () => {
     element.dispatchEvent(newWizardEvent([{ title: 'Test Page 1' }]));
     expect(element).property('workflow').to.have.lengthOf(1);
   });
 
-  describe('with a wizard in its workflow', () => {
+  describe('with a wizard factory in its workflow', () => {
     beforeEach(async () => {
       element.dispatchEvent(newWizardEvent([{ title: 'Test Page 1' }]));
       await element.updateComplete;
     });
 
-    it('removes the wizard on receiving a null WizardEvent', () => {
+    it('removes the wizard factory on receiving a null WizardEvent', () => {
       element.dispatchEvent(newWizardEvent());
       expect(element).property('workflow').to.be.empty;
     });
 
-    it('removes the wizard on wizard-dialog "close" action', async () => {
+    it('removes the wizard factory on wizard-dialog "close" action', async () => {
       await (<HTMLElement>(
         element
           .shadowRoot!.querySelector('wizard-dialog')!

--- a/test/unit/editors/communication/conductingap-editor.test.ts
+++ b/test/unit/editors/communication/conductingap-editor.test.ts
@@ -52,7 +52,7 @@ describe('A component to visualize SCL element ConnectedAP', () => {
     await element.requestUpdate();
 
     expect(wizardEvent).to.have.be.calledOnce;
-    expect(wizardEvent.args[0][0].detail.wizard[0].title).to.contain('edit');
+    expect(wizardEvent.args[0][0].detail.wizard()[0].title).to.contain('edit');
   });
 
   it('triggers remove action on action button click', async () => {

--- a/test/unit/editors/singlelinediagram/wizards/bay.test.ts
+++ b/test/unit/editors/singlelinediagram/wizards/bay.test.ts
@@ -1,18 +1,18 @@
-import {expect, fixture, html} from '@open-wc/testing';
+import { expect, fixture, html } from '@open-wc/testing';
 
 import '../../../../mock-wizard.js';
-import {MockWizard} from '../../../../mock-wizard.js';
+import { MockWizard } from '../../../../mock-wizard.js';
 import {
   executeWizardUpdateAction,
   expectWizardNoUpdateAction,
   fetchDoc,
-  setWizardTextFieldValue
-} from "../../../wizards/foundation.js";
+  setWizardTextFieldValue,
+} from '../../../wizards/foundation.js';
 
-import {WizardTextField} from "../../../../../src/wizard-textfield.js";
-import {WizardInput} from "../../../../../src/foundation.js";
-import {editBayWizard} from "../../../../../src/editors/singlelinediagram/wizards/bay.js";
-import {updateNamingAndCoordinatesAction} from "../../../../../src/editors/singlelinediagram/wizards/foundation.js";
+import { WizardTextField } from '../../../../../src/wizard-textfield.js';
+import { WizardInput } from '../../../../../src/foundation.js';
+import { editBayWizard } from '../../../../../src/editors/singlelinediagram/wizards/bay.js';
+import { updateNamingAndCoordinatesAction } from '../../../../../src/editors/singlelinediagram/wizards/foundation.js';
 
 describe('Wizards for SCL element Bay (X/Y)', () => {
   let doc: XMLDocument;
@@ -26,7 +26,7 @@ describe('Wizards for SCL element Bay (X/Y)', () => {
 
     element = await fixture(html`<mock-wizard></mock-wizard>`);
     const wizard = editBayWizard(bay);
-    element.workflow.push(wizard);
+    element.workflow.push(() => wizard);
     await element.requestUpdate();
     inputs = Array.from(element.wizardUI.inputs);
   });
@@ -34,23 +34,38 @@ describe('Wizards for SCL element Bay (X/Y)', () => {
   it('update name should be updated in document', async function () {
     await setWizardTextFieldValue(<WizardTextField>inputs[0], 'OtherBusBar A');
 
-    const updateAction = executeWizardUpdateAction(updateNamingAndCoordinatesAction(bay), inputs);
+    const updateAction = executeWizardUpdateAction(
+      updateNamingAndCoordinatesAction(bay),
+      inputs
+    );
     expect(updateAction.old.element).to.have.attribute('name', 'BusBar A');
     expect(updateAction.new.element).to.have.attribute('name', 'OtherBusBar A');
   });
 
   it('update description should be updated in document', async function () {
-    await setWizardTextFieldValue(<WizardTextField>inputs[1], 'Some description');
+    await setWizardTextFieldValue(
+      <WizardTextField>inputs[1],
+      'Some description'
+    );
 
-    const updateAction = executeWizardUpdateAction(updateNamingAndCoordinatesAction(bay), inputs);
+    const updateAction = executeWizardUpdateAction(
+      updateNamingAndCoordinatesAction(bay),
+      inputs
+    );
     expect(updateAction.old.element).to.not.have.attribute('desc');
-    expect(updateAction.new.element).to.have.attribute('desc', 'Some description');
+    expect(updateAction.new.element).to.have.attribute(
+      'desc',
+      'Some description'
+    );
   });
 
   it('update X-Coordinate should be updated in document', async function () {
     await setWizardTextFieldValue(<WizardTextField>inputs[2], '4');
 
-    const updateAction = executeWizardUpdateAction(updateNamingAndCoordinatesAction(bay), inputs);
+    const updateAction = executeWizardUpdateAction(
+      updateNamingAndCoordinatesAction(bay),
+      inputs
+    );
     expect(updateAction.old.element).to.have.attribute('sxy:x', '1');
     expect(updateAction.new.element).to.have.attribute('sxy:x', '4');
   });
@@ -58,7 +73,10 @@ describe('Wizards for SCL element Bay (X/Y)', () => {
   it('update Y-Coordinate should be updated in document', async function () {
     await setWizardTextFieldValue(<WizardTextField>inputs[3], '5');
 
-    const updateAction = executeWizardUpdateAction(updateNamingAndCoordinatesAction(bay), inputs);
+    const updateAction = executeWizardUpdateAction(
+      updateNamingAndCoordinatesAction(bay),
+      inputs
+    );
     expect(updateAction.old.element).to.have.attribute('sxy:y', '1');
     expect(updateAction.new.element).to.have.attribute('sxy:y', '5');
   });
@@ -66,7 +84,10 @@ describe('Wizards for SCL element Bay (X/Y)', () => {
   it('clear Y-Coordinate should be updated in document', async function () {
     await setWizardTextFieldValue(<WizardTextField>inputs[3], null);
 
-    const updateAction = executeWizardUpdateAction(updateNamingAndCoordinatesAction(bay), inputs);
+    const updateAction = executeWizardUpdateAction(
+      updateNamingAndCoordinatesAction(bay),
+      inputs
+    );
     expect(updateAction.old.element).to.have.attribute('sxy:y', '1');
     expect(updateAction.new.element).to.not.have.attribute('sxy:y');
   });

--- a/test/unit/editors/singlelinediagram/wizards/conductingequipment.test.ts
+++ b/test/unit/editors/singlelinediagram/wizards/conductingequipment.test.ts
@@ -1,18 +1,18 @@
-import {expect, fixture, html} from '@open-wc/testing';
+import { expect, fixture, html } from '@open-wc/testing';
 
 import '../../../../mock-wizard.js';
-import {MockWizard} from '../../../../mock-wizard.js';
+import { MockWizard } from '../../../../mock-wizard.js';
 import {
   executeWizardUpdateAction,
   expectWizardNoUpdateAction,
   fetchDoc,
-  setWizardTextFieldValue
-} from "../../../wizards/foundation.js";
+  setWizardTextFieldValue,
+} from '../../../wizards/foundation.js';
 
-import {WizardTextField} from "../../../../../src/wizard-textfield.js";
-import {WizardInput} from "../../../../../src/foundation.js";
-import {editConductingEquipmentWizard} from "../../../../../src/editors/singlelinediagram/wizards/conductingequipment.js";
-import {updateNamingAndCoordinatesAction} from "../../../../../src/editors/singlelinediagram/wizards/foundation.js";
+import { WizardTextField } from '../../../../../src/wizard-textfield.js';
+import { WizardInput } from '../../../../../src/foundation.js';
+import { editConductingEquipmentWizard } from '../../../../../src/editors/singlelinediagram/wizards/conductingequipment.js';
+import { updateNamingAndCoordinatesAction } from '../../../../../src/editors/singlelinediagram/wizards/foundation.js';
 
 describe('Wizards for SCL element Conducting Equipment (X/Y)', () => {
   let doc: XMLDocument;
@@ -26,7 +26,7 @@ describe('Wizards for SCL element Conducting Equipment (X/Y)', () => {
 
     element = await fixture(html`<mock-wizard></mock-wizard>`);
     const wizard = editConductingEquipmentWizard(conductingEquipment);
-    element.workflow.push(wizard);
+    element.workflow.push(() => wizard);
     await element.requestUpdate();
     inputs = Array.from(element.wizardUI.inputs);
   });
@@ -34,23 +34,38 @@ describe('Wizards for SCL element Conducting Equipment (X/Y)', () => {
   it('update name should be updated in document', async function () {
     await setWizardTextFieldValue(<WizardTextField>inputs[1], 'OtherQB1');
 
-    const updateAction = executeWizardUpdateAction(updateNamingAndCoordinatesAction(conductingEquipment), inputs);
+    const updateAction = executeWizardUpdateAction(
+      updateNamingAndCoordinatesAction(conductingEquipment),
+      inputs
+    );
     expect(updateAction.old.element).to.have.attribute('name', 'QB1');
     expect(updateAction.new.element).to.have.attribute('name', 'OtherQB1');
   });
 
   it('update description should be updated in document', async function () {
-    await setWizardTextFieldValue(<WizardTextField>inputs[2], 'Some description');
+    await setWizardTextFieldValue(
+      <WizardTextField>inputs[2],
+      'Some description'
+    );
 
-    const updateAction = executeWizardUpdateAction(updateNamingAndCoordinatesAction(conductingEquipment), inputs);
+    const updateAction = executeWizardUpdateAction(
+      updateNamingAndCoordinatesAction(conductingEquipment),
+      inputs
+    );
     expect(updateAction.old.element).to.not.have.attribute('desc');
-    expect(updateAction.new.element).to.have.attribute('desc', 'Some description');
+    expect(updateAction.new.element).to.have.attribute(
+      'desc',
+      'Some description'
+    );
   });
 
   it('update X-Coordinate should be updated in document', async function () {
     await setWizardTextFieldValue(<WizardTextField>inputs[3], '4');
 
-    const updateAction = executeWizardUpdateAction(updateNamingAndCoordinatesAction(conductingEquipment), inputs);
+    const updateAction = executeWizardUpdateAction(
+      updateNamingAndCoordinatesAction(conductingEquipment),
+      inputs
+    );
     expect(updateAction.old.element).to.have.attribute('sxy:x', '1');
     expect(updateAction.new.element).to.have.attribute('sxy:x', '4');
   });
@@ -58,7 +73,10 @@ describe('Wizards for SCL element Conducting Equipment (X/Y)', () => {
   it('update Y-Coordinate should be updated in document', async function () {
     await setWizardTextFieldValue(<WizardTextField>inputs[4], '5');
 
-    const updateAction = executeWizardUpdateAction(updateNamingAndCoordinatesAction(conductingEquipment), inputs);
+    const updateAction = executeWizardUpdateAction(
+      updateNamingAndCoordinatesAction(conductingEquipment),
+      inputs
+    );
     expect(updateAction.old.element).to.have.attribute('sxy:y', '1');
     expect(updateAction.new.element).to.have.attribute('sxy:y', '5');
   });
@@ -66,13 +84,19 @@ describe('Wizards for SCL element Conducting Equipment (X/Y)', () => {
   it('clear Y-Coordinate should be updated in document', async function () {
     await setWizardTextFieldValue(<WizardTextField>inputs[4], null);
 
-    const updateAction = executeWizardUpdateAction(updateNamingAndCoordinatesAction(conductingEquipment), inputs);
+    const updateAction = executeWizardUpdateAction(
+      updateNamingAndCoordinatesAction(conductingEquipment),
+      inputs
+    );
     expect(updateAction.old.element).to.have.attribute('sxy:y', '1');
     expect(updateAction.new.element).to.not.have.attribute('sxy:y');
   });
 
   it('when no fields changed there will be no update action', async function () {
-    expectWizardNoUpdateAction(updateNamingAndCoordinatesAction(conductingEquipment), inputs);
+    expectWizardNoUpdateAction(
+      updateNamingAndCoordinatesAction(conductingEquipment),
+      inputs
+    );
   });
 
   it('looks like the latest snapshot', async () => {

--- a/test/unit/editors/singlelinediagram/wizards/powertransformer.test.ts
+++ b/test/unit/editors/singlelinediagram/wizards/powertransformer.test.ts
@@ -1,18 +1,18 @@
-import {expect, fixture, html} from '@open-wc/testing';
+import { expect, fixture, html } from '@open-wc/testing';
 
 import '../../../../mock-wizard.js';
-import {MockWizard} from '../../../../mock-wizard.js';
+import { MockWizard } from '../../../../mock-wizard.js';
 import {
   executeWizardUpdateAction,
   expectWizardNoUpdateAction,
   fetchDoc,
-  setWizardTextFieldValue
-} from "../../../wizards/foundation.js";
+  setWizardTextFieldValue,
+} from '../../../wizards/foundation.js';
 
-import {WizardTextField} from "../../../../../src/wizard-textfield.js";
-import {WizardInput} from "../../../../../src/foundation.js";
-import {editPowerTransformerWizard} from "../../../../../src/editors/singlelinediagram/wizards/powertransformer.js";
-import {updateNamingAndCoordinatesAction} from "../../../../../src/editors/singlelinediagram/wizards/foundation.js";
+import { WizardTextField } from '../../../../../src/wizard-textfield.js';
+import { WizardInput } from '../../../../../src/foundation.js';
+import { editPowerTransformerWizard } from '../../../../../src/editors/singlelinediagram/wizards/powertransformer.js';
+import { updateNamingAndCoordinatesAction } from '../../../../../src/editors/singlelinediagram/wizards/foundation.js';
 
 describe('Wizards for SCL element Power Transformer (X/Y)', () => {
   let doc: XMLDocument;
@@ -26,7 +26,7 @@ describe('Wizards for SCL element Power Transformer (X/Y)', () => {
 
     element = await fixture(html`<mock-wizard></mock-wizard>`);
     const wizard = editPowerTransformerWizard(powerTransformer);
-    element.workflow.push(wizard);
+    element.workflow.push(() => wizard);
     await element.requestUpdate();
     inputs = Array.from(element.wizardUI.inputs);
   });
@@ -34,23 +34,38 @@ describe('Wizards for SCL element Power Transformer (X/Y)', () => {
   it('update name should be updated in document', async function () {
     await setWizardTextFieldValue(<WizardTextField>inputs[0], 'OtherTA1');
 
-    const updateAction = executeWizardUpdateAction(updateNamingAndCoordinatesAction(powerTransformer), inputs);
+    const updateAction = executeWizardUpdateAction(
+      updateNamingAndCoordinatesAction(powerTransformer),
+      inputs
+    );
     expect(updateAction.old.element).to.have.attribute('name', 'TA1');
     expect(updateAction.new.element).to.have.attribute('name', 'OtherTA1');
   });
 
   it('update description should be updated in document', async function () {
-    await setWizardTextFieldValue(<WizardTextField>inputs[1], 'Some description');
+    await setWizardTextFieldValue(
+      <WizardTextField>inputs[1],
+      'Some description'
+    );
 
-    const updateAction = executeWizardUpdateAction(updateNamingAndCoordinatesAction(powerTransformer), inputs);
+    const updateAction = executeWizardUpdateAction(
+      updateNamingAndCoordinatesAction(powerTransformer),
+      inputs
+    );
     expect(updateAction.old.element).to.not.have.attribute('desc');
-    expect(updateAction.new.element).to.have.attribute('desc', 'Some description');
+    expect(updateAction.new.element).to.have.attribute(
+      'desc',
+      'Some description'
+    );
   });
 
   it('update X-Coordinate should be updated in document', async function () {
     await setWizardTextFieldValue(<WizardTextField>inputs[2], '4');
 
-    const updateAction = executeWizardUpdateAction(updateNamingAndCoordinatesAction(powerTransformer), inputs);
+    const updateAction = executeWizardUpdateAction(
+      updateNamingAndCoordinatesAction(powerTransformer),
+      inputs
+    );
     expect(updateAction.old.element).to.have.attribute('sxy:x', '1');
     expect(updateAction.new.element).to.have.attribute('sxy:x', '4');
   });
@@ -58,7 +73,10 @@ describe('Wizards for SCL element Power Transformer (X/Y)', () => {
   it('update Y-Coordinate should be updated in document', async function () {
     await setWizardTextFieldValue(<WizardTextField>inputs[3], '5');
 
-    const updateAction = executeWizardUpdateAction(updateNamingAndCoordinatesAction(powerTransformer), inputs);
+    const updateAction = executeWizardUpdateAction(
+      updateNamingAndCoordinatesAction(powerTransformer),
+      inputs
+    );
     expect(updateAction.old.element).to.have.attribute('sxy:y', '9');
     expect(updateAction.new.element).to.have.attribute('sxy:y', '5');
   });
@@ -66,13 +84,19 @@ describe('Wizards for SCL element Power Transformer (X/Y)', () => {
   it('clear Y-Coordinate should be updated in document', async function () {
     await setWizardTextFieldValue(<WizardTextField>inputs[3], null);
 
-    const updateAction = executeWizardUpdateAction(updateNamingAndCoordinatesAction(powerTransformer), inputs);
+    const updateAction = executeWizardUpdateAction(
+      updateNamingAndCoordinatesAction(powerTransformer),
+      inputs
+    );
     expect(updateAction.old.element).to.have.attribute('sxy:y', '9');
     expect(updateAction.new.element).to.not.have.attribute('sxy:y');
   });
 
   it('when no fields changed there will be no update action', async function () {
-    expectWizardNoUpdateAction(updateNamingAndCoordinatesAction(powerTransformer), inputs);
+    expectWizardNoUpdateAction(
+      updateNamingAndCoordinatesAction(powerTransformer),
+      inputs
+    );
   });
 
   it('looks like the latest snapshot', async () => {

--- a/test/unit/editors/templates/lnodetype-wizard.test.ts
+++ b/test/unit/editors/templates/lnodetype-wizard.test.ts
@@ -27,7 +27,7 @@ describe('wizards for LNodeType element', () => {
         <string>identity(doc.querySelector('LNodeType')),
         doc
       )!;
-      element.workflow.push(wizard);
+      element.workflow.push(() => wizard);
       await element.requestUpdate();
 
       inputs = Array.from(element.wizardUI.inputs);

--- a/test/unit/foundation.test.ts
+++ b/test/unit/foundation.test.ts
@@ -149,12 +149,19 @@ describe('foundation', () => {
   });
 
   describe('WizardEvent', () => {
-    it('optionally bears a wizard in its detail', () => {
+    it('optionally bears a wizard factory in its detail', () => {
       expect(newWizardEvent()).property('detail').property('wizard').to.be.null;
       expect(newWizardEvent([]))
         .property('detail')
         .property('wizard')
-        .to.be.an('array').and.to.be.empty;
+        .to.be.a('function');
+    });
+
+    it('allows to dispatch dynamic wizards', () => {
+      expect(newWizardEvent(() => []))
+        .property('detail')
+        .property('wizard')
+        .to.be.a('function');
     });
   });
 

--- a/test/unit/wizards/abstractda.test.ts
+++ b/test/unit/wizards/abstractda.test.ts
@@ -98,7 +98,7 @@ describe('abstractda wizards', () => {
           ),
         },
       ];
-      element.workflow.push(wizard);
+      element.workflow.push(() => wizard);
       await element.requestUpdate();
       nameTextField = element.wizardUI.dialog!.querySelector<WizardTextField>(
         'wizard-textfield[label="name"]'

--- a/test/unit/wizards/address.test.ts
+++ b/test/unit/wizards/address.test.ts
@@ -36,7 +36,7 @@ describe('address', () => {
       )!;
       const wizard = [{ title: 'title', content: renderGseSmvAddress(gse) }];
 
-      element.workflow.push(wizard);
+      element.workflow.push(() => wizard);
       await element.requestUpdate();
     });
     it('looks like the latest snapshot', async () => {
@@ -61,7 +61,7 @@ describe('address', () => {
             content: renderGseSmvAddress(gse),
           },
         ];
-        element.workflow.push(wizard);
+        element.workflow.push(() => wizard);
         await element.requestUpdate();
         inputs = Array.from(element.wizardUI.inputs);
         await element.requestUpdate();
@@ -144,7 +144,7 @@ describe('address', () => {
             content: renderGseSmvAddress(gse),
           },
         ];
-        element.workflow.push(wizard);
+        element.workflow.push(() => wizard);
         await element.requestUpdate();
         inputs = Array.from(element.wizardUI.inputs);
         await element.requestUpdate();

--- a/test/unit/wizards/bda.test.ts
+++ b/test/unit/wizards/bda.test.ts
@@ -65,7 +65,7 @@ describe('bda wizards', () => {
           ),
         },
       ];
-      element.workflow.push(wizard);
+      element.workflow.push(() => wizard);
       await element.requestUpdate();
       inputs = Array.from(element.wizardUI.inputs);
       await element.requestUpdate();
@@ -211,7 +211,7 @@ describe('bda wizards', () => {
           ),
         },
       ];
-      element.workflow.push(wizard);
+      element.workflow.push(() => wizard);
       await element.requestUpdate();
       inputs = Array.from(element.wizardUI.inputs);
       await element.requestUpdate();

--- a/test/unit/wizards/connectedap-pattern.test.ts
+++ b/test/unit/wizards/connectedap-pattern.test.ts
@@ -35,7 +35,7 @@ describe('Edit wizard for SCL element ConnectedAP', () => {
           .then(str => new DOMParser().parseFromString(str, 'application/xml'));
 
         const wizard = editConnectedApWizard(doc.querySelector('ConnectedAP')!);
-        element.workflow.push(wizard);
+        element.workflow.push(() => wizard);
         await element.requestUpdate();
 
         inputs = Array.from(element.wizardUI.inputs);
@@ -419,7 +419,7 @@ describe('Edit wizard for SCL element ConnectedAP', () => {
           .then(str => new DOMParser().parseFromString(str, 'application/xml'));
 
         const wizard = editConnectedApWizard(doc.querySelector('ConnectedAP')!);
-        element.workflow.push(wizard);
+        element.workflow.push(() => wizard);
         await element.requestUpdate();
 
         inputs = Array.from(element.wizardUI.inputs);
@@ -617,7 +617,7 @@ describe('Edit wizard for SCL element ConnectedAP', () => {
           .then(str => new DOMParser().parseFromString(str, 'application/xml'));
 
         const wizard = editConnectedApWizard(doc.querySelector('ConnectedAP')!);
-        element.workflow.push(wizard);
+        element.workflow.push(() => wizard);
         await element.requestUpdate();
 
         inputs = Array.from(element.wizardUI.inputs);

--- a/test/unit/wizards/connectedap.test.ts
+++ b/test/unit/wizards/connectedap.test.ts
@@ -45,7 +45,7 @@ describe('Wizards for SCL element ConnectedAP', () => {
         .then(str => new DOMParser().parseFromString(str, 'application/xml'));
 
       const wizard = editConnectedApWizard(doc.querySelector('ConnectedAP')!);
-      element.workflow.push(wizard);
+      element.workflow.push(() => wizard);
       await element.requestUpdate();
 
       inputs = Array.from(element.wizardUI.inputs);
@@ -166,7 +166,7 @@ describe('Wizards for SCL element ConnectedAP', () => {
         .then(str => new DOMParser().parseFromString(str, 'application/xml'));
 
       const wizard = createConnectedApWizard(doc.querySelector('ConnectedAP')!);
-      element.workflow.push(wizard);
+      element.workflow.push(() => wizard);
       await element.requestUpdate();
 
       inputs = Array.from(element.wizardUI.inputs);

--- a/test/unit/wizards/connectivitynode.test.ts
+++ b/test/unit/wizards/connectivitynode.test.ts
@@ -18,7 +18,7 @@ describe('Wizards for SCL element ConnectivityNode', () => {
     const wizard = editConnectivityNodeWizard(
       doc.querySelector('ConnectivityNode')!
     );
-    element.workflow.push(wizard);
+    element.workflow.push(() => wizard);
     await element.requestUpdate();
   });
   it('looks like the latest snapshot', async () => {

--- a/test/unit/wizards/da.test.ts
+++ b/test/unit/wizards/da.test.ts
@@ -72,7 +72,7 @@ describe('da wizards', () => {
           ],
         },
       ];
-      element.workflow.push(wizard);
+      element.workflow.push(() => wizard);
       await element.requestUpdate();
       inputs = Array.from(element.wizardUI.inputs);
       await element.requestUpdate();
@@ -272,7 +272,7 @@ describe('da wizards', () => {
           ],
         },
       ];
-      element.workflow.push(wizard);
+      element.workflow.push(() => wizard);
       await element.requestUpdate();
       inputs = Array.from(element.wizardUI.inputs);
       await element.requestUpdate();

--- a/test/unit/wizards/dataset.test.ts
+++ b/test/unit/wizards/dataset.test.ts
@@ -33,7 +33,7 @@ describe('dataset wizards', () => {
       const wizard = editDataSetWizard(
         doc.querySelector('IED[name="IED2"] DataSet[name="GooseDataSet1"]')!
       );
-      element.workflow.push(wizard);
+      element.workflow.push(() => wizard);
       await element.requestUpdate();
 
       wizardEvent = sinon.spy();
@@ -68,7 +68,7 @@ describe('dataset wizards', () => {
         );
         wizard = editDataSetWizard(dataSet);
         element.workflow.length = 0;
-        element.workflow.push(wizard);
+        element.workflow.push(() => wizard);
         await element.requestUpdate();
         inputs = Array.from(element.wizardUI.inputs);
         await element.requestUpdate();
@@ -121,7 +121,7 @@ describe('dataset wizards', () => {
         )!;
         wizard = editDataSetWizard(dataSet);
         element.workflow.length = 0;
-        element.workflow.push(wizard);
+        element.workflow.push(() => wizard);
         await element.requestUpdate();
         inputs = Array.from(element.wizardUI.inputs);
         await element.requestUpdate();

--- a/test/unit/wizards/fcda.test.ts
+++ b/test/unit/wizards/fcda.test.ts
@@ -28,7 +28,7 @@ describe('create wizard for FCDA element', () => {
   describe('with a valid SCL file', () => {
     beforeEach(async () => {
       const wizard = createFCDAsWizard(doc.querySelector('DataSet')!);
-      element.workflow.push(wizard!);
+      element.workflow.push(() => wizard!);
       await element.requestUpdate();
       finder =
         element.wizardUI.dialog!.querySelector<FinderList>('finder-list')!;

--- a/test/unit/wizards/gse.test.ts
+++ b/test/unit/wizards/gse.test.ts
@@ -38,7 +38,7 @@ describe('gse wizards', () => {
       const wizard = editGseWizard(
         doc.querySelector('GSE[ldInst="CircuitBreaker_CB1"][cbName="GCB"]')!
       );
-      element.workflow.push(wizard);
+      element.workflow.push(() => wizard);
       await element.requestUpdate();
     });
     it('looks like the latest snapshot', async () => {
@@ -67,7 +67,7 @@ describe('gse wizards', () => {
       wizard = editGseWizard(
         doc.querySelector('GSE[ldInst="CircuitBreaker_CB1"][cbName="GCB"]')!
       );
-      element.workflow.push(wizard);
+      element.workflow.push(() => wizard);
       await element.requestUpdate();
       inputs = Array.from(element.wizardUI.inputs);
       await element.requestUpdate();

--- a/test/unit/wizards/gsecontrol.test.ts
+++ b/test/unit/wizards/gsecontrol.test.ts
@@ -35,7 +35,7 @@ describe('gsecontrol wizards', () => {
   describe('selectGseControlWizard', () => {
     beforeEach(async () => {
       const wizard = selectGseControlWizard(doc.documentElement);
-      element.workflow.push(wizard);
+      element.workflow.push(() => wizard);
       await element.requestUpdate();
     });
     it('looks like the latest snapshot', async () => {
@@ -60,7 +60,7 @@ describe('gsecontrol wizards', () => {
           ),
         },
       ];
-      element.workflow.push(wizard);
+      element.workflow.push(() => wizard);
       await element.requestUpdate();
       nameTextField = element.wizardUI.dialog!.querySelector<WizardTextField>(
         'wizard-textfield[label="name"]'
@@ -93,7 +93,7 @@ describe('gsecontrol wizards', () => {
   describe('editGseControlWizard', () => {
     beforeEach(async () => {
       const wizard = editGseControlWizard(doc.querySelector('GSEControl')!);
-      element.workflow.push(wizard);
+      element.workflow.push(() => wizard);
       await element.requestUpdate();
     });
     it('looks like the latest snapshot', async () => {
@@ -219,7 +219,7 @@ describe('gsecontrol wizards', () => {
           ),
         },
       ];
-      element.workflow.push(wizard);
+      element.workflow.push(() => wizard);
       await element.requestUpdate();
       inputs = Array.from(element.wizardUI.inputs);
       await element.requestUpdate();

--- a/test/unit/wizards/powertransformer.test.ts
+++ b/test/unit/wizards/powertransformer.test.ts
@@ -1,19 +1,19 @@
-import {expect, fixture, html} from '@open-wc/testing';
+import { expect, fixture, html } from '@open-wc/testing';
 
 import '../../mock-wizard.js';
-import {MockWizard} from '../../mock-wizard.js';
+import { MockWizard } from '../../mock-wizard.js';
 
-import {WizardTextField} from "../../../src/wizard-textfield.js";
-import {WizardInput} from "../../../src/foundation.js";
-import {editPowerTransformerWizard} from "../../../src/wizards/powertransformer.js";
-import {updateNamingAction} from "../../../src/wizards/foundation/actions.js";
+import { WizardTextField } from '../../../src/wizard-textfield.js';
+import { WizardInput } from '../../../src/foundation.js';
+import { editPowerTransformerWizard } from '../../../src/wizards/powertransformer.js';
+import { updateNamingAction } from '../../../src/wizards/foundation/actions.js';
 
 import {
   executeWizardUpdateAction,
   expectWizardNoUpdateAction,
   fetchDoc,
-  setWizardTextFieldValue
-} from "./foundation.js";
+  setWizardTextFieldValue,
+} from './foundation.js';
 
 describe('Wizards for SCL element Power Transformer', () => {
   let doc: XMLDocument;
@@ -27,7 +27,7 @@ describe('Wizards for SCL element Power Transformer', () => {
 
     element = await fixture(html`<mock-wizard></mock-wizard>`);
     const wizard = editPowerTransformerWizard(powerTransformer);
-    element.workflow.push(wizard);
+    element.workflow.push(() => wizard);
     await element.requestUpdate();
     inputs = Array.from(element.wizardUI.inputs);
   });
@@ -35,17 +35,29 @@ describe('Wizards for SCL element Power Transformer', () => {
   it('update name should be updated in document', async function () {
     await setWizardTextFieldValue(<WizardTextField>inputs[0], 'OtherTA1');
 
-    const updateAction = executeWizardUpdateAction(updateNamingAction(powerTransformer), inputs);
+    const updateAction = executeWizardUpdateAction(
+      updateNamingAction(powerTransformer),
+      inputs
+    );
     expect(updateAction.old.element).to.have.attribute('name', 'TA1');
     expect(updateAction.new.element).to.have.attribute('name', 'OtherTA1');
   });
 
   it('update description should be updated in document', async function () {
-    await setWizardTextFieldValue(<WizardTextField>inputs[1], 'Some description');
+    await setWizardTextFieldValue(
+      <WizardTextField>inputs[1],
+      'Some description'
+    );
 
-    const updateAction = executeWizardUpdateAction(updateNamingAction(powerTransformer), inputs);
+    const updateAction = executeWizardUpdateAction(
+      updateNamingAction(powerTransformer),
+      inputs
+    );
     expect(updateAction.old.element).to.not.have.attribute('desc');
-    expect(updateAction.new.element).to.have.attribute('desc', 'Some description');
+    expect(updateAction.new.element).to.have.attribute(
+      'desc',
+      'Some description'
+    );
   });
 
   it('when no fields changed there will be no update action', async function () {

--- a/test/unit/wizards/terminal.test.ts
+++ b/test/unit/wizards/terminal.test.ts
@@ -16,7 +16,7 @@ describe('Wizards for SCL element Terminal', () => {
       .then(str => new DOMParser().parseFromString(str, 'application/xml'));
 
     const wizard = editTerminalWizard(doc.querySelector('Terminal')!);
-    element.workflow.push(wizard);
+    element.workflow.push(() => wizard);
     await element.requestUpdate();
   });
   it('looks like the latest snapshot', async () => {

--- a/test/unit/zeroline/conducting-equipment-editor.test.ts
+++ b/test/unit/zeroline/conducting-equipment-editor.test.ts
@@ -51,7 +51,7 @@ describe('conducting-equipment-editor', () => {
     await element.requestUpdate();
 
     expect(wizardEvent).to.have.be.calledOnce;
-    expect(wizardEvent.args[0][0].detail.wizard[0].title).to.contain('lnode');
+    expect(wizardEvent.args[0][0].detail.wizard()[0].title).to.contain('lnode');
   });
 
   it('triggers edit wizard for ConductingEquipment element on action button click', async () => {
@@ -62,7 +62,7 @@ describe('conducting-equipment-editor', () => {
     await element.requestUpdate();
 
     expect(wizardEvent).to.have.be.calledOnce;
-    expect(wizardEvent.args[0][0].detail.wizard[0].title).to.contain('edit');
+    expect(wizardEvent.args[0][0].detail.wizard()[0].title).to.contain('edit');
   });
 
   it('triggers remove action on action button click', async () => {

--- a/test/unit/zeroline/ied-editor.test.ts
+++ b/test/unit/zeroline/ied-editor.test.ts
@@ -47,7 +47,9 @@ describe('A component to visualize SCL element IED', () => {
     await element.requestUpdate();
 
     expect(wizardEvent).to.have.be.calledOnce;
-    expect(wizardEvent.args[0][0].detail.wizard[0].title).to.contain('select');
+    expect(wizardEvent.args[0][0].detail.wizard()[0].title).to.contain(
+      'select'
+    );
   });
 
   it('triggers create wizard for ClientLN element on action button click', async () => {
@@ -58,7 +60,7 @@ describe('A component to visualize SCL element IED', () => {
     await element.requestUpdate();
 
     expect(wizardEvent).to.have.be.calledOnce;
-    expect(wizardEvent.args[0][0].detail.wizard[0].title).to.contain(
+    expect(wizardEvent.args[0][0].detail.wizard()[0].title).to.contain(
       'connectToIED'
     );
   });
@@ -75,7 +77,7 @@ describe('A component to visualize SCL element IED', () => {
     await element.requestUpdate();
 
     expect(wizardEvent).to.have.been.calledOnce;
-    expect(wizardEvent.args[0][0].detail.wizard[0].title).to.contain(
+    expect(wizardEvent.args[0][0].detail.wizard()[0].title).to.contain(
       'connectToIED'
     );
   });


### PR DESCRIPTION
This PR and the feature me and @ca-d added to the wizard mechanism is triggered by the UI discussion with nested wizard-dialogs as we use for GOOSEs in the Substation editor for example. The biggest drawback here is that navigation back and forth is not possible. To be more precise a `subsizerd` option exist that allows to navigate between the parent and child wizard, but we did not use this at all, because when returning to the parent wizard it is not updated. 

Let's say the name of the `GSEControl ` element has been changed in the edit wizard. Using the `subwizard ` OpenSCD navigated back to the select wizard, but the changed GSEControl element appears to be unchanged. 

What we did in the PR is to change the information we send with the wizard event. Before it was a static Wizard object now it is a factory function that returns a Wizard option. This allows to create the Wizard when pushing it to the wizard-dialog dynamically.

@dlabordus and @Flurb I would love you to have a look at the changes. Most of the file changes is test files that needed to be adapted due to the API change. 