### PR TITLE
fix(editors): In IED and SLD Editors fixed preserving the selection (IED or Substation)

### DIFF
--- a/src/editors/IED.ts
+++ b/src/editors/IED.ts
@@ -28,8 +28,10 @@ export default class IedPlugin extends LitElement {
   doc!: XMLDocument;
 
   private get alphabeticOrderedIeds() : Element[] {
-    return Array.from(this.doc?.querySelectorAll(':root > IED'))
-                .sort((a,b) => compareNames(a,b));
+    return (this.doc)
+      ? Array.from(this.doc.querySelectorAll(':root > IED'))
+             .sort((a,b) => compareNames(a,b))
+      : [];
   }
 
   @state()

--- a/src/editors/IED.ts
+++ b/src/editors/IED.ts
@@ -16,6 +16,10 @@ import { compareNames, getDescriptionAttribute, getNameAttribute } from '../foun
  * more than once during working with the IED Editor, for instance when opening a Wizard to edit the IED.
  */
 let iedEditorSelectedIedName: string | undefined;
+/*
+ * We will also add an Event Listener when a new document is opened. We then want to reset the selection
+ * so setting it to undefined will set the selected IED again on the first in the list.
+ */
 function onOpenDocResetSelectedIed() {
   iedEditorSelectedIedName = undefined;
 }

--- a/src/editors/IED.ts
+++ b/src/editors/IED.ts
@@ -1,4 +1,4 @@
-import { css, html, LitElement, property, query, state, TemplateResult } from 'lit-element';
+import { css, html, LitElement, property, state, TemplateResult } from 'lit-element';
 
 import '@material/mwc-fab';
 import '@material/mwc-select';
@@ -8,9 +8,18 @@ import '../zeroline-pane.js';
 import './ied/ied-container.js'
 
 import { translate } from 'lit-translate';
-import { Select } from '@material/mwc-select';
 import { SingleSelectedEvent } from '@material/mwc-list/mwc-list-foundation';
 import { compareNames, getDescriptionAttribute, getNameAttribute } from '../foundation.js';
+
+/*
+ * We need a variable outside the plugin to save the selected IED, because the Plugin is created
+ * more than once during working with the IED Editor, for instance when opening a Wizard to edit the IED.
+ */
+let iedEditorSelectedIed: Element | undefined;
+function onOpenDocResetSelectedIed() {
+  iedEditorSelectedIed = undefined;
+}
+addEventListener('open-doc', onOpenDocResetSelectedIed);
 
 /** An editor [[`plugin`]] for editing the `IED` section. */
 export default class IedPlugin extends LitElement {
@@ -18,15 +27,21 @@ export default class IedPlugin extends LitElement {
   @property()
   doc!: XMLDocument;
 
-  /** Query holding the current selected IEDs. */
-  @state()
-  currentSelectedIEDs = ':root > IED';
-
-  @query('#iedSelect') iedSelector?: Select;
-
   private get alphabeticOrderedIeds() : Element[] {
     return Array.from(this.doc?.querySelectorAll(':root > IED'))
-    .sort((a,b) => compareNames(a,b));
+                .sort((a,b) => compareNames(a,b));
+  }
+
+  @state()
+  private set selectedIed(element: Element | undefined) {
+    iedEditorSelectedIed = element;
+  }
+
+  private get selectedIed(): Element {
+    if (iedEditorSelectedIed === undefined) {
+      iedEditorSelectedIed = this.alphabeticOrderedIeds[0];
+    }
+    return iedEditorSelectedIed;
   }
 
   /**
@@ -35,38 +50,37 @@ export default class IedPlugin extends LitElement {
    * actual IED before getting the actual value (in this case the name).
    */
   private onSelect(event: SingleSelectedEvent): void {
-    const ied = this.alphabeticOrderedIeds[event.detail.index];
-    this.currentSelectedIEDs = `:root > IED[name="${getNameAttribute(ied)}"]`;
+    this.selectedIed = this.alphabeticOrderedIeds[event.detail.index];
+    this.requestUpdate("selectedIed");
   }
 
   render(): TemplateResult {
-    return this.doc?.querySelector(':root > IED')
-      ? html`<section>
-        <mwc-select
-          id="iedSelect"
-          label="${translate("iededitor.searchHelper")}"
-          @selected=${this.onSelect}>
-          ${this.alphabeticOrderedIeds.map(
-            ied =>
-              html`<mwc-list-item
-                ?selected=${ied == this.alphabeticOrderedIeds[0]}
-                value="${getNameAttribute(ied)}"
-                >${getNameAttribute(ied)} ${ied.hasAttribute('desc') ? translate('iededitor.searchHelperDesc', {
-                  description: getDescriptionAttribute(ied)!,
-                }) : ''}
-              </mwc-list-item>`
-          )}
-        </mwc-select>
-        ${Array.from(this.doc?.querySelectorAll(this.currentSelectedIEDs)).map(
-          ied => html`<ied-container
-            .element=${ied}
-          ></ied-container>`
-        )}</section>`
-      : html`<h1>
-          <span style="color: var(--base1)"
-            >${translate('iededitor.missing')}</span
-          >
-        </h1>`;
+    const iedList = this.alphabeticOrderedIeds;
+    return (iedList.length > 0)
+      ? html `
+          <section>
+            <mwc-select
+              id="iedSelect"
+              label="${translate("iededitor.searchHelper")}"
+              @selected=${this.onSelect}>
+              ${iedList.map(
+                ied =>
+                  html`
+                    <mwc-list-item
+                      ?selected=${ied == this.selectedIed}
+                      value="${getNameAttribute(ied)}"
+                    >${getNameAttribute(ied)} ${ied.hasAttribute('desc') ? translate('iededitor.searchHelperDesc', {
+                      description: getDescriptionAttribute(ied)!,
+                    }) : ''}
+                    </mwc-list-item>`
+              )}
+            </mwc-select>
+            <ied-container .element=${this.selectedIed}></ied-container>
+          </section>`
+      : html `
+          <h1>
+            <span style="color: var(--base1)">${translate('iededitor.missing')}</span>
+          </h1>`
   }
 
   static styles = css`

--- a/src/editors/SingleLineDiagram.ts
+++ b/src/editors/SingleLineDiagram.ts
@@ -57,6 +57,10 @@ import '@material/mwc-textfield';
  * more than once during working with the SLD, for instance when opening a Wizard to edit equipment.
  */
 let sldEditorSelectedSubstationName: string | undefined;
+/*
+ * We will also add an Event Listener when a new document is opened. We then want to reset the selection
+ * so setting it to undefined will set the selected Substation again on the first in the list.
+ */
 function onOpenDocResetSelectedSubstation() {
   sldEditorSelectedSubstationName = undefined;
 }

--- a/src/editors/SingleLineDiagram.ts
+++ b/src/editors/SingleLineDiagram.ts
@@ -75,8 +75,10 @@ export default class SingleLineDiagramPlugin extends LitElement {
   @query('#svg') svg!: SVGGraphicsElement;
 
   private get substations() : Element[] {
-    return Array.from(this.doc.querySelectorAll(':root > Substation'))
-                .sort((a,b) => compareNames(a,b));
+    return (this.doc)
+      ? Array.from(this.doc.querySelectorAll(':root > Substation'))
+             .sort((a,b) => compareNames(a,b))
+      : [];
   }
 
   @state()

--- a/src/editors/SingleLineDiagram.ts
+++ b/src/editors/SingleLineDiagram.ts
@@ -3,7 +3,8 @@ import {
   html,
   LitElement,
   property,
-  query, state,
+  query,
+  state,
   TemplateResult,
 } from 'lit-element';
 import panzoom from 'panzoom';

--- a/test/integration/editors/IED.test.ts
+++ b/test/integration/editors/IED.test.ts
@@ -1,23 +1,25 @@
 import { html, fixture, expect } from '@open-wc/testing';
 
-import '../../../mock-wizard.js';
+import '../../mock-wizard.js';
+import '../../../src/editors/IED.js';
 
-import IED from '../../../../src/editors/IED.js';
-import { Editing } from '../../../../src/Editing.js';
-import { Wizarding } from '../../../../src/Wizarding.js';
+import IED from '../../../src/editors/IED.js';
+import { Editing } from '../../../src/Editing.js';
+import { Wizarding } from '../../../src/Wizarding.js';
 import { Select } from '@material/mwc-select';
 
 describe('IED Plugin', () => {
   if (customElements.get('ied-plugin') === undefined)
     customElements.define('ied-plugin', Wizarding(Editing(IED)));
   let element: IED;
-  beforeEach(async () => {
-    element = await fixture(
-      html`<ied-plugin></ied-plugin>`
-    );
-  });
 
   describe('without a doc loaded', () => {
+    beforeEach(async () => {
+      element = await fixture(
+        html`<ied-plugin></ied-plugin>`
+      );
+    });
+
     it('looks like the latest snapshot', async () => {
       await expect(element).shadowDom.to.equalSnapshot();
     });
@@ -25,7 +27,7 @@ describe('IED Plugin', () => {
 
   describe('with a doc loaded including IED without a name', () => {
     let doc: XMLDocument;
-    
+
     beforeEach(async () => {
       doc = await fetch('/test/testfiles/valid2007B4.scd')
         .then(response => response.text())
@@ -43,7 +45,7 @@ describe('IED Plugin', () => {
   describe('with a doc loaded including valid IED sections', () => {
     let doc: XMLDocument;
     let selector: Select;
-    
+
     beforeEach(async () => {
       doc = await fetch('/test/testfiles/valid2007B4.scd')
         .then(response => response.text())
@@ -58,7 +60,7 @@ describe('IED Plugin', () => {
       expect(element.shadowRoot?.querySelector('ied-container')!
         .shadowRoot?.querySelector('action-pane')!.shadowRoot?.innerHTML).to.include('IED1');
     });
-    
+
     it('it selects another IED after using the drop down box', async () => {
       selector = <Select>(
         element.shadowRoot?.querySelector('mwc-select[id="iedSelect"]')

--- a/test/integration/editors/__snapshots__/IED.test.snap.js
+++ b/test/integration/editors/__snapshots__/IED.test.snap.js
@@ -1,17 +1,6 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["IED Plugin without a doc loaded looks like the latest snapshot"] = 
-`<h1>
-  <span style="color: var(--base1)">
-    [iededitor.missing]
-  </span>
-</h1>
-<wizard-dialog>
-</wizard-dialog>
-`;
-/* end snapshot IED Plugin without a doc loaded looks like the latest snapshot */
-
 snapshots["IED Plugin with a doc loaded including IED without a name looks like the latest snapshot"] = 
 `<section>
   <mwc-select
@@ -55,4 +44,15 @@ snapshots["IED Plugin with a doc loaded including IED without a name looks like 
 </wizard-dialog>
 `;
 /* end snapshot IED Plugin with a doc loaded including IED without a name looks like the latest snapshot */
+
+snapshots["IED Plugin without a doc loaded looks like the latest snapshot"] = 
+`<h1>
+  <span style="color: var(--base1)">
+    [iededitor.missing]
+  </span>
+</h1>
+<wizard-dialog>
+</wizard-dialog>
+`;
+/* end snapshot IED Plugin without a doc loaded looks like the latest snapshot */
 


### PR DESCRIPTION
If a IED or Substation was selected in the drop-down box and next a Element was edited using one of the Wizards the selection was lost and the first element of the list was again selected.

The solution for now is to save the selection outside the LitElement, preventing it being lost after being re-created.