### PR TITLE
feat(wizard-checkbox): web component for xs:boolean XML attributes

### DIFF
--- a/src/editors/templates/foundation.ts
+++ b/src/editors/templates/foundation.ts
@@ -105,19 +105,6 @@ export function addReferencedDataTypes(
   return actions;
 }
 
-export function buildListFromStringArray(
-  list: (string | null)[],
-  selected: string | null
-): TemplateResult[] {
-  return list.map(
-    item => html`<mwc-list-item
-      value=${ifDefined(item === null ? undefined : item)}
-      ?selected=${item === selected}
-      >${item}</mwc-list-item
-    >`
-  );
-}
-
 /** Common `CSS` styles used by DataTypeTemplate subeditors */
 export const styles = css`
   :host(.moving) section {

--- a/src/editors/templates/lnodetype-wizard.ts
+++ b/src/editors/templates/lnodetype-wizard.ts
@@ -10,6 +10,7 @@ import { ListItem } from '@material/mwc-list/mwc-list-item';
 import { Select } from '@material/mwc-select';
 import { SingleSelectedEvent } from '@material/mwc-list/mwc-list-foundation';
 
+import '../../wizard-checkbox.js';
 import '../../wizard-textfield.js';
 import '../../wizard-select.js';
 import {
@@ -33,7 +34,6 @@ import { WizardSelect } from '../../wizard-select.js';
 import {
   addReferencedDataTypes,
   allDataTypeSelector,
-  buildListFromStringArray,
   CreateOptions,
   unifyCreateActionArray,
   UpdateOptions,
@@ -127,7 +127,7 @@ function dOWizard(options: WizardOptions): Wizard | undefined {
     name,
     desc,
     accessControl,
-    transientList,
+    transient,
   ] = DO
     ? [
         get('do.wizard.title.edit'),
@@ -154,10 +154,7 @@ function dOWizard(options: WizardOptions): Wizard | undefined {
         DO.getAttribute('name'),
         DO.getAttribute('desc'),
         DO.getAttribute('accessControl'),
-        buildListFromStringArray(
-          [null, 'true', 'false'],
-          DO.getAttribute('transient')
-        ),
+        DO.getAttribute('transient'),
       ]
     : [
         get('do.wizard.title.add'),
@@ -167,7 +164,7 @@ function dOWizard(options: WizardOptions): Wizard | undefined {
         '',
         null,
         null,
-        buildListFromStringArray([null, 'true', 'false'], null),
+        null,
       ];
 
   const types = Array.from(doc.querySelectorAll('DOType'))
@@ -219,12 +216,12 @@ function dOWizard(options: WizardOptions): Wizard | undefined {
           nullable
           pattern="${patterns.normalizedString}"
         ></wizard-textfield>`,
-        html`<mwc-select
-          fixedMenuPosition
+        html`<wizard-checkbox
           label="transient"
+          .maybeValue="${transient}"
           helper="${translate('scl.transient')}"
-          >${transientList}</mwc-select
-        >`,
+          nullable
+        ></wizard-checkbox>`,
       ],
     },
   ];
