### PR TITLE
style: make landing buttons reactive

### DIFF
--- a/src/open-scd.ts
+++ b/src/open-scd.ts
@@ -134,12 +134,10 @@ export class OpenSCD extends Hosting(
     }
 
     .landing {
-      display: flex;
-      flex-direction: row;
-      justify-content: center;
       position: absolute;
-      top: calc(50vh - 82px);
-      left: calc(50vw - 184px);
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
     }
 
     .landing_icon:hover {


### PR DESCRIPTION
The fact that the landing buttons only look nice if I have exactly two of them has been bothering me for a long time.

This patch finally fixes that by making the display of the landing buttons reactive.