### PR TITLE
refactor(Editing): update action swaps attributes not elements

### DIFF
--- a/src/Editing.ts
+++ b/src/Editing.ts
@@ -219,8 +219,10 @@ export function Editing<TBase extends LitElementConstructor>(Base: TBase) {
       oldAttrs.forEach(attr => newElement.setAttributeNode(attr));
       newAttrs.forEach(attr => oldElement.setAttributeNode(attr));
 
+      if (!action.new.childNodes) return true;
+
       const newChildNodes = action.new.childNodes;
-      const oldChildNodes = action.old.childNodes;
+      const oldChildNodes = Array.from(action.old.element.childNodes);
 
       oldChildNodes?.forEach(child => oldElement.removeChild(child));
 

--- a/src/Editing.ts
+++ b/src/Editing.ts
@@ -210,28 +210,19 @@ export function Editing<TBase extends LitElementConstructor>(Base: TBase) {
 
       const oldElement = action.old.element;
       const newElement = action.new.element;
-      const oldAttrs = action.old.element.attributes;
-      const newAttrs = action.new.element.attributes;
+      const oldAttrs = Array.from(action.old.element.attributes);
+      const newAttrs = Array.from(action.new.element.attributes);
 
-      const intElement =
-        action.new.element.ownerDocument.createElement('Clone');
+      oldAttrs.forEach(attr => oldElement.removeAttributeNode(attr));
+      newAttrs.forEach(attr => newElement.removeAttributeNode(attr));
 
-      while (oldAttrs.length > 0)
-        intElement.setAttributeNode(
-          oldElement.removeAttributeNode(oldAttrs[0])
-        );
+      oldAttrs.forEach(attr => newElement.setAttributeNode(attr));
+      newAttrs.forEach(attr => oldElement.setAttributeNode(attr));
 
-      while (newAttrs.length > 0)
-        oldElement.setAttributeNode(
-          newElement.removeAttributeNode(newAttrs[0])
-        );
-
-      while (intElement.attributes.length > 0)
-        newElement.setAttributeNode(
-          intElement.removeAttributeNode(intElement.attributes[0])
-        );
-
-      if (action.new.element.textContent) {
+      if (
+        action.new.element.childNodes.length === 1 &&
+        action.new.element.children.length === 0
+      ) {
         const oldTextContent = action.old.element.textContent;
         action.old.element.textContent = action.new.element.textContent;
         action.new.element.textContent = oldTextContent;

--- a/src/Editing.ts
+++ b/src/Editing.ts
@@ -219,10 +219,7 @@ export function Editing<TBase extends LitElementConstructor>(Base: TBase) {
       oldAttrs.forEach(attr => newElement.setAttributeNode(attr));
       newAttrs.forEach(attr => oldElement.setAttributeNode(attr));
 
-      if (
-        action.new.element.childNodes.length === 1 &&
-        action.new.element.children.length === 0
-      ) {
+      if (newElement.hasChildNodes() && !newElement.firstElementChild) {
         const oldTextContent = action.old.element.textContent;
         action.old.element.textContent = action.new.element.textContent;
         action.new.element.textContent = oldTextContent;

--- a/src/Editing.ts
+++ b/src/Editing.ts
@@ -219,11 +219,16 @@ export function Editing<TBase extends LitElementConstructor>(Base: TBase) {
       oldAttrs.forEach(attr => newElement.setAttributeNode(attr));
       newAttrs.forEach(attr => oldElement.setAttributeNode(attr));
 
-      if (newElement.hasChildNodes() && !newElement.firstElementChild) {
-        const oldTextContent = action.old.element.textContent;
-        action.old.element.textContent = action.new.element.textContent;
-        action.new.element.textContent = oldTextContent;
-      }
+      const newChildNodes = action.new.childNodes;
+      const oldChildNodes = action.old.childNodes;
+
+      oldChildNodes?.forEach(child => oldElement.removeChild(child));
+
+      newChildNodes?.forEach(child => oldElement.appendChild(child));
+      oldChildNodes?.forEach(child => newElement.appendChild(child));
+
+      action.old.childNodes = newChildNodes;
+      action.new.childNodes = oldChildNodes;
 
       return true;
     }

--- a/src/Editing.ts
+++ b/src/Editing.ts
@@ -208,8 +208,35 @@ export function Editing<TBase extends LitElementConstructor>(Base: TBase) {
     private onUpdate(action: Update) {
       if (!this.checkUpdateValidity(action)) return false;
 
-      action.new.element.append(...Array.from(action.old.element.children));
-      action.old.element.replaceWith(action.new.element);
+      const oldElement = action.old.element;
+      const newElement = action.new.element;
+      const oldAttrs = action.old.element.attributes;
+      const newAttrs = action.new.element.attributes;
+
+      const intElement =
+        action.new.element.ownerDocument.createElement('Clone');
+
+      while (oldAttrs.length > 0)
+        intElement.setAttributeNode(
+          oldElement.removeAttributeNode(oldAttrs[0])
+        );
+
+      while (newAttrs.length > 0)
+        oldElement.setAttributeNode(
+          newElement.removeAttributeNode(newAttrs[0])
+        );
+
+      while (intElement.attributes.length > 0)
+        newElement.setAttributeNode(
+          intElement.removeAttributeNode(intElement.attributes[0])
+        );
+
+      if (action.new.element.textContent) {
+        const oldTextContent = action.old.element.textContent;
+        action.old.element.textContent = action.new.element.textContent;
+        action.new.element.textContent = oldTextContent;
+      }
+
       return true;
     }
 

--- a/src/editors/templates/enumtype-wizard.ts
+++ b/src/editors/templates/enumtype-wizard.ts
@@ -84,9 +84,14 @@ function updateEnumValAction(element: Element): WizardActor {
       return [];
 
     const newElement = cloneElement(element, { desc, ord });
-    newElement.textContent = value;
+    const newTextNode = document.createTextNode(value);
 
-    return [{ old: { element }, new: { element: newElement } }];
+    return [
+      {
+        old: { element, childNodes: Array.from(element.childNodes) },
+        new: { element: newElement, childNodes: [newTextNode] },
+      },
+    ];
   };
 }
 

--- a/src/editors/templates/enumtype-wizard.ts
+++ b/src/editors/templates/enumtype-wizard.ts
@@ -88,7 +88,7 @@ function updateEnumValAction(element: Element): WizardActor {
 
     return [
       {
-        old: { element, childNodes: Array.from(element.childNodes) },
+        old: { element },
         new: { element: newElement, childNodes: [newTextNode] },
       },
     ];

--- a/src/foundation.ts
+++ b/src/foundation.ts
@@ -39,8 +39,8 @@ export interface Move {
 }
 /** Replaces `old.element` with `new.element`, keeping element children. */
 export interface Update {
-  old: { element: Element };
-  new: { element: Element };
+  old: { element: Element; childNodes?: Node[] };
+  new: { element: Element; childNodes?: Node[] };
   derived?: boolean;
   checkValidity?: () => boolean;
 }

--- a/src/wizards/gse.ts
+++ b/src/wizards/gse.ts
@@ -51,7 +51,7 @@ export function getMTimeAction(
   const newTextNode = document.createTextNode(Time);
 
   return {
-    old: { element: oldTime, childNodes: Array.from(oldTime.childNodes) },
+    old: { element: oldTime },
     new: { element: newTime, childNodes: [newTextNode] },
   };
 }

--- a/src/wizards/gse.ts
+++ b/src/wizards/gse.ts
@@ -48,10 +48,11 @@ export function getMTimeAction(
     };
 
   const newTime = <Element>oldTime.cloneNode(false);
-  newTime.textContent = Time;
+  const newTextNode = document.createTextNode(Time);
+
   return {
-    old: { element: oldTime },
-    new: { element: newTime },
+    old: { element: oldTime, childNodes: Array.from(oldTime.childNodes) },
+    new: { element: newTime, childNodes: [newTextNode] },
   };
 }
 

--- a/src/wizards/subnetwork.ts
+++ b/src/wizards/subnetwork.ts
@@ -154,7 +154,7 @@ function getBitRateAction(
   const newTextNode = document.createTextNode(BitRate);
 
   return {
-    old: { element: oldBitRate, childNodes: Array.from(oldBitRate.childNodes) },
+    old: { element: oldBitRate },
     new: { element: newBitRate, childNodes: [newTextNode] },
   };
 }

--- a/src/wizards/subnetwork.ts
+++ b/src/wizards/subnetwork.ts
@@ -151,11 +151,11 @@ function getBitRateAction(
     };
 
   const newBitRate = cloneElement(oldBitRate, { multiplier });
-  newBitRate.textContent = BitRate;
+  const newTextNode = document.createTextNode(BitRate);
 
   return {
-    old: { element: oldBitRate },
-    new: { element: newBitRate },
+    old: { element: oldBitRate, childNodes: Array.from(oldBitRate.childNodes) },
+    new: { element: newBitRate, childNodes: [newTextNode] },
   };
 }
 

--- a/src/wizards/voltagelevel.ts
+++ b/src/wizards/voltagelevel.ts
@@ -170,11 +170,10 @@ function getVoltageAction(
     };
 
   const newVoltage = cloneElement(oldVoltage, { multiplier });
-  newVoltage.textContent = Voltage;
-
+  const newVoltageText = document.createTextNode(Voltage);
   return {
-    old: { element: oldVoltage },
-    new: { element: newVoltage },
+    old: { element: oldVoltage, childNodes: Array.from(oldVoltage.childNodes) },
+    new: { element: newVoltage, childNodes: [newVoltageText] },
   };
 }
 

--- a/src/wizards/voltagelevel.ts
+++ b/src/wizards/voltagelevel.ts
@@ -172,7 +172,7 @@ function getVoltageAction(
   const newVoltage = cloneElement(oldVoltage, { multiplier });
   const newVoltageText = document.createTextNode(Voltage);
   return {
-    old: { element: oldVoltage, childNodes: Array.from(oldVoltage.childNodes) },
+    old: { element: oldVoltage },
     new: { element: newVoltage, childNodes: [newVoltageText] },
   };
 }

--- a/test/unit/Editing.test.ts
+++ b/test/unit/Editing.test.ts
@@ -100,21 +100,54 @@ describe('EditingElement', () => {
   });
 
   it('updates an element on receiving an Update action', () => {
+    const newElement = <Element>element.cloneNode(false);
+    newElement.setAttribute('name', 'newName');
+
     elm.dispatchEvent(
-      newActionEvent({
-        old: {
-          element,
-        },
-        new: {
-          element: elm.doc!.createElement('newBay'),
-        },
-      })
+      newActionEvent({ old: { element }, new: { element: newElement } })
     );
+
     expect(parent.querySelector('Bay[name="Q01"]')).to.be.null;
-    expect(parent.querySelector('newBay')).to.not.be.null;
-    expect(parent.querySelector('newBay')?.nextElementSibling).to.equal(
-      parent.querySelector('Bay[name="Q02"]')
+    expect(parent.querySelector('Bay[name="newName"]')).to.not.be.null;
+  });
+
+  it('swap attributes between old and new element on update', () => {
+    const newElement = <Element>element.cloneNode(false);
+    newElement.setAttribute('name', 'newName');
+
+    elm.dispatchEvent(
+      newActionEvent({ old: { element }, new: { element: newElement } })
     );
+
+    expect(element.parentElement).to.not.be.null;
+    expect(newElement.parentElement).to.be.null;
+  });
+
+  it('swaps textContent of old and new element this existing new element textContent', () => {
+    element.textContent = 'oldTextContent';
+    const newElement = <Element>element.cloneNode(false);
+    newElement.setAttribute('name', 'newName');
+    newElement.textContent = 'newTextContent';
+
+    elm.dispatchEvent(
+      newActionEvent({ old: { element }, new: { element: newElement } })
+    );
+
+    expect(element.textContent).to.equal('newTextContent');
+    expect(newElement.textContent).to.equal('oldTextContent');
+  });
+
+  it('does not swap textContent of old and new element with missing new element textContent', () => {
+    element.textContent = 'oldTextContent';
+    const newElement = <Element>element.cloneNode(false);
+    newElement.setAttribute('name', 'newName');
+
+    elm.dispatchEvent(
+      newActionEvent({ old: { element }, new: { element: newElement } })
+    );
+
+    expect(element.textContent).to.equal('oldTextContent');
+    expect(newElement.textContent).to.equal('');
   });
 
   it('does not update an element with name conflict', () => {
@@ -122,15 +155,9 @@ describe('EditingElement', () => {
     newElement?.setAttribute('name', 'Q02');
 
     elm.dispatchEvent(
-      newActionEvent({
-        old: {
-          element,
-        },
-        new: {
-          element: newElement,
-        },
-      })
+      newActionEvent({ old: { element }, new: { element: newElement } })
     );
+
     expect(parent.querySelector('Bay[name="Q01"]')).to.not.null;
     expect(
       parent.querySelector('Bay[name="Q01"]')?.nextElementSibling

--- a/test/unit/Editing.test.ts
+++ b/test/unit/Editing.test.ts
@@ -123,14 +123,17 @@ describe('EditingElement', () => {
     expect(newElement.parentElement).to.be.null;
   });
 
-  it('swaps textContent of old and new element this existing new element textContent', () => {
+  it('swaps option childNodes of old and new elements', () => {
     element.textContent = 'oldTextContent';
     const newElement = <Element>element.cloneNode(false);
     newElement.setAttribute('name', 'newName');
-    newElement.textContent = 'newTextContent';
+    const newTextNode = document.createTextNode('newTextContent');
 
     elm.dispatchEvent(
-      newActionEvent({ old: { element }, new: { element: newElement } })
+      newActionEvent({
+        old: { element, childNodes: Array.from(element.childNodes) },
+        new: { element: newElement, childNodes: [newTextNode] },
+      })
     );
 
     expect(element.textContent).to.equal('newTextContent');

--- a/test/unit/mock-editor.ts
+++ b/test/unit/mock-editor.ts
@@ -1,5 +1,6 @@
 import { LitElement, customElement } from 'lit-element';
 import { Editing } from '../../src/Editing.js';
+import { Logging } from '../../src/Logging.js';
 
 @customElement('mock-editor')
-export class MockEditor extends Editing(LitElement) {}
+export class MockEditor extends Editing(Logging(LitElement)) {}

--- a/test/unit/wizards/gse.test.ts
+++ b/test/unit/wizards/gse.test.ts
@@ -171,7 +171,7 @@ describe('gse wizards', () => {
       expect(actions[0]).to.satisfy(isUpdate);
       const updateAction = <Update>actions[0];
       expect(updateAction.old.element.textContent?.trim()).to.equal('10');
-      expect(updateAction.new.element.textContent?.trim()).to.equal('15');
+      expect(updateAction.new.childNodes?.[0].textContent).to.equal('15');
     });
     it('update a GSE element when only MaxTime attribute changed', async () => {
       const input = <WizardTextField>inputs[5];
@@ -185,7 +185,7 @@ describe('gse wizards', () => {
       expect(actions[0]).to.satisfy(isUpdate);
       const updateAction = <Update>actions[0];
       expect(updateAction.old.element.textContent?.trim()).to.equal('10000');
-      expect(updateAction.new.element.textContent?.trim()).to.equal('65');
+      expect(updateAction.new.childNodes?.[0].textContent).to.equal('65');
     });
   });
 
@@ -206,7 +206,7 @@ describe('gse wizards', () => {
     it('updates a MinTime child element when chenged', () => {
       const editorAction = getMTimeAction('MinTime', oldMinTime, '654', gse);
       expect(editorAction).to.satisfy(isUpdate);
-      expect((<Update>editorAction).new.element.textContent?.trim()).to.equal(
+      expect((<Update>editorAction).new.childNodes?.[0].textContent).to.equal(
         '654'
       );
     });
@@ -230,7 +230,7 @@ describe('gse wizards', () => {
         gse
       );
       expect(editorAction).to.satisfy(isUpdate);
-      expect((<Update>editorAction).new.element.textContent?.trim()).to.equal(
+      expect((<Update>editorAction).new.childNodes?.[0].textContent).to.equal(
         '1234123'
       );
     });

--- a/test/unit/wizards/subnetwork.test.ts
+++ b/test/unit/wizards/subnetwork.test.ts
@@ -147,7 +147,7 @@ describe('Wizards for SCL element SubNetwork', () => {
         const updateAction = <Update>actionEvent.args[0][0].detail.action;
         expect(updateAction.old.element.innerHTML.trim()).to.equal('100.0');
         expect(updateAction.old.element).to.not.have.attribute('multiplier');
-        expect(updateAction.new.element.innerHTML.trim()).to.equal('200.');
+        expect(updateAction.new.childNodes?.[0].textContent).to.equal('200.');
         expect(updateAction.new.element).to.have.attribute('multiplier', 'M');
       });
 


### PR DESCRIPTION
This is the refactor we have discussed in issue #498. 
- the main refactor is swapping attributes between old and new element of the update action
- in addition to that we need to swap the textContent as sometimes information is stored here, not in attributes. E.g. `<MinTime multiplier="m" unit="s">10</MinTime>`.
- textContent shall only be swapped if the new element has a textContent defined to avoid changing something we did not intend to change

> swapping attributes seems ugly to me as I needed to add a dummy element to store atrributes from one of the elements. But I did not see a better way to do it.