@@ -335,7 +332,7 @@ function createLNodeTypeHelperWizard(
           .maybeValue=${null}
           >${validDOTypes.map(
             doType =>
-              html`<mwc-list-item value="${doType.getAttribute('id')}"
+              html`<mwc-list-item value="${doType.getAttribute('id')!}"
                 >${doType.getAttribute('id')}</mwc-list-item
               >`
           )}</wizard-select

--- a/src/foundation.ts
+++ b/src/foundation.ts
@@ -8,6 +8,7 @@ import AceEditor from 'ace-custom-element';
 
 import { WizardTextField } from './wizard-textfield.js';
 import { WizardSelect } from './wizard-select.js';
+import { WizardCheckbox } from './wizard-checkbox.js';
 
 export type SimpleAction = Create | Update | Delete | Move;
 export type ComplexAction = {
@@ -133,7 +134,7 @@ export function newActionEvent<T extends EditorAction>(
 }
 
 export const wizardInputSelector =
-  'wizard-textfield, mwc-textfield, ace-editor, mwc-select,wizard-select';
+  'wizard-textfield, mwc-textfield, ace-editor, mwc-select,wizard-select, wizard-checkbox';
 export type WizardInput =
   | WizardTextField
   | TextField
@@ -173,7 +174,11 @@ export function reportValidity(input: WizardInput): boolean {
 
 /** @returns the `value` or `maybeValue` of `input` depending on type. */
 export function getValue(input: WizardInput): string | null {
-  if (input instanceof WizardTextField || input instanceof WizardSelect)
+  if (
+    input instanceof WizardTextField ||
+    input instanceof WizardSelect ||
+    input instanceof WizardCheckbox
+  )
     return input.maybeValue;
   else return input.value ?? null;
 }

--- a/src/wizard-checkbox.ts
+++ b/src/wizard-checkbox.ts
@@ -14,21 +14,21 @@ import '@material/mwc-checkbox';
 import { Checkbox } from '@material/mwc-checkbox';
 import { Switch } from '@material/mwc-switch';
 
-/** A potentially `nullable` `Checkbox`. */
+/** A potentially `nullable` labelled checkbox. */
 @customElement('wizard-checkbox')
 export class WizardCheckbox extends LitElement {
   @property({ type: String })
   label = '';
-  /** Additional information rendered to the formfield: `label (helper)`*/
+  /** Parenthetical information rendered after the label: `label (helper)` */
   @property({ type: String })
   helper = '';
   /** Whether [[`maybeValue`]] may be `null` */
   @property({ type: Boolean })
   nullable = false;
-  /** The default `checked` displayed if [[`maybeValue`]] is `null`. */
+  /** The default `checked` state while [[`maybeValue`]] is `null`. */
   @property({ type: Boolean })
   defaultChecked = false;
-  /** Reflects `checked` attribute of `mwc-checkbox`. Can be `null` if [[`nullable`]]. */
+  /** Is `"true"` when checked, `"false"` un-checked, `null` if [[`nullable`]]. */
   @property({ type: String })
   get maybeValue(): string | null {
     return this.null ? null : this.checked ? 'true' : 'false';
@@ -112,7 +112,11 @@ export class WizardCheckbox extends LitElement {
     return html`
       <div style="display: flex; flex-direction: row;">
         <div style="flex: auto;">
-          <mwc-formfield label="${this.formfieldLabel}"
+          <mwc-formfield
+            label="${this.formfieldLabel}"
+            style="${this.disabled
+              ? `--mdc-theme-text-primary-on-background:rgba(0, 0, 0, 0.38)`
+              : ``}"
             ><mwc-checkbox
               ?checked=${this.initChecked}
               ?disabled=${this.disabled}

--- a/src/wizard-checkbox.ts
+++ b/src/wizard-checkbox.ts
@@ -1,0 +1,128 @@
+import {
+  customElement,
+  html,
+  LitElement,
+  property,
+  query,
+  state,
+  TemplateResult,
+} from 'lit-element';
+
+import '@material/mwc-formfield';
+import '@material/mwc-switch';
+import '@material/mwc-checkbox';
+import { Checkbox } from '@material/mwc-checkbox';
+import { Switch } from '@material/mwc-switch';
+
+/** A potentially `nullable` `Checkbox`. */
+@customElement('wizard-checkbox')
+export class WizardCheckbox extends LitElement {
+  @property({ type: String })
+  label = '';
+  /** Additional information rendered to the formfield: `label (helper)`*/
+  @property({ type: String })
+  helper = '';
+  /** Whether [[`maybeValue`]] may be `null` */
+  @property({ type: Boolean })
+  nullable = false;
+  /** The default `checked` displayed if [[`maybeValue`]] is `null`. */
+  @property({ type: Boolean })
+  defaultChecked = false;
+  /** Reflects `checked` attribute of `mwc-checkbox`. Can be `null` if [[`nullable`]]. */
+  @property({ type: String })
+  get maybeValue(): string | null {
+    return this.null ? null : this.checked ? 'true' : 'false';
+  }
+  set maybeValue(check: string | null) {
+    if (check === null) this.null = true;
+    else {
+      this.null = false;
+      this.checked = check === 'true' ? true : false;
+    }
+  }
+
+  private isNull = false;
+
+  @state()
+  private get null(): boolean {
+    return this.nullable && this.isNull;
+  }
+  private set null(value: boolean) {
+    if (!this.nullable || value === this.isNull) return;
+    this.isNull = value;
+    if (this.null) this.disable();
+    else this.enable();
+  }
+
+  private initChecked = false;
+
+  @state()
+  get checked(): boolean {
+    return this.checkbox?.checked ?? this.initChecked;
+  }
+  set checked(value: boolean) {
+    if (this.checkbox) this.checkbox.checked = value;
+    else this.initChecked = value;
+  }
+
+  @state()
+  disabled = false;
+  @state()
+  get formfieldLabel(): string {
+    return this.helper ? `${this.label} (${this.helper})` : this.label;
+  }
+
+  @query('mwc-switch') nullSwitch?: Switch;
+  @query('mwc-checkbox') checkbox?: Checkbox;
+
+  private nulled: boolean | null = null;
+
+  private enable(): void {
+    if (this.nulled === null) return;
+    this.checked = this.nulled;
+    this.nulled = null;
+    this.disabled = false;
+  }
+
+  private disable(): void {
+    if (this.nulled !== null) return;
+    this.nulled = this.checked;
+    this.checked = this.defaultChecked;
+    this.disabled = true;
+  }
+
+  firstUpdated(): void {
+    this.requestUpdate();
+  }
+
+  renderSwitch(): TemplateResult {
+    if (this.nullable) {
+      return html`<mwc-switch
+        style="margin-left: 12px;"
+        ?checked=${!this.null}
+        @change=${() => {
+          this.null = !this.nullSwitch!.checked;
+        }}
+      ></mwc-switch>`;
+    }
+    return html``;
+  }
+
+  render(): TemplateResult {
+    return html`
+      <div style="display: flex; flex-direction: row;">
+        <div style="flex: auto;">
+          <mwc-formfield label="${this.formfieldLabel}"
+            ><mwc-checkbox
+              ?checked=${this.initChecked}
+              ?disabled=${this.disabled}
+            ></mwc-checkbox
+          ></mwc-formfield>
+        </div>
+        <div style="display: flex; align-items: center;">
+          ${this.renderSwitch()}
+        </div>
+      </div>
+    `;
+  }
+}

--- a/src/wizards/abstractda.ts
+++ b/src/wizards/abstractda.ts
@@ -6,6 +6,7 @@ import { ListItem } from '@material/mwc-list/mwc-list-item';
 import { SelectedEvent } from '@material/mwc-list/mwc-list-foundation';
 import { Select } from '@material/mwc-select';
 
+import '../wizard-checkbox.js';
 import '../wizard-select.js';
 import '../wizard-textfield.js';
 import { createElement, EditorAction } from '../foundation.js';
@@ -173,20 +174,13 @@ export function wizardContent(
           >`
       )}</wizard-select
     >`,
-    html`<wizard-select
+    html`<wizard-checkbox
       label="valImport"
       .maybeValue=${valImport}
       helper="${translate('scl.valImport')}"
       nullable
       required
-      fixedMenuPosition
-      >${['true', 'false'].map(
-        valImportOption =>
-          html`<mwc-list-item value="${valImportOption}"
-            >${valImportOption}</mwc-list-item
-          >`
-      )}</wizard-select
-    >`,
+    ></wizard-checkbox>`,
     html`<wizard-select
       label="Val"
       .maybeValue=${Val}

--- a/src/wizards/da.ts
+++ b/src/wizards/da.ts
@@ -4,6 +4,7 @@ import { get, translate } from 'lit-translate';
 import '@material/mwc-button';
 import '@material/mwc-list/mwc-list-item';
 
+import '../wizard-checkbox.js';
 import '../wizard-select.js';
 import {
   cloneElement,
@@ -38,42 +39,24 @@ export function renderDa(
           html`<mwc-list-item value="${fcOption}">${fcOption}</mwc-list-item>`
       )}</wizard-select
     >`,
-    html`<wizard-select
+    html`<wizard-checkbox
       label="dchg"
       .maybeValue=${dchg}
-      helper="${translate('scl.valImport')}"
+      helper="${translate('scl.dchg')}"
       nullable
-      required
-      fixedMenuPosition
-      >${['true', 'false'].map(
-        option =>
-          html`<mwc-list-item value="${option}">${option}</mwc-list-item>`
-      )}</wizard-select
-    >`,
-    html`<wizard-select
+    ></wizard-checkbox>`,
+    html`<wizard-checkbox
       label="qchg"
       .maybeValue=${qchg}
-      helper="${translate('scl.valImport')}"
+      helper="${translate('scl.qchg')}"
       nullable
-      required
-      fixedMenuPosition
-      >${['true', 'false'].map(
-        option =>
-          html`<mwc-list-item value="${option}">${option}</mwc-list-item>`
-      )}</wizard-select
-    >`,
-    html`<wizard-select
+    ></wizard-checkbox>`,
+    html`<wizard-checkbox
       label="dupd"
       .maybeValue=${dupd}
-      helper="${translate('scl.valImport')}"
+      helper="${translate('scl.dupd')}"
       nullable
-      required
-      fixedMenuPosition
-      >${['true', 'false'].map(
-        option =>
-          html`<mwc-list-item value="${option}">${option}</mwc-list-item>`
-      )}</wizard-select
-    >`,
+    ></wizard-checkbox>`,
   ];
 }
 

--- a/src/wizards/gsecontrol.ts
+++ b/src/wizards/gsecontrol.ts
@@ -8,6 +8,7 @@ import { ListItem } from '@material/mwc-list/mwc-list-item';
 import { SingleSelectedEvent } from '@material/mwc-list/mwc-list-foundation';
 
 import '../filtered-list.js';
+import '../wizard-checkbox.js';
 import '../wizard-select.js';
 import '../wizard-textfield.js';
 import {
@@ -86,16 +87,12 @@ export function renderGseAttributes(
       required
       validationMessage="${translate('textfield.nonempty')}"
     ></wizard-textfield>`,
-    html`<wizard-select
+    html`<wizard-checkbox
       label="fixedOffs"
       .maybeValue=${fixedOffs}
       nullable
-      required
       helper="${translate('scl.fixedOffs')}"
-      >${['true', 'false'].map(
-        type => html`<mwc-list-item value="${type}">${type}</mwc-list-item>`
-      )}</wizard-select
-    >`,
+    ></wizard-checkbox>`,
     html`<wizard-select
       label="securityEnabled"
       .maybeValue=${securityEnabled}

--- a/src/wizards/optfields.ts
+++ b/src/wizards/optfields.ts
@@ -3,6 +3,7 @@ import { get } from 'lit-translate';
 
 import '@material/mwc-list/mwc-list-item';
 
+import '../wizard-checkbox.js';
 import '../wizard-select.js';
 import {
   cloneElement,
@@ -73,16 +74,12 @@ export function editOptFieldsWizard(element: Element): Wizard {
       },
       content: optFields.map(
         optField =>
-          html`<wizard-select
+          html`<wizard-checkbox
             label="${optField}"
             .maybeValue=${element.getAttribute(optField)}
             nullable
             required
-            >${['true', 'false'].map(
-              option =>
-                html`<mwc-list-item value="${option}">${option}</mwc-list-item>`
-            )}</wizard-select
-          >`
+          ></wizard-checkbox>`
       ),
     },
   ];

--- a/src/wizards/reportcontrol.ts
+++ b/src/wizards/reportcontrol.ts
@@ -7,6 +7,7 @@ import { List } from '@material/mwc-list';
 import { ListItemBase } from '@material/mwc-list/mwc-list-item-base';
 import { SingleSelectedEvent } from '@material/mwc-list/mwc-list-foundation';
 
+import '../wizard-checkbox.js';
 import '../wizard-textfield.js';
 import '../wizard-select.js';
 import '../filtered-list.js';
@@ -174,16 +175,11 @@ function renderReportControlWizardInputs(
       nullable
       helper="${translate('scl.desc')}"
     ></wizard-textfield>`,
-    html`<wizard-select
+    html`<wizard-checkbox
       label="buffered"
       .maybeValue=${options.buffered}
-      helper="${translate('scl.buffered')}"
       disabled
-      >${['true', 'false'].map(
-        option =>
-          html`<mwc-list-item value="${option}">${option}</mwc-list-item>`
-      )}</wizard-select
-    >`,
+    ></wizard-checkbox>`,
     html`<wizard-textfield
       label="rptID"
       .maybeValue=${options.rptID}
@@ -191,16 +187,11 @@ function renderReportControlWizardInputs(
       required
       validationMessage="${translate('textfield.nonempty')}"
     ></wizard-textfield>`,
-    html`<wizard-select
+    html`<wizard-checkbox
       label="indexed"
       .maybeValue=${options.indexed}
       nullable
-      required
-      helper="${translate('scl.indexed')}"
-      >${['true', 'false'].map(
-        type => html`<mwc-list-item value="${type}">${type}</mwc-list-item>`
-      )}</wizard-select
-    >`,
+    ></wizard-checkbox>`,
     html`<wizard-textfield
       label="max Clients"
       .maybeValue=${options.max}

--- a/src/wizards/sampledvaluecontrol.ts
+++ b/src/wizards/sampledvaluecontrol.ts
@@ -7,6 +7,7 @@ import { ListItemBase } from '@material/mwc-list/mwc-list-item-base';
 import { SingleSelectedEvent } from '@material/mwc-list/mwc-list-foundation';
 
 import '../filtered-list.js';
+import '../wizard-checkbox.js';
 import '../wizard-select.js';
 import '../wizard-textfield.js';
 import {
@@ -74,16 +75,12 @@ function contentSampledValueControlWizard(
       pattern="${patterns.normalizedString}"
       helper="${translate('scl.desc')}"
     ></wizard-textfield>`,
-    html`<wizard-select
+    html`<wizard-checkbox
       label="multicast"
       .maybeValue=${options.multicast}
       helper="${translate('scl.multicast')}"
       disabled
-      >${['true', 'false'].map(
-        option =>
-          html`<mwc-list-item value="${option}">${option}</mwc-list-item>`
-      )}</wizard-select
-    >`,
+    ></wizard-checkbox>`,
     html`<wizard-textfield
       label="smvID"
       .maybeValue=${options.smvID}

--- a/src/wizards/trgops.ts
+++ b/src/wizards/trgops.ts
@@ -3,6 +3,7 @@ import { get } from 'lit-translate';
 
 import '@material/mwc-list/mwc-list-item';
 
+import '../wizard-checkbox.js';
 import '../wizard-select.js';
 import {
   cloneElement,
@@ -56,16 +57,11 @@ export function editTrgOpsWizard(element: Element): Wizard {
       },
       content: trgOps.map(
         trgOp =>
-          html`<wizard-select
+          html`<wizard-checkbox
             label="${trgOp}"
             .maybeValue=${element.getAttribute(trgOp)}
             nullable
-            required
-            >${['true', 'false'].map(
-              option =>
-                html`<mwc-list-item value="${option}">${option}</mwc-list-item>`
-            )}</wizard-select
-          >`
+          ></wizard-checkbox>`
       ),
     },
   ];

--- a/test/integration/editors/templates/__snapshots__/lnodetype-wizard.test.snap.js
+++ b/test/integration/editors/templates/__snapshots__/lnodetype-wizard.test.snap.js
@@ -3973,39 +3973,12 @@ snapshots["LNodeType wizards defines a dOWizard to create a new DO element looks
       pattern="([ -~]|[]|[ -퟿]|[-�])*"
     >
     </wizard-textfield>
-    <mwc-select
-      fixedmenuposition=""
+    <wizard-checkbox
       helper="[scl.transient]"
       label="transient"
+      nullable=""
     >
-      <mwc-list-item
-        aria-disabled="false"
-        aria-selected="true"
-        mwc-list-item=""
-        role="option"
-        selected=""
-        tabindex="0"
-      >
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="true"
-      >
-        true
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="false"
-      >
-        false
-      </mwc-list-item>
-    </mwc-select>
+    </wizard-checkbox>
   </div>
   <mwc-button
     dialogaction="close"

--- a/test/integration/editors/templates/lnodetype-wizard.test.ts
+++ b/test/integration/editors/templates/lnodetype-wizard.test.ts
@@ -9,6 +9,7 @@ import { Select } from '@material/mwc-select';
 import { FilteredList } from '../../../../src/filtered-list.js';
 import TemplatesPlugin from '../../../../src/editors/Templates.js';
 import { WizardTextField } from '../../../../src/wizard-textfield.js';
+import { WizardCheckbox } from '../../../../src/wizard-checkbox.js';
 
 describe('LNodeType wizards', () => {
   if (customElements.get('templates-editor') === undefined)
@@ -359,7 +360,7 @@ describe('LNodeType wizards', () => {
     let descField: WizardTextField;
     let typeSelect: Select;
     let accessControlField: WizardTextField;
-    let transientSelect: Select;
+    let transientSelect: WizardCheckbox;
     let primaryAction: HTMLElement;
     let deleteButton: HTMLElement;
 
@@ -391,8 +392,10 @@ describe('LNodeType wizards', () => {
       typeSelect = <Select>(
         parent.wizardUI.dialog?.querySelector('mwc-select[label="type"]')
       );
-      transientSelect = <Select>(
-        parent.wizardUI.dialog?.querySelector('mwc-select[label="transient"]')
+      transientSelect = <WizardCheckbox>(
+        parent.wizardUI.dialog?.querySelector(
+          'wizard-checkbox[label="transient"]'
+        )
       );
       primaryAction = <HTMLElement>(
         parent.wizardUI.dialog?.querySelector(
@@ -431,7 +434,7 @@ describe('LNodeType wizards', () => {
       typeSelect.value = 'Dummy.CMV';
       accessControlField.nullable = false;
       accessControlField.maybeValue = 'myAccessControl';
-      transientSelect.value = 'true';
+      transientSelect.maybeValue = 'true';
 
       await parent.requestUpdate();
       primaryAction.click();
@@ -481,7 +484,7 @@ describe('LNodeType wizards', () => {
     let descField: WizardTextField;
     let typeSelect: Select;
     let accessControlField: WizardTextField;
-    let transientSelect: Select;
+    let transientSelect: WizardCheckbox;
     let primaryAction: HTMLElement;
 
     beforeEach(async () => {
@@ -512,8 +515,10 @@ describe('LNodeType wizards', () => {
       typeSelect = <Select>(
         parent.wizardUI.dialog?.querySelector('mwc-select[label="type"]')
       );
-      transientSelect = <Select>(
-        parent.wizardUI.dialog?.querySelector('mwc-select[label="transient"]')
+      transientSelect = <WizardCheckbox>(
+        parent.wizardUI.dialog?.querySelector(
+          'wizard-checkbox[label="transient"]'
+        )
       );
       primaryAction = <HTMLElement>(
         parent.wizardUI.dialog?.querySelector(
@@ -551,7 +556,7 @@ describe('LNodeType wizards', () => {
       typeSelect.value = 'Dummy.CMV';
       accessControlField.nullable = false;
       accessControlField.maybeValue = 'myAccessControl';
-      transientSelect.value = 'true';
+      transientSelect.maybeValue = 'true';
 
       await parent.requestUpdate();
       primaryAction.click();

--- a/test/integration/wizards/__snapshots__/bda-wizarding-editing.test.snap.js
+++ b/test/integration/wizards/__snapshots__/bda-wizarding-editing.test.snap.js
@@ -520,33 +520,13 @@ snapshots["BDA wizarding editing integration defines a editBDaWizard to edit an 
         Set
       </mwc-list-item>
     </wizard-select>
-    <wizard-select
-      disabled=""
-      fixedmenuposition=""
+    <wizard-checkbox
       helper="[scl.valImport]"
       label="valImport"
       nullable=""
       required=""
     >
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="0"
-        value="true"
-      >
-        true
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="false"
-      >
-        false
-      </mwc-list-item>
-    </wizard-select>
+    </wizard-checkbox>
     <wizard-select
       disabled=""
       helper="[scl.Val]"
@@ -1128,33 +1108,13 @@ snapshots["BDA wizarding editing integration defines a createBDaWizard to create
         Set
       </mwc-list-item>
     </wizard-select>
-    <wizard-select
-      disabled=""
-      fixedmenuposition=""
+    <wizard-checkbox
       helper="[scl.valImport]"
       label="valImport"
       nullable=""
       required=""
     >
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="0"
-        value="true"
-      >
-        true
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="false"
-      >
-        false
-      </mwc-list-item>
-    </wizard-select>
+    </wizard-checkbox>
     <wizard-select
       disabled=""
       helper="[scl.Val]"

--- a/test/integration/wizards/__snapshots__/da-wizarding-editing.test.snap.js
+++ b/test/integration/wizards/__snapshots__/da-wizarding-editing.test.snap.js
@@ -564,33 +564,13 @@ snapshots["DA wizarding editing integration defines a editDaWizard to edit an ex
         Set
       </mwc-list-item>
     </wizard-select>
-    <wizard-select
-      disabled=""
-      fixedmenuposition=""
+    <wizard-checkbox
       helper="[scl.valImport]"
       label="valImport"
       nullable=""
       required=""
     >
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="0"
-        value="true"
-      >
-        true
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="false"
-      >
-        false
-      </mwc-list-item>
-    </wizard-select>
+    </wizard-checkbox>
     <wizard-select
       disabled=""
       helper="[scl.Val]"
@@ -783,87 +763,24 @@ snapshots["DA wizarding editing integration defines a editDaWizard to edit an ex
         CO
       </mwc-list-item>
     </wizard-select>
-    <wizard-select
-      disabled=""
-      fixedmenuposition=""
-      helper="[scl.valImport]"
+    <wizard-checkbox
+      helper="[scl.dchg]"
       label="dchg"
       nullable=""
-      required=""
     >
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="0"
-        value="true"
-      >
-        true
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="false"
-      >
-        false
-      </mwc-list-item>
-    </wizard-select>
-    <wizard-select
-      disabled=""
-      fixedmenuposition=""
-      helper="[scl.valImport]"
+    </wizard-checkbox>
+    <wizard-checkbox
+      helper="[scl.qchg]"
       label="qchg"
       nullable=""
-      required=""
     >
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="0"
-        value="true"
-      >
-        true
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="false"
-      >
-        false
-      </mwc-list-item>
-    </wizard-select>
-    <wizard-select
-      disabled=""
-      fixedmenuposition=""
-      helper="[scl.valImport]"
+    </wizard-checkbox>
+    <wizard-checkbox
+      helper="[scl.dupd]"
       label="dupd"
       nullable=""
-      required=""
     >
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="0"
-        value="true"
-      >
-        true
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="false"
-      >
-        false
-      </mwc-list-item>
-    </wizard-select>
+    </wizard-checkbox>
   </div>
   <mwc-button
     dialogaction="close"
@@ -1420,33 +1337,13 @@ snapshots["DA wizarding editing integration defines a createDaWizard to create a
         Set
       </mwc-list-item>
     </wizard-select>
-    <wizard-select
-      disabled=""
-      fixedmenuposition=""
+    <wizard-checkbox
       helper="[scl.valImport]"
       label="valImport"
       nullable=""
       required=""
     >
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="0"
-        value="true"
-      >
-        true
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="false"
-      >
-        false
-      </mwc-list-item>
-    </wizard-select>
+    </wizard-checkbox>
     <wizard-select
       disabled=""
       helper="[scl.Val]"
@@ -1585,87 +1482,24 @@ snapshots["DA wizarding editing integration defines a createDaWizard to create a
         CO
       </mwc-list-item>
     </wizard-select>
-    <wizard-select
-      disabled=""
-      fixedmenuposition=""
-      helper="[scl.valImport]"
+    <wizard-checkbox
+      helper="[scl.dchg]"
       label="dchg"
       nullable=""
-      required=""
     >
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="0"
-        value="true"
-      >
-        true
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="false"
-      >
-        false
-      </mwc-list-item>
-    </wizard-select>
-    <wizard-select
-      disabled=""
-      fixedmenuposition=""
-      helper="[scl.valImport]"
+    </wizard-checkbox>
+    <wizard-checkbox
+      helper="[scl.qchg]"
       label="qchg"
       nullable=""
-      required=""
     >
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="0"
-        value="true"
-      >
-        true
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="false"
-      >
-        false
-      </mwc-list-item>
-    </wizard-select>
-    <wizard-select
-      disabled=""
-      fixedmenuposition=""
-      helper="[scl.valImport]"
+    </wizard-checkbox>
+    <wizard-checkbox
+      helper="[scl.dupd]"
       label="dupd"
       nullable=""
-      required=""
     >
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="0"
-        value="true"
-      >
-        true
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="false"
-      >
-        false
-      </mwc-list-item>
-    </wizard-select>
+    </wizard-checkbox>
   </div>
   <mwc-button
     dialogaction="close"

--- a/test/integration/wizards/bda-wizarding-editing.test.ts
+++ b/test/integration/wizards/bda-wizarding-editing.test.ts
@@ -9,6 +9,7 @@ import { FilteredList } from '../../../src/filtered-list.js';
 import { WizardSelect } from '../../../src/wizard-select.js';
 import { WizardTextField } from '../../../src/wizard-textfield.js';
 import TemplatesPlugin from '../../../src/editors/Templates.js';
+import { WizardCheckbox } from '../../../src/wizard-checkbox.js';
 
 describe('BDA wizarding editing integration', () => {
   if (customElements.get('templates-editor') === undefined)
@@ -121,7 +122,7 @@ describe('BDA wizarding editing integration', () => {
     let sAddrField: WizardTextField;
     let bTypeSelect: WizardSelect;
     let valKindSelect: WizardSelect;
-    let valImportSelect: WizardSelect;
+    let valImportSelect: WizardCheckbox;
     let primayAction: HTMLElement;
 
     beforeEach(async () => {
@@ -151,9 +152,9 @@ describe('BDA wizarding editing integration', () => {
       valKindSelect = <WizardSelect>(
         parent.wizardUI.dialog?.querySelector('wizard-select[label="valKind"]')
       );
-      valImportSelect = <WizardSelect>(
+      valImportSelect = <WizardCheckbox>(
         parent.wizardUI.dialog?.querySelector(
-          'wizard-select[label="valImport"]'
+          'wizard-checkbox[label="valImport"]'
         )
       );
       primayAction = <HTMLElement>(
@@ -202,7 +203,7 @@ describe('BDA wizarding editing integration', () => {
       valKindSelect.nullable = false;
       valKindSelect.value = 'RO';
       valImportSelect.nullable = false;
-      valImportSelect.value = 'true';
+      valImportSelect.maybeValue = 'true';
 
       await parent.requestUpdate();
       primayAction.click();

--- a/test/integration/wizards/da-wizarding-editing.test.ts
+++ b/test/integration/wizards/da-wizarding-editing.test.ts
@@ -8,6 +8,7 @@ import { ListItem } from '@material/mwc-list/mwc-list-item';
 import TemplatesPlugin from '../../../src/editors/Templates.js';
 import { WizardSelect } from '../../../src/wizard-select.js';
 import { WizardTextField } from '../../../src/wizard-textfield.js';
+import { WizardCheckbox } from '../../../src/wizard-checkbox.js';
 
 describe('DA wizarding editing integration', () => {
   if (customElements.get('templates-editor') === undefined)
@@ -123,7 +124,7 @@ describe('DA wizarding editing integration', () => {
     let bTypeSelect: WizardSelect;
     let typeSelect: WizardSelect;
     let valKindSelect: WizardSelect;
-    let valImportSelect: WizardSelect;
+    let valImportSelect: WizardCheckbox;
     let fcSelect: WizardSelect;
     let primayAction: HTMLElement;
 
@@ -159,9 +160,9 @@ describe('DA wizarding editing integration', () => {
       valKindSelect = <WizardSelect>(
         parent.wizardUI.dialog?.querySelector('wizard-select[label="valKind"]')
       );
-      valImportSelect = <WizardSelect>(
+      valImportSelect = <WizardCheckbox>(
         parent.wizardUI.dialog?.querySelector(
-          'wizard-select[label="valImport"]'
+          'wizard-checkbox[label="valImport"]'
         )
       );
       fcSelect = <WizardSelect>(
@@ -217,7 +218,7 @@ describe('DA wizarding editing integration', () => {
       valKindSelect.nullable = false;
       valKindSelect.value = 'RO';
       valImportSelect.nullable = false;
-      valImportSelect.value = 'true';
+      valImportSelect.maybeValue = 'true';
       fcSelect.value = 'ST';
 
       await parent.requestUpdate();

--- a/test/integration/wizards/reportcontrol-wizarding-editing.test.ts
+++ b/test/integration/wizards/reportcontrol-wizarding-editing.test.ts
@@ -192,7 +192,7 @@ describe('Wizards for SCL element ReportControl', () => {
       await new Promise(resolve => setTimeout(resolve, 100)); // await animation
 
       const dchgSelect = <WizardTextField>(
-        element.wizardUI.dialog?.querySelector('wizard-select[label="dchg"]')
+        element.wizardUI.dialog?.querySelector('wizard-checkbox[label="dchg"]')
       );
       await dchgSelect.updateComplete;
 
@@ -211,7 +211,9 @@ describe('Wizards for SCL element ReportControl', () => {
       await new Promise(resolve => setTimeout(resolve, 100)); // await animation
 
       const seqNumSelect = <WizardTextField>(
-        element.wizardUI.dialog?.querySelector('wizard-select[label="seqNum"]')
+        element.wizardUI.dialog?.querySelector(
+          'wizard-checkbox[label="seqNum"]'
+        )
       );
       await seqNumSelect.updateComplete;
 

--- a/test/unit/wizard-checkbox.test.ts
+++ b/test/unit/wizard-checkbox.test.ts
@@ -9,7 +9,7 @@ describe('wizard-textfield', () => {
     element = await fixture(html`<wizard-checkbox></wizard-checkbox>`);
   });
 
-  describe('per default', () => {
+  describe('with no attribute set', () => {
     it('does not render a null value switch', () =>
       expect(element.nullSwitch).to.not.exist);
 
@@ -23,7 +23,7 @@ describe('wizard-textfield', () => {
       expect(element).to.have.property('maybeValue', 'true');
     });
 
-    it('is un-checked for invalid maybaChecked input', () => {
+    it('is un-checked for invalid maybeValue input', () => {
       element.maybeValue = 'someinvalidinput';
       expect(element.checkbox).to.have.property('checked', false);
     });
@@ -52,7 +52,7 @@ describe('wizard-textfield', () => {
       expect(element).to.have.property('disabled', true);
     });
 
-    it('remebers its previous value on switch toggle', async () => {
+    it('remembers its previous value on switch toggle', async () => {
       element.maybeValue = 'true';
       await element.updateComplete;
       element.nullSwitch!.click();

--- a/test/unit/wizard-checkbox.test.ts
+++ b/test/unit/wizard-checkbox.test.ts
@@ -1,0 +1,102 @@
+import { html, fixture, expect } from '@open-wc/testing';
+
+import '../../src/wizard-checkbox.js';
+import { WizardCheckbox } from '../../src/wizard-checkbox.js';
+
+describe('wizard-textfield', () => {
+  let element: WizardCheckbox;
+  beforeEach(async () => {
+    element = await fixture(html`<wizard-checkbox></wizard-checkbox>`);
+  });
+
+  describe('per default', () => {
+    it('does not render a null value switch', () =>
+      expect(element.nullSwitch).to.not.exist);
+
+    it('is enabled', () => expect(element).to.have.property('disabled', false));
+
+    it('is un-checked', () =>
+      expect(element.checkbox).to.have.property('checked', false));
+
+    it('returns the checked attribute as maybeValue', () => {
+      element.maybeValue = 'true';
+      expect(element).to.have.property('maybeValue', 'true');
+    });
+
+    it('is un-checked for invalid maybaChecked input', () => {
+      element.maybeValue = 'someinvalidinput';
+      expect(element.checkbox).to.have.property('checked', false);
+    });
+
+    it('is un-checked in case input null with non-nullable property', () => {
+      element.maybeValue = null;
+      expect(element.checkbox).to.have.property('checked', false);
+    });
+  });
+
+  describe('with nullable set', () => {
+    beforeEach(async () => {
+      element.nullable = true;
+      await element.updateComplete;
+    });
+
+    it('renders a null value switch', async () =>
+      expect(element.nullSwitch).to.exist);
+
+    it('disables itself on switch toggle', async () => {
+      expect(element).to.have.property('maybeValue', 'false');
+      expect(element).to.have.property('disabled', false);
+      element.nullSwitch!.click();
+      await element.updateComplete;
+      expect(element).to.have.property('maybeValue', null);
+      expect(element).to.have.property('disabled', true);
+    });
+
+    it('remebers its previous value on switch toggle', async () => {
+      element.maybeValue = 'true';
+      await element.updateComplete;
+      element.nullSwitch!.click();
+      await element.updateComplete;
+      element.nullSwitch!.click();
+      await element.updateComplete;
+      expect(element).to.have.property('disabled', false);
+      expect(element).to.have.property('maybeValue', 'true');
+    });
+
+    describe('with a null value', () => {
+      beforeEach(async () => {
+        element.maybeValue = null;
+        await element.updateComplete;
+      });
+
+      it('enables itself on switch toggle', async () => {
+        element.nullSwitch?.click();
+        await element.updateComplete;
+        expect(element).to.have.property('disabled', false);
+      });
+
+      it('has a disabled checkbox', () =>
+        expect(element).to.have.property('disabled', true));
+
+      it('is false per default', () =>
+        expect(element.checkbox).to.have.property('checked', false));
+
+      it('is checked with true defaultChecked', async () => {
+        element.defaultChecked = true;
+        element.nullSwitch?.click();
+        await element.requestUpdate();
+
+        element.maybeValue = 'true';
+        await element.requestUpdate();
+
+        element.nullSwitch?.click();
+        await element.requestUpdate();
+
+        expect(element.checkbox).to.have.property('checked', true);
+      });
+
+      it('returns null', () =>
+        expect(element).to.have.property('maybeValue', null));
+    });
+  });
+});

--- a/test/unit/wizards/__snapshots__/abstractda.test.snap.js
+++ b/test/unit/wizards/__snapshots__/abstractda.test.snap.js
@@ -467,31 +467,13 @@ snapshots["abstractda wizards renderWizard looks like the latest snapshot"] =
         Set
       </mwc-list-item>
     </wizard-select>
-    <wizard-select
-      disabled=""
-      fixedmenuposition=""
+    <wizard-checkbox
       helper="[scl.valImport]"
       label="valImport"
       nullable=""
       required=""
     >
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        tabindex="-1"
-        value="true"
-      >
-        true
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        tabindex="-1"
-        value="false"
-      >
-        false
-      </mwc-list-item>
-    </wizard-select>
+    </wizard-checkbox>
     <wizard-select
       helper="[scl.Val]"
       label="Val"

--- a/test/unit/wizards/__snapshots__/gsecontrol.test.snap.js
+++ b/test/unit/wizards/__snapshots__/gsecontrol.test.snap.js
@@ -118,30 +118,12 @@ snapshots["gsecontrol wizards renderGseAttribute looks like the latest snapshot"
       validationmessage="[textfield.nonempty]"
     >
     </wizard-textfield>
-    <wizard-select
-      disabled=""
+    <wizard-checkbox
       helper="[scl.fixedOffs]"
       label="fixedOffs"
       nullable=""
-      required=""
     >
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        tabindex="-1"
-        value="true"
-      >
-        true
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        tabindex="-1"
-        value="false"
-      >
-        false
-      </mwc-list-item>
-    </wizard-select>
+    </wizard-checkbox>
     <wizard-select
       disabled=""
       helper="[scl.securityEnable]"
@@ -245,29 +227,12 @@ snapshots["gsecontrol wizards editGseControlWizard looks like the latest snapsho
       validationmessage="[textfield.nonempty]"
     >
     </wizard-textfield>
-    <wizard-select
+    <wizard-checkbox
       helper="[scl.fixedOffs]"
       label="fixedOffs"
       nullable=""
-      required=""
     >
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        tabindex="-1"
-        value="true"
-      >
-        true
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        tabindex="-1"
-        value="false"
-      >
-        false
-      </mwc-list-item>
-    </wizard-select>
+    </wizard-checkbox>
     <wizard-select
       disabled=""
       helper="[scl.securityEnable]"

--- a/test/unit/wizards/__snapshots__/optfields.test.snap.js
+++ b/test/unit/wizards/__snapshots__/optfields.test.snap.js
@@ -8,204 +8,54 @@ snapshots["Wizards for SCL OptFields element define an edit wizard that looks li
   open=""
 >
   <div id="wizard-content">
-    <wizard-select
-      disabled=""
+    <wizard-checkbox
       label="seqNum"
       nullable=""
       required=""
     >
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="true"
-      >
-        true
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="false"
-      >
-        false
-      </mwc-list-item>
-    </wizard-select>
-    <wizard-select
-      disabled=""
+    </wizard-checkbox>
+    <wizard-checkbox
       label="timeStamp"
       nullable=""
       required=""
     >
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="true"
-      >
-        true
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="false"
-      >
-        false
-      </mwc-list-item>
-    </wizard-select>
-    <wizard-select
+    </wizard-checkbox>
+    <wizard-checkbox
       label="dataSet"
       nullable=""
       required=""
     >
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="true"
-      >
-        true
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="false"
-      >
-        false
-      </mwc-list-item>
-    </wizard-select>
-    <wizard-select
-      disabled=""
+    </wizard-checkbox>
+    <wizard-checkbox
       label="reasonCode"
       nullable=""
       required=""
     >
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="true"
-      >
-        true
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="false"
-      >
-        false
-      </mwc-list-item>
-    </wizard-select>
-    <wizard-select
-      disabled=""
+    </wizard-checkbox>
+    <wizard-checkbox
       label="dataRef"
       nullable=""
       required=""
     >
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="true"
-      >
-        true
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="false"
-      >
-        false
-      </mwc-list-item>
-    </wizard-select>
-    <wizard-select
-      disabled=""
+    </wizard-checkbox>
+    <wizard-checkbox
       label="entryID"
       nullable=""
       required=""
     >
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="true"
-      >
-        true
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="false"
-      >
-        false
-      </mwc-list-item>
-    </wizard-select>
-    <wizard-select
-      disabled=""
+    </wizard-checkbox>
+    <wizard-checkbox
       label="configRef"
       nullable=""
       required=""
     >
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="true"
-      >
-        true
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="false"
-      >
-        false
-      </mwc-list-item>
-    </wizard-select>
-    <wizard-select
+    </wizard-checkbox>
+    <wizard-checkbox
       label="bufOvfl"
       nullable=""
       required=""
     >
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="true"
-      >
-        true
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="false"
-      >
-        false
-      </mwc-list-item>
-    </wizard-select>
+    </wizard-checkbox>
   </div>
   <mwc-button
     dialogaction="close"

--- a/test/unit/wizards/__snapshots__/reportcontrol.test.snap.js
+++ b/test/unit/wizards/__snapshots__/reportcontrol.test.snap.js
@@ -25,30 +25,11 @@ snapshots["Wizards for SCL ReportControl element define an edit wizard that look
       nullable=""
     >
     </wizard-textfield>
-    <wizard-select
+    <wizard-checkbox
       disabled=""
-      helper="[scl.buffered]"
       label="buffered"
     >
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="true"
-      >
-        true
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="false"
-      >
-        false
-      </mwc-list-item>
-    </wizard-select>
+    </wizard-checkbox>
     <wizard-textfield
       helper="[scl.id]"
       label="rptID"
@@ -56,31 +37,11 @@ snapshots["Wizards for SCL ReportControl element define an edit wizard that look
       validationmessage="[textfield.nonempty]"
     >
     </wizard-textfield>
-    <wizard-select
-      helper="[scl.indexed]"
+    <wizard-checkbox
       label="indexed"
       nullable=""
-      required=""
     >
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="true"
-      >
-        true
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="false"
-      >
-        false
-      </mwc-list-item>
-    </wizard-select>
+    </wizard-checkbox>
     <wizard-textfield
       helper="[scl.maxReport]"
       label="max Clients"

--- a/test/unit/wizards/__snapshots__/sampledvaluecontrol.test.snap.js
+++ b/test/unit/wizards/__snapshots__/sampledvaluecontrol.test.snap.js
@@ -26,30 +26,12 @@ snapshots["Wizards for SCL element SampledValueControl define an edit wizard tha
       pattern="([ -~]|[]|[ -퟿]|[-�])*"
     >
     </wizard-textfield>
-    <wizard-select
+    <wizard-checkbox
       disabled=""
       helper="[scl.multicast]"
       label="multicast"
     >
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="true"
-      >
-        true
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="false"
-      >
-        false
-      </mwc-list-item>
-    </wizard-select>
+    </wizard-checkbox>
     <wizard-textfield
       helper="[scl.id]"
       label="smvID"

--- a/test/unit/wizards/__snapshots__/trgops.test.snap.js
+++ b/test/unit/wizards/__snapshots__/trgops.test.snap.js
@@ -8,129 +8,31 @@ snapshots["Wizards for SCL TrgOps element define an edit wizard that looks like 
   open=""
 >
   <div id="wizard-content">
-    <wizard-select
+    <wizard-checkbox
       label="dchg"
       nullable=""
-      required=""
     >
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="true"
-      >
-        true
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="false"
-      >
-        false
-      </mwc-list-item>
-    </wizard-select>
-    <wizard-select
-      disabled=""
+    </wizard-checkbox>
+    <wizard-checkbox
       label="qchg"
       nullable=""
-      required=""
     >
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="true"
-      >
-        true
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="false"
-      >
-        false
-      </mwc-list-item>
-    </wizard-select>
-    <wizard-select
-      disabled=""
+    </wizard-checkbox>
+    <wizard-checkbox
       label="dupd"
       nullable=""
-      required=""
     >
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="true"
-      >
-        true
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="false"
-      >
-        false
-      </mwc-list-item>
-    </wizard-select>
-    <wizard-select
-      disabled=""
+    </wizard-checkbox>
+    <wizard-checkbox
       label="period"
       nullable=""
-      required=""
     >
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="true"
-      >
-        true
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="false"
-      >
-        false
-      </mwc-list-item>
-    </wizard-select>
-    <wizard-select
+    </wizard-checkbox>
+    <wizard-checkbox
       label="gi"
       nullable=""
-      required=""
     >
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="true"
-      >
-        true
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        role="option"
-        tabindex="-1"
-        value="false"
-      >
-        false
-      </mwc-list-item>
-    </wizard-select>
+    </wizard-checkbox>
   </div>
   <mwc-button
     dialogaction="close"

--- a/test/unit/wizards/bda.test.ts
+++ b/test/unit/wizards/bda.test.ts
@@ -137,7 +137,7 @@ describe('bda wizards', () => {
     it('update a BDA element when valImport attribute changed', async () => {
       const input = <WizardTextField>inputs[6];
       input.nullSwitch?.click();
-      input.value = 'true';
+      input.maybeValue = 'true';
       await input.requestUpdate();
       const editorAction = updateBDaAction(bda);
       const updateActions = editorAction(inputs, newWizard());

--- a/test/unit/wizards/da.test.ts
+++ b/test/unit/wizards/da.test.ts
@@ -144,7 +144,7 @@ describe('da wizards', () => {
     it('update a DA element when valImport attribute changed', async () => {
       const input = <WizardSelect>inputs[6];
       input.nullSwitch?.click();
-      input.value = 'true';
+      input.maybeValue = 'true';
       await input.requestUpdate();
       const editorAction = updateDaAction(da);
       const updateActions = editorAction(inputs, newWizard());
@@ -183,7 +183,7 @@ describe('da wizards', () => {
     it('update a DA element when dchg attribute changed', async () => {
       const input = <WizardSelect>inputs[10];
       input.nullSwitch?.click();
-      input.value = 'true';
+      input.maybeValue = 'true';
       await input.requestUpdate();
       const editorAction = updateDaAction(da);
       const updateActions = editorAction(inputs, newWizard());
@@ -196,7 +196,7 @@ describe('da wizards', () => {
     it('update a DA element when qchg attribute changed', async () => {
       const input = <WizardSelect>inputs[11];
       input.nullSwitch?.click();
-      input.value = 'true';
+      input.maybeValue = 'true';
       await input.requestUpdate();
       const editorAction = updateDaAction(da);
       const updateActions = editorAction(inputs, newWizard());
@@ -209,7 +209,7 @@ describe('da wizards', () => {
     it('update a DA element when dupd attribute changed', async () => {
       const input = <WizardSelect>inputs[12];
       input.nullSwitch?.click();
-      input.value = 'true';
+      input.maybeValue = 'true';
       await input.requestUpdate();
       const editorAction = updateDaAction(da);
       const updateActions = editorAction(inputs, newWizard());
@@ -320,13 +320,13 @@ describe('da wizards', () => {
       valImport.value = 'false';
       await valImport.requestUpdate();
       dchg.nullSwitch?.click();
-      dchg.value = 'true';
+      dchg.maybeValue = 'true';
       await dchg.requestUpdate();
       qchg.nullSwitch?.click();
-      qchg.value = 'false';
+      qchg.maybeValue = 'false';
       await qchg.requestUpdate();
       dupd.nullSwitch?.click();
-      dupd.value = 'true';
+      dupd.maybeValue = 'true';
       await dupd.requestUpdate();
 
       const editorAction = createDaAction(daType);

--- a/test/unit/wizards/gsecontrol.test.ts
+++ b/test/unit/wizards/gsecontrol.test.ts
@@ -297,7 +297,7 @@ describe('gsecontrol wizards', () => {
     it('update a GSEControl element when fixedOffs attribute changed', async () => {
       const input = <WizardTextField>inputs[4];
       input.nullSwitch?.click();
-      input.value = 'true';
+      input.maybeValue = 'true';
       await input.requestUpdate();
       const editorAction = updateGseControlAction(gseControl);
       const updateActions = editorAction(inputs, newWizard());

--- a/test/unit/wizards/optfields.test.ts
+++ b/test/unit/wizards/optfields.test.ts
@@ -58,7 +58,7 @@ describe('Wizards for SCL OptFields element', () => {
 
     it('update the OptFields element with changed dataSet attribute', async () => {
       const input = <WizardSelect>inputs[2];
-      input.value = 'false';
+      input.maybeValue = 'false';
       await input.requestUpdate();
 
       primaryAction.click();
@@ -93,7 +93,7 @@ describe('Wizards for SCL OptFields element', () => {
     it('updates the OptFields element with changed seqNum attribute', async () => {
       const input = <WizardSelect>inputs[0];
       input.nullSwitch?.click();
-      input.value = 'true';
+      input.maybeValue = 'true';
       await input.requestUpdate();
 
       primaryAction.click();
@@ -111,7 +111,7 @@ describe('Wizards for SCL OptFields element', () => {
     it('updates the OptFields element with changed timeStamp attribute', async () => {
       const input = <WizardSelect>inputs[1];
       input.nullSwitch?.click();
-      input.value = 'true';
+      input.maybeValue = 'true';
       await input.requestUpdate();
 
       primaryAction.click();
@@ -129,7 +129,7 @@ describe('Wizards for SCL OptFields element', () => {
     it('updates the OptFields element with changed reasonCode attribute', async () => {
       const input = <WizardSelect>inputs[3];
       input.nullSwitch?.click();
-      input.value = 'true';
+      input.maybeValue = 'true';
       await input.requestUpdate();
 
       primaryAction.click();
@@ -147,7 +147,7 @@ describe('Wizards for SCL OptFields element', () => {
     it('updates the OptFields element with changed dataRef attribute', async () => {
       const input = <WizardSelect>inputs[4];
       input.nullSwitch?.click();
-      input.value = 'true';
+      input.maybeValue = 'true';
       await input.requestUpdate();
 
       primaryAction.click();
@@ -165,7 +165,7 @@ describe('Wizards for SCL OptFields element', () => {
     it('updates the OptFields element with changed entryID attribute', async () => {
       const input = <WizardSelect>inputs[5];
       input.nullSwitch?.click();
-      input.value = 'true';
+      input.maybeValue = 'true';
       await input.requestUpdate();
 
       primaryAction.click();
@@ -183,7 +183,7 @@ describe('Wizards for SCL OptFields element', () => {
     it('updates the OptFields element with changed configRef attribute', async () => {
       const input = <WizardSelect>inputs[6];
       input.nullSwitch?.click();
-      input.value = 'true';
+      input.maybeValue = 'true';
       await input.requestUpdate();
 
       primaryAction.click();
@@ -200,7 +200,7 @@ describe('Wizards for SCL OptFields element', () => {
 
     it('updates the OptFields element with changed bufOvfl attribute', async () => {
       const input = <WizardSelect>inputs[7];
-      input.value = 'false';
+      input.maybeValue = 'false';
       await input.requestUpdate();
 
       primaryAction.click();

--- a/test/unit/wizards/reportcontrol.test.ts
+++ b/test/unit/wizards/reportcontrol.test.ts
@@ -199,7 +199,7 @@ describe('Wizards for SCL ReportControl element', () => {
 
     it('update a ReportControl element when indexed attribute changed', async () => {
       const input = <WizardTextField>inputs[4];
-      input.value = 'false';
+      input.maybeValue = 'false';
       await input.requestUpdate();
 
       primaryAction.click();

--- a/test/unit/wizards/trgops.test.ts
+++ b/test/unit/wizards/trgops.test.ts
@@ -58,7 +58,7 @@ describe('Wizards for SCL TrgOps element', () => {
 
     it('updates the TrgOps element with changed dchg attribute', async () => {
       const input = <WizardSelect>inputs[0];
-      input.value = 'false';
+      input.maybeValue = 'false';
       await input.requestUpdate();
 
       primaryAction.click();
@@ -76,7 +76,7 @@ describe('Wizards for SCL TrgOps element', () => {
     it('updates the TrgOps element with changed qchg attribute', async () => {
       const input = <WizardSelect>inputs[1];
       input.nullSwitch?.click();
-      input.value = 'false';
+      input.maybeValue = 'false';
       await input.requestUpdate();
 
       primaryAction.click();
@@ -94,7 +94,7 @@ describe('Wizards for SCL TrgOps element', () => {
     it('updates the TrgOps element with changed dupd attribute', async () => {
       const input = <WizardSelect>inputs[2];
       input.nullSwitch?.click();
-      input.value = 'true';
+      input.maybeValue = 'true';
       await input.requestUpdate();
 
       primaryAction.click();
@@ -111,7 +111,7 @@ describe('Wizards for SCL TrgOps element', () => {
 
     it('updates the TrgOps element with changed gi attribute', async () => {
       const input = <WizardSelect>inputs[4];
-      input.value = 'true';
+      input.maybeValue = 'true';
       await input.requestUpdate();
 
       primaryAction.click();
@@ -129,7 +129,7 @@ describe('Wizards for SCL TrgOps element', () => {
     it('updates the TrgOps element with changed period attribute', async () => {
       const input = <WizardSelect>inputs[3];
       input.nullSwitch?.click();
-      input.value = 'true';
+      input.maybeValue = 'true';
       await input.requestUpdate();
 
       primaryAction.click();


### PR DESCRIPTION
This was on my personal machine for some time now...until now we use `wizard-select` for xs:boolean type attributes. This is not the best UI and takes up too much space in my opinion. A good example is `OptFields`, a `ReportControl` subwizard, where all inputs are xs:boolean type. 

I did not want to have everything refactored right away, and applied this web component only in the `GSEControl` edit wizard for the attribute `fixedOffs`. I would be happy about review and comments on this component :).