### PR TITLE
fix(wizards/fcda): make sure lnInst is non empty string

### DIFF
--- a/src/wizards/fcda.ts
+++ b/src/wizards/fcda.ts
@@ -31,7 +31,7 @@ function newFCDA(parent: Element, path: string[]): Element | undefined {
   const prefix = ln.getAttribute('prefix') ?? '';
   const lnClass = ln.getAttribute('lnClass');
   const lnInst =
-    ln.getAttribute('inst') && ln.getAttribute('inst') !== ''
+    (ln.getAttribute('inst') && ln.getAttribute('inst') !== '')
       ? ln.getAttribute('inst')
       : null;
 

--- a/src/wizards/fcda.ts
+++ b/src/wizards/fcda.ts
@@ -30,7 +30,10 @@ function newFCDA(parent: Element, path: string[]): Element | undefined {
   const ldInst = ln.closest('LDevice')?.getAttribute('inst');
   const prefix = ln.getAttribute('prefix') ?? '';
   const lnClass = ln.getAttribute('lnClass');
-  const lnInst = ln.getAttribute('inst') ?? '';
+  const lnInst =
+    ln.getAttribute('inst') && ln.getAttribute('inst') !== ''
+      ? ln.getAttribute('inst')
+      : null;
 
   let doName = '';
   let daName = '';

--- a/test/integration/wizards/fcda-wizarding-editing-integration.test.ts
+++ b/test/integration/wizards/fcda-wizarding-editing-integration.test.ts
@@ -46,14 +46,14 @@ describe('FCDA editing wizarding integration', () => {
       expect(
         doc.querySelector(
           'DataSet > FCDA[ldInst="CircuitBreaker_CB1"]' +
-            '[prefix=""][lnClass="LLN0"][lnInst=""][doName="Beh"][daName="stVal"][fc="ST"]'
+            '[prefix=""][lnClass="LLN0"]:not(lnInst)[doName="Beh"][daName="stVal"][fc="ST"]'
         )
       ).to.not.exist;
       await primaryAction.click();
       expect(
         doc.querySelector(
           'DataSet > FCDA[ldInst="CircuitBreaker_CB1"]' +
-            '[prefix=""][lnClass="LLN0"][lnInst=""][doName="Beh"][daName="stVal"][fc="ST"]'
+            '[prefix=""][lnClass="LLN0"]:not(lnInst)[doName="Beh"][daName="stVal"][fc="ST"]'
         )
       ).to.exist;
     });

--- a/test/unit/wizards/fcda.test.ts
+++ b/test/unit/wizards/fcda.test.ts
@@ -81,7 +81,7 @@ describe('create wizard for FCDA element', () => {
         expect(newElement).to.have.attribute('ldInst', 'CircuitBreaker_CB1');
         expect(newElement).to.have.attribute('prefix', '');
         expect(newElement).to.have.attribute('lnClass', 'LLN0');
-        expect(newElement).to.have.attribute('lnInst', '');
+        expect(newElement).to.not.have.attribute('lnInst');
         expect(newElement).to.have.attribute('doName', 'Beh');
         expect(newElement).to.have.attribute('daName', 'stVal');
         expect(newElement).to.have.attribute('fc', 'ST');


### PR DESCRIPTION
Close #497 

Sorry @ca-d. I should have added a description of the PR here. With this fix I wanted to prevent that an empty string is set for the attribute `lnInst` within the element `FCDA`. To do so, the action function checks if the referenced `LN` or `LN0` has a `inst` defined AND if it is not an empty string. In these cases `lnInst` must be `inst`. In all other cases, `lnInst` must be missing within `FCDA`.