### PR TITLE
refactor(foundation): rename Update to Replace

### DIFF
--- a/src/Editing.ts
+++ b/src/Editing.ts
@@ -11,7 +11,7 @@ import {
   isDelete,
   isMove,
   isSimple,
-  isUpdate,
+  isReplace,
   LitElementConstructor,
   Mixin,
   Move,
@@ -20,7 +20,7 @@ import {
   OpenDocEvent,
   SCLTag,
   SimpleAction,
-  Update,
+  Replace,
 } from './foundation.js';
 
 /** Mixin that edits an `XML` `doc`, listening to [[`EditorActionEvent`]]s */
@@ -174,17 +174,18 @@ export function Editing<TBase extends LitElementConstructor>(Base: TBase) {
       );
     }
 
-    private checkUpdateValidity(update: Update): boolean {
-      if (update.checkValidity !== undefined) return update.checkValidity();
+    private checkReplaceValidity(replace: Replace): boolean {
+      if (replace.checkValidity !== undefined) return replace.checkValidity();
 
       const invalid =
-        update.new.element.hasAttribute('name') &&
-        update.new.element.getAttribute('name') !==
-          update.old.element.getAttribute('name') &&
-        Array.from(update.old.element.parentElement?.children ?? []).some(
+        replace.new.element.hasAttribute('name') &&
+        replace.new.element.getAttribute('name') !==
+          replace.old.element.getAttribute('name') &&
+        Array.from(replace.old.element.parentElement?.children ?? []).some(
           elm =>
-            elm.tagName === update.new.element.tagName &&
-            elm.getAttribute('name') === update.new.element.getAttribute('name')
+            elm.tagName === replace.new.element.tagName &&
+            elm.getAttribute('name') ===
+              replace.new.element.getAttribute('name')
         );
 
       if (invalid)
@@ -192,12 +193,12 @@ export function Editing<TBase extends LitElementConstructor>(Base: TBase) {
           newLogEvent({
             kind: 'error',
             title: get('editing.error.update', {
-              name: update.new.element.tagName,
+              name: replace.new.element.tagName,
             }),
             message: get('editing.error.nameClash', {
-              parent: update.old.element.parentElement!.tagName,
-              child: update.new.element.tagName,
-              name: update.new.element.getAttribute('name')!,
+              parent: replace.old.element.parentElement!.tagName,
+              child: replace.new.element.tagName,
+              name: replace.new.element.getAttribute('name')!,
             }),
           })
         );
@@ -205,15 +206,15 @@ export function Editing<TBase extends LitElementConstructor>(Base: TBase) {
       return !invalid;
     }
 
-    private onUpdate(action: Update) {
-      if (!this.checkUpdateValidity(action)) return false;
+    private onReplace(action: Replace) {
+      if (!this.checkReplaceValidity(action)) return false;
 
       action.new.element.append(...Array.from(action.old.element.children));
       action.old.element.replaceWith(action.new.element);
       return true;
     }
 
-    private logUpdate(action: Update) {
+    private logUpdate(action: Replace) {
       this.dispatchEvent(
         newLogEvent({
           kind: 'action',
@@ -229,14 +230,14 @@ export function Editing<TBase extends LitElementConstructor>(Base: TBase) {
       if (isMove(action)) return this.onMove(action as Move);
       else if (isCreate(action)) return this.onCreate(action as Create);
       else if (isDelete(action)) return this.onDelete(action as Delete);
-      else if (isUpdate(action)) return this.onUpdate(action as Update);
+      else if (isReplace(action)) return this.onReplace(action as Replace);
     }
 
     private logSimpleAction(action: SimpleAction) {
       if (isMove(action)) this.logMove(action as Move);
       else if (isCreate(action)) this.logCreate(action as Create);
       else if (isDelete(action)) this.logDelete(action as Delete);
-      else if (isUpdate(action)) this.logUpdate(action as Update);
+      else if (isReplace(action)) this.logUpdate(action as Replace);
     }
 
     private onAction(event: EditorActionEvent<EditorAction>) {

--- a/src/editors/templates/foundation.ts
+++ b/src/editors/templates/foundation.ts
@@ -51,8 +51,8 @@ function containsCreateAction(actions: Create[], newAction: Create): boolean {
   return !actions.some(
     action =>
       action.new.parent === newAction.new.parent &&
-      action.new.element.getAttribute('id') ===
-        newAction.new.element.getAttribute('id')
+      (<Element>action.new.element).getAttribute('id') ===
+        (<Element>newAction.new.element).getAttribute('id')
   );
 }
 

--- a/src/foundation.ts
+++ b/src/foundation.ts
@@ -20,13 +20,13 @@ export type ComplexAction = {
 export type EditorAction = SimpleAction | ComplexAction;
 /** Inserts `new.element` to `new.parent` before `new.reference`. */
 export interface Create {
-  new: { parent: Element; element: Element; reference?: Node | null };
+  new: { parent: Node; element: Node; reference?: Node | null };
   derived?: boolean;
   checkValidity?: () => boolean;
 }
 /** Removes `old.element` from `old.parent` before `old.reference`. */
 export interface Delete {
-  old: { parent: Element; element: Element; reference?: Node | null };
+  old: { parent: Node; element: Node; reference?: Node | null };
   derived?: boolean;
   checkValidity?: () => boolean;
 }

--- a/src/foundation.ts
+++ b/src/foundation.ts
@@ -10,7 +10,7 @@ import { WizardTextField } from './wizard-textfield.js';
 import { WizardSelect } from './wizard-select.js';
 import { WizardCheckbox } from './wizard-checkbox.js';
 
-export type SimpleAction = Create | Replace | Delete | Move;
+export type SimpleAction = Update | Create | Replace | Delete | Move;
 export type ComplexAction = {
   actions: SimpleAction[];
   title: string;
@@ -44,6 +44,14 @@ export interface Replace {
   derived?: boolean;
   checkValidity?: () => boolean;
 }
+/** Swaps `element`s `oldAttributes` with `newAttributes` */
+export interface Update {
+  element: Element;
+  oldAttributes: Record<string, string | null>;
+  newAttributes: Record<string, string | null>;
+  derived?: boolean;
+  checkValidity?: () => boolean;
+}
 
 export function isCreate(action: EditorAction): action is Create {
   return (
@@ -73,6 +81,15 @@ export function isReplace(action: EditorAction): action is Replace {
     (action as Replace).old?.element !== undefined &&
     (action as Move).new?.parent === undefined &&
     (action as Replace).new?.element !== undefined
+  );
+}
+export function isUpdate(action: EditorAction): action is Update {
+  return (
+    (action as Replace).old === undefined &&
+    (action as Replace).new === undefined &&
+    (action as Update).element !== undefined &&
+    (action as Update).newAttributes !== undefined &&
+    (action as Update).oldAttributes !== undefined
   );
 }
 export function isSimple(action: EditorAction): action is SimpleAction {
@@ -111,7 +128,26 @@ export function invert(action: EditorAction): EditorAction {
     };
   else if (isReplace(action))
     return { new: action.old, old: action.new, ...metaData };
+  else if (isUpdate(action))
+    return {
+      element: action.element,
+      oldAttributes: action.newAttributes,
+      newAttributes: action.oldAttributes,
+      ...metaData,
+    };
   else return unreachable('Unknown EditorAction type in invert.');
+}
+//** return `Update` action for `element` adding `oldAttributes` */
+export function createUpdateAction(
+  element: Element,
+  newAttributes: Record<string, string | null>
+): Update {
+  const oldAttributes: Record<string, string | null> = {};
+  Array.from(element.attributes).forEach(attr => {
+    oldAttributes[attr.name] = attr.value;
+  });
+
+  return { element, oldAttributes, newAttributes };
 }
 
 /** Represents some intended modification of a `Document` being edited. */

--- a/src/foundation.ts
+++ b/src/foundation.ts
@@ -10,7 +10,7 @@ import { WizardTextField } from './wizard-textfield.js';
 import { WizardSelect } from './wizard-select.js';
 import { WizardCheckbox } from './wizard-checkbox.js';
 
-export type SimpleAction = Create | Update | Delete | Move;
+export type SimpleAction = Create | Replace | Delete | Move;
 export type ComplexAction = {
   actions: SimpleAction[];
   title: string;
@@ -38,7 +38,7 @@ export interface Move {
   checkValidity?: () => boolean;
 }
 /** Replaces `old.element` with `new.element`, keeping element children. */
-export interface Update {
+export interface Replace {
   old: { element: Element };
   new: { element: Element };
   derived?: boolean;
@@ -47,7 +47,7 @@ export interface Update {
 
 export function isCreate(action: EditorAction): action is Create {
   return (
-    (action as Update).old === undefined &&
+    (action as Replace).old === undefined &&
     (action as Create).new?.parent !== undefined &&
     (action as Create).new?.element !== undefined
   );
@@ -56,7 +56,7 @@ export function isDelete(action: EditorAction): action is Delete {
   return (
     (action as Delete).old?.parent !== undefined &&
     (action as Delete).old?.element !== undefined &&
-    (action as Update).new === undefined
+    (action as Replace).new === undefined
   );
 }
 export function isMove(action: EditorAction): action is Move {
@@ -64,15 +64,15 @@ export function isMove(action: EditorAction): action is Move {
     (action as Move).old?.parent !== undefined &&
     (action as Move).old?.element !== undefined &&
     (action as Move).new?.parent !== undefined &&
-    (action as Update).new?.element == undefined
+    (action as Replace).new?.element == undefined
   );
 }
-export function isUpdate(action: EditorAction): action is Update {
+export function isReplace(action: EditorAction): action is Replace {
   return (
     (action as Move).old?.parent === undefined &&
-    (action as Update).old?.element !== undefined &&
+    (action as Replace).old?.element !== undefined &&
     (action as Move).new?.parent === undefined &&
-    (action as Update).new?.element !== undefined
+    (action as Replace).new?.element !== undefined
   );
 }
 export function isSimple(action: EditorAction): action is SimpleAction {
@@ -109,7 +109,7 @@ export function invert(action: EditorAction): EditorAction {
       new: { parent: action.old.parent, reference: action.old.reference },
       ...metaData,
     };
-  else if (isUpdate(action))
+  else if (isReplace(action))
     return { new: action.old, old: action.new, ...metaData };
   else return unreachable('Unknown EditorAction type in invert.');
 }

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -87,6 +87,7 @@ export const de: Translations = {
     smvcontrol: 'Sampled Values anzeigen',
   },
   editing: {
+    node: 'Benutzerdefiniertes Objekt',
     created: '{{ name }} hinzugefügt',
     deleted: '{{ name }} entfernt',
     moved: '{{ name }} verschoben',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -85,6 +85,7 @@ export const en = {
     smvcontrol: 'Show all Sampled Values',
   },
   editing: {
+    node: 'User defined object',
     created: 'Added {{ name }}',
     deleted: 'Removed {{ name }}',
     moved: 'Moved {{ name }}',

--- a/src/wizards/address.ts
+++ b/src/wizards/address.ts
@@ -92,7 +92,7 @@ export function updateAddress(
   const oldAddress = parent.querySelector('Address');
 
   if (oldAddress !== null && !isEqualAddress(oldAddress, newAddress)) {
-    // We cannot use updateAction on address as both address child elements P are changed
+    //address & child elements P are changed: cannot use replace editor action
     actions.push({
       old: {
         parent: parent,

--- a/src/wizards/connectedap.ts
+++ b/src/wizards/connectedap.ts
@@ -179,7 +179,7 @@ function updateConnectedApAction(parent: Element): WizardActor {
       }),
     };
     if (oldAddress !== null && !isEqualAddress(oldAddress, newAddress)) {
-      // We cannot use updateAction on address as both address child elements P are changed
+      //address & child elements P are changed: cannot use replace editor action
       complexAction.actions.push({
         old: {
           parent,

--- a/src/wizards/dataset.ts
+++ b/src/wizards/dataset.ts
@@ -13,7 +13,7 @@ import {
   identity,
   newSubWizardEvent,
   selector,
-  Update,
+  Replace,
   Wizard,
   WizardAction,
   WizardActor,
@@ -27,7 +27,7 @@ function updateDataSetAction(element: Element): WizardActor {
     const desc = getValue(inputs.find(i => i.label === 'desc')!);
     const oldName = element.getAttribute('name');
 
-    const dataSetUpdateAction: Update[] = [];
+    const dataSetUpdateAction: Replace[] = [];
     if (!(name === oldName && desc === element.getAttribute('desc'))) {
       const newElement = cloneElement(element, { name, desc });
 

--- a/test/integration/Editing.test.ts
+++ b/test/integration/Editing.test.ts
@@ -3,7 +3,11 @@ import { expect, fixture, html } from '@open-wc/testing';
 import '../mock-editor-logger.js';
 import { MockEditorLogger } from '../mock-editor-logger.js';
 
-import { newActionEvent } from '../../src/foundation.js';
+import {
+  createUpdateAction,
+  newActionEvent,
+  Update,
+} from '../../src/foundation.js';
 
 describe('Editing-Logging integration', () => {
   let elm: MockEditorLogger;
@@ -22,68 +26,252 @@ describe('Editing-Logging integration', () => {
     element = parent.querySelector('Bay[name="Q01"]')!;
   });
 
-  it('add valid reference onCreate when reference is missing', () => {
-    const newElement = elm.doc!.createElement('Bay');
-    newElement?.setAttribute('name', 'Q03');
+  describe('has a Create EditorAction type that', () => {
+    let newElement: Element;
+    beforeEach(() => {
+      newElement = elm.doc!.createElement('Bay');
+      newElement?.setAttribute('name', 'Q03');
+    });
 
-    elm.dispatchEvent(
-      newActionEvent({
-        new: {
-          parent,
-          element: newElement,
-        },
-      })
-    );
-    expect(parent.querySelector('Bay[name="Q03"]')).to.not.be.null;
-    elm.undo();
-    expect(parent.querySelector('Bay[name="Q03"]')).to.be.null;
-    elm.redo();
-    expect(parent.querySelector('Bay[name="Q03"]')).to.not.be.null;
-    expect(
-      parent.querySelector('Bay[name="Q03"]')?.nextElementSibling
-    ).to.equal(parent.querySelector('Bay[name="Q01"]'));
+    it('can be undone', () => {
+      elm.dispatchEvent(
+        newActionEvent({ new: { parent, element: newElement } })
+      );
+      expect(newElement.parentElement).to.equal(parent);
+
+      elm.undo();
+      expect(newElement.parentElement).to.be.null;
+    });
+
+    it('can be redone', () => {
+      elm.dispatchEvent(
+        newActionEvent({ new: { parent, element: newElement } })
+      );
+
+      elm.undo();
+
+      elm.redo();
+      expect(newElement.parentElement).to.equal(parent);
+    });
+
+    it('automatically assignes a missing reference on redo', () => {
+      elm.dispatchEvent(
+        newActionEvent({ new: { parent, element: newElement } })
+      );
+      elm.undo();
+
+      elm.redo();
+      expect(
+        parent.querySelector('Bay[name="Q03"]')?.nextElementSibling
+      ).to.equal(parent.querySelector('Bay[name="Q01"]'));
+    });
+
+    it('properly uses the reference on redo', () => {
+      const newElement = elm.doc!.createElement('Bay');
+      newElement?.setAttribute('name', 'Q03');
+
+      elm.dispatchEvent(
+        newActionEvent({
+          new: {
+            parent,
+            element: newElement,
+            reference: parent.lastChild,
+          },
+        })
+      );
+
+      elm.undo();
+
+      elm.redo();
+
+      expect(parent.querySelector('Bay[name="Q03"]')?.nextSibling).to.equal(
+        parent.lastChild
+      );
+    });
   });
 
-  it('add valid reference onDelete when reference is missing', () => {
-    elm.dispatchEvent(
-      newActionEvent({
-        old: {
-          parent,
-          element,
-        },
-      })
-    );
-    expect(parent.querySelector('Bay[name="Q01"]')).to.be.null;
-    elm.undo();
-    expect(parent.querySelector('Bay[name="Q01"]')).to.not.be.null;
-    expect(
-      parent.querySelector('Bay[name="Q01"]')?.nextElementSibling
-    ).to.equal(parent.querySelector('Bay[name="Q02"]'));
+  describe('has a Delete EditorAction type that', () => {
+    it('can be ondone', () => {
+      expect(element.parentElement).to.equal(parent);
+
+      elm.dispatchEvent(
+        newActionEvent({
+          old: {
+            parent,
+            element,
+          },
+        })
+      );
+      expect(element.parentElement).to.be.null;
+
+      elm.undo();
+      expect(element.parentElement).to.equal(parent);
+    });
+
+    it('can be rodone', () => {
+      elm.dispatchEvent(
+        newActionEvent({
+          old: {
+            parent,
+            element,
+          },
+        })
+      );
+
+      elm.undo();
+
+      elm.redo();
+      expect(element.parentElement).to.be.null;
+    });
+
+    it('puts the deleted Node back to its original position on undo', () => {
+      const originalNextSibling = element.nextSibling;
+
+      elm.dispatchEvent(
+        newActionEvent({
+          old: {
+            parent,
+            element,
+          },
+        })
+      );
+      elm.undo();
+
+      expect(element.nextSibling).to.equal(originalNextSibling);
+    });
   });
 
-  it('add valid reference onMove when reference is missing', () => {
-    elm.dispatchEvent(
-      newActionEvent({
-        old: {
-          parent,
-          element,
-        },
-        new: {
-          parent: elm.doc!.querySelector('VoltageLevel[name="J1"]')!,
-        },
-      })
-    );
-    expect(parent.querySelector('Bay[name="Q01"]')).to.be.null;
-    expect(elm.doc!.querySelector('VoltageLevel[name="J1"] > Bay[name="Q01"]'))
-      .to.not.be.null;
-    elm.undo();
-    expect(
-      parent.querySelector('Bay[name="Q01"]')?.nextElementSibling
-    ).to.equal(parent.querySelector('Bay[name="Q02"]'));
-    elm.redo();
-    expect(
-      elm.doc!.querySelector('VoltageLevel[name="J1"] > Bay[name="Q01"]')
-        ?.nextElementSibling
-    ).to.equal(elm.doc!.querySelector('VoltageLevel[name="J1"] > Function'));
+  describe('has a Move EditorAction type that', () => {
+    let newParent: Element;
+    beforeEach(() => {
+      newParent = elm.doc!.querySelector('VoltageLevel[name="J1"]')!;
+    });
+
+    it('can be undone', () => {
+      expect(element.parentElement).to.equal(parent);
+
+      elm.dispatchEvent(
+        newActionEvent({ old: { parent, element }, new: { parent: newParent } })
+      );
+      expect(element.parentElement).to.equal(newParent);
+
+      elm.undo();
+      expect(element.parentElement).to.equal(parent);
+    });
+
+    it('can be redone', () => {
+      elm.dispatchEvent(
+        newActionEvent({ old: { parent, element }, new: { parent: newParent } })
+      );
+
+      elm.undo();
+
+      elm.redo();
+      expect(element.parentElement).to.equal(newParent);
+    });
+
+    it('adds the element in a valid location in the new parent', () => {
+      elm.dispatchEvent(
+        newActionEvent({ old: { parent, element }, new: { parent: newParent } })
+      );
+      expect(
+        elm.doc!.querySelector('VoltageLevel[name="J1"] > Bay[name="Q01"]')
+          ?.nextElementSibling
+      ).to.equal(elm.doc!.querySelector('VoltageLevel[name="J1"] > Function'));
+    });
+
+    it('puts the element back to its original postition with parent', () => {
+      elm.dispatchEvent(
+        newActionEvent({ old: { parent, element }, new: { parent: newParent } })
+      );
+
+      elm.undo();
+      expect(
+        parent.querySelector('Bay[name="Q01"]')?.nextElementSibling
+      ).to.equal(parent.querySelector('Bay[name="Q02"]'));
+    });
+  });
+
+  describe('has a Replace EditorAction type that', () => {
+    let newElement: Element;
+    beforeEach(() => {
+      newElement = elm.doc!.createElement('Bay');
+      newElement?.setAttribute('name', 'Q03');
+    });
+
+    it('can be undone', () => {
+      elm.dispatchEvent(
+        newActionEvent({ old: { element }, new: { element: newElement } })
+      );
+
+      elm.undo();
+      expect(newElement.parentElement).to.be.null;
+      expect(element.parentElement).to.equal(parent);
+    });
+
+    it('can be redone', () => {
+      elm.dispatchEvent(
+        newActionEvent({ old: { element }, new: { element: newElement } })
+      );
+
+      elm.undo();
+
+      elm.redo();
+
+      expect(newElement.parentElement).to.equal(parent);
+      expect(element.parentElement).to.be.null;
+    });
+
+    it('correctly copying child elements between element and newElement for multiple undo/redo', () => {
+      const originOldChildCount = element.children.length;
+      const originNewChildCount = newElement.children.length;
+
+      elm.dispatchEvent(
+        newActionEvent({ old: { element }, new: { element: newElement } })
+      );
+      expect(element.children).to.have.lengthOf(originNewChildCount);
+      expect(newElement.children).to.have.lengthOf(originOldChildCount);
+
+      elm.undo();
+      elm.redo();
+
+      elm.undo();
+      expect(element.children).to.have.lengthOf(originOldChildCount);
+      expect(newElement.children).to.have.lengthOf(originNewChildCount);
+
+      elm.redo();
+      expect(element.children).to.have.lengthOf(originNewChildCount);
+      expect(newElement.children).to.have.lengthOf(originOldChildCount);
+    });
+  });
+
+  describe('has an Update EditorAction type that', () => {
+    let updateAction: Update;
+    beforeEach(() => {
+      const newAttributes: Record<string, string | null> = {};
+      newAttributes['name'] = 'Q03';
+
+      updateAction = createUpdateAction(element, newAttributes);
+    });
+
+    it('can undo', () => {
+      elm.dispatchEvent(newActionEvent(updateAction));
+      expect(element).to.have.attribute('name', 'Q03');
+      expect(element).to.not.have.attribute('desc');
+
+      elm.undo();
+      expect(element).to.have.attribute('name', 'Q01');
+      expect(element).to.have.attribute('desc', 'Bay');
+    });
+
+    it('can redo', () => {
+      elm.dispatchEvent(newActionEvent(updateAction));
+
+      elm.undo();
+      elm.redo();
+
+      expect(element).to.have.attribute('name', 'Q03');
+      expect(element).to.not.have.attribute('desc');
+    });
   });
 });

--- a/test/unit/Editing.test.ts
+++ b/test/unit/Editing.test.ts
@@ -163,7 +163,7 @@ describe('EditingElement', () => {
     expect(testNode.parentNode).to.null;
   });
 
-  it('updates an element on receiving an Update action', () => {
+  it('replaces an element on receiving an Delete action', () => {
     elm.dispatchEvent(
       newActionEvent({
         old: {
@@ -181,7 +181,7 @@ describe('EditingElement', () => {
     );
   });
 
-  it('does not update an element with name conflict', () => {
+  it('does not replace an element with name conflict', () => {
     const newElement = elm.doc!.createElement('Bay');
     newElement?.setAttribute('name', 'Q02');
 

--- a/test/unit/Editing.test.ts
+++ b/test/unit/Editing.test.ts
@@ -37,6 +37,35 @@ describe('EditingElement', () => {
     expect(elm.doc!.querySelector('newBay')).to.not.be.null;
   });
 
+  it('creates an Node on receiving a Create Action', () => {
+    const testNode = document.createTextNode('myTestNode');
+
+    elm.dispatchEvent(
+      newActionEvent({
+        new: {
+          parent,
+          element: testNode,
+        },
+      })
+    );
+    expect(parent.lastChild).to.equal(testNode);
+  });
+
+  it('creates the Node based on the reference definition', () => {
+    const testNode = document.createTextNode('myTestNode');
+
+    elm.dispatchEvent(
+      newActionEvent({
+        new: {
+          parent,
+          element: testNode,
+          reference: parent.firstChild,
+        },
+      })
+    );
+    expect(parent.firstChild).to.equal(testNode);
+  });
+
   it('triggers getReference with missing reference on Create Action', () => {
     elm.dispatchEvent(
       newActionEvent({
@@ -97,6 +126,41 @@ describe('EditingElement', () => {
     );
     expect(elm.doc!.querySelector('VoltageLevel[name="E1"] > Bay[name="Q01"]'))
       .to.be.null;
+  });
+
+  it('deletes a Node on receiving a Delete action', () => {
+    const testNode = document.createTextNode('myTestNode');
+    parent.appendChild(testNode);
+    expect(testNode.parentNode).to.be.equal(parent);
+
+    elm.dispatchEvent(
+      newActionEvent({
+        old: {
+          parent,
+          element: testNode,
+        },
+      })
+    );
+
+    expect(parent.lastChild).to.not.equal(testNode);
+    expect(testNode.parentNode).to.be.null;
+  });
+
+  it('correctly handles incorrect delete action definition', () => {
+    const testNode = document.createTextNode('myTestNode');
+    expect(testNode.parentNode).to.null;
+
+    elm.dispatchEvent(
+      newActionEvent({
+        old: {
+          parent,
+          element: testNode,
+        },
+      })
+    );
+
+    expect(parent.lastChild).to.not.equal(testNode);
+    expect(testNode.parentNode).to.null;
   });
 
   it('updates an element on receiving an Update action', () => {

--- a/test/unit/Editing.test.ts
+++ b/test/unit/Editing.test.ts
@@ -3,7 +3,7 @@ import { html, fixture, expect } from '@open-wc/testing';
 import './mock-editor.js';
 import { MockEditor } from './mock-editor.js';
 
-import { newActionEvent } from '../../src/foundation.js';
+import { createUpdateAction, newActionEvent } from '../../src/foundation.js';
 
 describe('EditingElement', () => {
   let elm: MockEditor;
@@ -263,6 +263,32 @@ describe('EditingElement', () => {
       elm.doc!.querySelector('VoltageLevel[name="J1"] > Bay[name="Q01"]')
         ?.nextElementSibling
     ).to.be.null;
+  });
+
+  it('updates an element on receiving an Update action', () => {
+    const newAttributes: Record<string, string | null> = {};
+    newAttributes['name'] = 'Q03';
+
+    elm.dispatchEvent(
+      newActionEvent(createUpdateAction(element, newAttributes))
+    );
+
+    expect(element.parentElement).to.equal(parent);
+    expect(element).to.have.attribute('name', 'Q03');
+    expect(element).to.not.have.attribute('desc');
+  });
+
+  it('does not update an element with name conflict', () => {
+    const newAttributes: Record<string, string | null> = {};
+    newAttributes['name'] = 'Q02';
+
+    elm.dispatchEvent(
+      newActionEvent(createUpdateAction(element, newAttributes))
+    );
+
+    expect(element.parentElement).to.equal(parent);
+    expect(element).to.have.attribute('name', 'Q01');
+    expect(element).to.have.attribute('desc', 'Bay');
   });
 
   it('carries out subactions sequentially on receiving a ComplexAction', () => {

--- a/test/unit/editors/subscriberinfo.test.ts
+++ b/test/unit/editors/subscriberinfo.test.ts
@@ -21,60 +21,60 @@ describe('SubscriberInfo', () => {
 
     it('the first writes the correct IEDName element', () => {
       expect(actions[0]).to.satisfy(isCreate);
-      expect((<Create>actions[0]).new.element.getAttribute('apRef')).to.equal(
-        'P1'
-      );
-      expect((<Create>actions[0]).new.element.getAttribute('ldInst')).to.equal(
-        'CBSW'
-      );
-      expect((<Create>actions[0]).new.element.getAttribute('prefix')).to.equal(
-        ''
-      );
-      expect((<Create>actions[0]).new.element.getAttribute('lnClass')).to.equal(
-        'XSWI'
-      );
-      expect((<Create>actions[0]).new.element.getAttribute('lnInst')).to.equal(
-        '1'
-      );
-      expect((<Create>actions[0]).new.element.innerHTML).to.equal('IED2');
+      expect(
+        (<Element>(<Create>actions[0]).new.element).getAttribute('apRef')
+      ).to.equal('P1');
+      expect(
+        (<Element>(<Create>actions[0]).new.element).getAttribute('ldInst')
+      ).to.equal('CBSW');
+      expect(
+        (<Element>(<Create>actions[0]).new.element).getAttribute('prefix')
+      ).to.equal('');
+      expect(
+        (<Element>(<Create>actions[0]).new.element).getAttribute('lnClass')
+      ).to.equal('XSWI');
+      expect(
+        (<Element>(<Create>actions[0]).new.element).getAttribute('lnInst')
+      ).to.equal('1');
+      expect((<Create>actions[0]).new.element.textContent).to.equal('IED2');
     });
     it('the second writes the correct IEDName element', () => {
       expect(actions[1]).to.satisfy(isCreate);
-      expect((<Create>actions[1]).new.element.getAttribute('apRef')).to.equal(
-        'P1'
-      );
-      expect((<Create>actions[1]).new.element.getAttribute('ldInst')).to.equal(
-        'Disconnectors'
-      );
-      expect((<Create>actions[1]).new.element.getAttribute('prefix')).to.equal(
-        'DC'
-      );
-      expect((<Create>actions[1]).new.element.getAttribute('lnClass')).to.equal(
-        'CSWI'
-      );
-      expect((<Create>actions[1]).new.element.getAttribute('lnInst')).to.equal(
-        '1'
-      );
-      expect((<Create>actions[1]).new.element.innerHTML).to.equal('IED1');
+      expect(
+        (<Element>(<Create>actions[1]).new.element).getAttribute('apRef')
+      ).to.equal('P1');
+      expect(
+        (<Element>(<Create>actions[1]).new.element).getAttribute('ldInst')
+      ).to.equal('Disconnectors');
+      expect(
+        (<Element>(<Create>actions[1]).new.element).getAttribute('prefix')
+      ).to.equal('DC');
+      expect(
+        (<Element>(<Create>actions[1]).new.element).getAttribute('lnClass')
+      ).to.equal('CSWI');
+      expect(
+        (<Element>(<Create>actions[1]).new.element).getAttribute('lnInst')
+      ).to.equal('1');
+      expect((<Create>actions[1]).new.element.textContent).to.equal('IED1');
     });
     it('the third writes the correct IEDName element', () => {
       expect(actions[2]).to.satisfy(isCreate);
-      expect((<Create>actions[2]).new.element.getAttribute('apRef')).to.equal(
-        'P1'
-      );
-      expect((<Create>actions[2]).new.element.getAttribute('ldInst')).to.equal(
-        'Disconnectors'
-      );
-      expect((<Create>actions[2]).new.element.getAttribute('prefix')).to.equal(
-        ''
-      );
-      expect((<Create>actions[2]).new.element.getAttribute('lnClass')).to.equal(
-        'CSWI'
-      );
-      expect((<Create>actions[2]).new.element.getAttribute('lnInst')).to.equal(
-        '2'
-      );
-      expect((<Create>actions[2]).new.element.innerHTML).to.equal('IED1');
+      expect(
+        (<Element>(<Create>actions[2]).new.element).getAttribute('apRef')
+      ).to.equal('P1');
+      expect(
+        (<Element>(<Create>actions[2]).new.element).getAttribute('ldInst')
+      ).to.equal('Disconnectors');
+      expect(
+        (<Element>(<Create>actions[2]).new.element).getAttribute('prefix')
+      ).to.equal('');
+      expect(
+        (<Element>(<Create>actions[2]).new.element).getAttribute('lnClass')
+      ).to.equal('CSWI');
+      expect(
+        (<Element>(<Create>actions[2]).new.element).getAttribute('lnInst')
+      ).to.equal('2');
+      expect((<Create>actions[2]).new.element.textContent).to.equal('IED1');
     });
   });
 
@@ -95,21 +95,26 @@ describe('SubscriberInfo', () => {
 
     it('the first writing correct IEDName element', () => {
       expect(actions[0]).to.satisfy(isCreate);
-      expect((<Create>actions[0]).new.element.innerHTML).to.equal('IED1');
+      expect((<Create>actions[0]).new.element.textContent).to.equal('IED1');
     });
 
     it('the second writing correct IEDName element', () => {
       expect(actions[1]).to.satisfy(isCreate);
-      expect((<Create>actions[1]).new.element.innerHTML).to.equal('IED1');
+      expect((<Create>actions[1]).new.element.textContent).to.equal('IED1');
     });
 
     it('not writing Edition2 attributes into the IEDName element', () => {
       actions.forEach(action => {
-        expect((<Create>action).new.element.getAttribute('apRef')).to.be.null;
-        expect((<Create>action).new.element.getAttribute('ldInst')).to.be.null;
-        expect((<Create>action).new.element.getAttribute('prefix')).to.be.null;
-        expect((<Create>action).new.element.getAttribute('lnClass')).to.be.null;
-        expect((<Create>action).new.element.getAttribute('lnInst')).to.be.null;
+        expect((<Element>(<Create>action).new.element).getAttribute('apRef')).to
+          .be.null;
+        expect((<Element>(<Create>action).new.element).getAttribute('ldInst'))
+          .to.be.null;
+        expect((<Element>(<Create>action).new.element).getAttribute('prefix'))
+          .to.be.null;
+        expect((<Element>(<Create>action).new.element).getAttribute('lnClass'))
+          .to.be.null;
+        expect((<Element>(<Create>action).new.element).getAttribute('lnInst'))
+          .to.be.null;
       });
     });
   });

--- a/test/unit/foundation.test.ts
+++ b/test/unit/foundation.test.ts
@@ -13,7 +13,7 @@ import {
   isMove,
   isSame,
   isSimple,
-  isUpdate,
+  isReplace,
   newActionEvent,
   newPendingStateEvent,
   newWizardEvent,
@@ -65,8 +65,8 @@ describe('foundation', () => {
       expect(MockAction.cre).to.satisfy(isCreate);
       expect(MockAction.del).to.satisfy(isDelete);
       expect(MockAction.mov).to.satisfy(isMove);
-      expect(MockAction.upd).to.satisfy(isUpdate);
-
+      expect(MockAction.upd).to.satisfy(isReplace);
+      isReplace;
       expect(MockAction.cre).to.satisfy(isSimple);
       expect(MockAction.del).to.satisfy(isSimple);
       expect(MockAction.mov).to.satisfy(isSimple);
@@ -74,16 +74,16 @@ describe('foundation', () => {
 
       expect(MockAction.cre).to.not.satisfy(isDelete);
       expect(MockAction.cre).to.not.satisfy(isMove);
-      expect(MockAction.cre).to.not.satisfy(isUpdate);
-
+      expect(MockAction.cre).to.not.satisfy(isReplace);
+      isReplace;
       expect(MockAction.del).to.not.satisfy(isCreate);
       expect(MockAction.del).to.not.satisfy(isMove);
-      expect(MockAction.del).to.not.satisfy(isUpdate);
-
+      expect(MockAction.del).to.not.satisfy(isReplace);
+      isReplace;
       expect(MockAction.mov).to.not.satisfy(isCreate);
       expect(MockAction.mov).to.not.satisfy(isDelete);
-      expect(MockAction.mov).to.not.satisfy(isUpdate);
-
+      expect(MockAction.mov).to.not.satisfy(isReplace);
+      isReplace;
       expect(MockAction.upd).to.not.satisfy(isCreate);
       expect(MockAction.upd).to.not.satisfy(isDelete);
       expect(MockAction.upd).to.not.satisfy(isMove);
@@ -95,8 +95,9 @@ describe('foundation', () => {
       expect(MockAction.complex).to.not.satisfy(isCreate);
       expect(MockAction.complex).to.not.satisfy(isDelete);
       expect(MockAction.complex).to.not.satisfy(isMove);
-      expect(MockAction.complex).to.not.satisfy(isUpdate);
+      expect(MockAction.complex).to.not.satisfy(isReplace);
     });
+    isReplace;
 
     describe('invert', () => {
       it('turns Create into Delete and vice versa', () => {
@@ -109,8 +110,9 @@ describe('foundation', () => {
       });
 
       it('turns Update into Update', () => {
-        expect(invert(MockAction.upd)).to.satisfy(isUpdate);
+        expect(invert(MockAction.upd)).to.satisfy(isReplace);
       });
+      isReplace;
 
       it('inverts components of complex actions in reverse order', () => {
         const action = MockAction.complex;

--- a/test/unit/menu/UpdateDescriptionSEL.test.ts
+++ b/test/unit/menu/UpdateDescriptionSEL.test.ts
@@ -3,7 +3,7 @@ import { SinonSpy, spy } from 'sinon';
 
 import '../../../src/open-scd.js';
 import { OpenSCD } from '../../../src/open-scd.js';
-import { ComplexAction, isSimple, isUpdate } from '../../../src/foundation.js';
+import { ComplexAction, isSimple, isReplace } from '../../../src/foundation.js';
 import UpdateDescriptionSel from '../../../src/menu/UpdateDescriptionSEL.js';
 
 describe('Update method for desc attributes in SEL IEDs', () => {
@@ -101,7 +101,7 @@ describe('Update method for desc attributes in SEL IEDs', () => {
         );
         expect(complexAction.actions.length).to.equal(7);
         for (const action of complexAction.actions)
-          expect(action).to.satisfy(isUpdate);
+          expect(action).to.satisfy(isReplace);
       });
     });
 
@@ -132,7 +132,7 @@ describe('Update method for desc attributes in SEL IEDs', () => {
         );
         expect(complexAction.actions.length).to.equal(7);
         for (const action of complexAction.actions)
-          expect(action).to.satisfy(isUpdate);
+          expect(action).to.satisfy(isReplace);
       });
     });
   });

--- a/test/unit/menu/UpdateDescritionABB.test.ts
+++ b/test/unit/menu/UpdateDescritionABB.test.ts
@@ -4,7 +4,7 @@ import sinon, { SinonSpy } from 'sinon';
 import '../../mock-wizard.js';
 import { MockWizard } from '../../mock-wizard.js';
 
-import { ComplexAction, isSimple, isUpdate } from '../../../src/foundation.js';
+import { ComplexAction, isSimple, isReplace } from '../../../src/foundation.js';
 import UpdateDescriptionAbb from '../../../src/menu/UpdateDescriptionABB.js';
 
 describe('Update method for desc attributes in ABB IEDs', () => {
@@ -71,7 +71,7 @@ describe('Update method for desc attributes in ABB IEDs', () => {
       );
       expect(complexAction.actions.length).to.equal(2);
       for (const action of complexAction.actions)
-        expect(action).to.satisfy(isUpdate);
+        expect(action).to.satisfy(isReplace);
     });
   });
 });

--- a/test/unit/wizards/abstractda.test.ts
+++ b/test/unit/wizards/abstractda.test.ts
@@ -10,8 +10,8 @@ import {
   Create,
   isCreate,
   isDelete,
-  isUpdate,
-  Update,
+  isReplace,
+  Replace,
 } from '../../../src/foundation.js';
 import {
   getValAction,
@@ -32,11 +32,11 @@ describe('abstractda wizards', () => {
 
     it('updates a Val child element when changed', () => {
       const editorAction = getValAction(oldVal, 'newVal', abstractda);
-      expect(editorAction).to.satisfy(isUpdate);
+      expect(editorAction).to.satisfy(isReplace);
     });
 
     it('properly updates an new Val', () => {
-      const editorAction = <Update>getValAction(oldVal, 'newVal', abstractda);
+      const editorAction = <Replace>getValAction(oldVal, 'newVal', abstractda);
       expect(editorAction.new.element.textContent?.trim()).to.equal('newVal');
     });
 

--- a/test/unit/wizards/address.test.ts
+++ b/test/unit/wizards/address.test.ts
@@ -88,8 +88,8 @@ describe('address', () => {
           expect(actions.length).to.equal(2);
           expect(actions[0]).to.satisfy(isDelete);
           expect(actions[1]).to.satisfy(isCreate);
-          const oldElement = (<Delete>actions[0]).old.element;
-          const newElement = (<Create>actions[1]).new.element;
+          const oldElement = <Element>(<Delete>actions[0]).old.element;
+          const newElement = <Element>(<Create>actions[1]).new.element;
           expect(
             oldElement.querySelector(`P[type="${type}"]`)?.textContent?.trim()
           ).to.equal(oldValue);
@@ -118,8 +118,8 @@ describe('address', () => {
           expect(actions.length).to.equal(2);
           expect(actions[0]).to.satisfy(isDelete);
           expect(actions[1]).to.satisfy(isCreate);
-          const oldElement = (<Delete>actions[0]).old.element;
-          const newElement = (<Create>actions[1]).new.element;
+          const oldElement = <Element>(<Delete>actions[0]).old.element;
+          const newElement = <Element>(<Create>actions[1]).new.element;
           expect(
             oldElement.querySelector(`P[type="${type}"]`)?.textContent?.trim()
           ).to.equal(oldValue);
@@ -165,7 +165,7 @@ describe('address', () => {
           const actions = updateAddress(gse, inputs, false);
           expect(actions.length).to.equal(1);
           expect(actions[0]).to.satisfy(isCreate);
-          const newElement = (<Create>actions[0]).new.element;
+          const newElement = <Element>(<Create>actions[0]).new.element;
           expect(
             newElement.querySelector(`P[type="${type}"]`)?.textContent?.trim()
           ).to.equal(newValue);
@@ -189,7 +189,7 @@ describe('address', () => {
           const actions = updateAddress(gse, inputs, true);
           expect(actions.length).to.equal(1);
           expect(actions[0]).to.satisfy(isCreate);
-          const newElement = (<Create>actions[0]).new.element;
+          const newElement = <Element>(<Create>actions[0]).new.element;
           expect(
             newElement.querySelector(`P[type="${type}"]`)?.textContent?.trim()
           ).to.equal(newValue);

--- a/test/unit/wizards/bda.test.ts
+++ b/test/unit/wizards/bda.test.ts
@@ -8,8 +8,8 @@ import { WizardTextField } from '../../../src/wizard-textfield.js';
 import {
   Create,
   isCreate,
-  isUpdate,
-  Update,
+  isReplace,
+  Replace,
   Wizard,
   WizardInput,
 } from '../../../src/foundation.js';
@@ -80,7 +80,7 @@ describe('bda wizards', () => {
       await (<WizardTextField>inputs[0]).requestUpdate();
       const editorAction = updateBDaAction(bda);
       expect(editorAction(inputs, newWizard()).length).to.equal(1);
-      expect(editorAction(inputs, newWizard())[0]).to.satisfy(isUpdate);
+      expect(editorAction(inputs, newWizard())[0]).to.satisfy(isReplace);
     });
     it('update a BDA element when only desc attribute changed', async () => {
       const input = <WizardTextField>inputs[1];
@@ -89,22 +89,22 @@ describe('bda wizards', () => {
       await input.requestUpdate();
       const editorAction = updateBDaAction(bda);
       expect(editorAction(inputs, newWizard()).length).to.equal(1);
-      expect(editorAction(inputs, newWizard())[0]).to.satisfy(isUpdate);
+      expect(editorAction(inputs, newWizard())[0]).to.satisfy(isReplace);
     });
     it('update a BDA element when only bType attribute changed', async () => {
       inputs[2].value = 'BOOLEAN';
       await (<WizardSelect>inputs[2]).requestUpdate();
       const editorAction = updateBDaAction(bda);
       expect(editorAction(inputs, newWizard()).length).to.equal(1);
-      expect(editorAction(inputs, newWizard())[0]).to.satisfy(isUpdate);
+      expect(editorAction(inputs, newWizard())[0]).to.satisfy(isReplace);
     });
     it('update a BDA element when type attribute changed to null', async () => {
       inputs[2].value = 'BOOLEAN';
       await (<WizardSelect>inputs[2]).requestUpdate();
       const editorAction = updateBDaAction(bda);
       expect(editorAction(inputs, newWizard()).length).to.equal(1);
-      expect(editorAction(inputs, newWizard())[0]).to.satisfy(isUpdate);
-      const updateAction = <Update>editorAction(inputs, newWizard())[0];
+      expect(editorAction(inputs, newWizard())[0]).to.satisfy(isReplace);
+      const updateAction = <Replace>editorAction(inputs, newWizard())[0];
       expect(updateAction.old.element).to.have.attribute('type');
       expect(updateAction.new.element).to.not.have.attribute('type');
     });
@@ -116,8 +116,8 @@ describe('bda wizards', () => {
       const editorAction = updateBDaAction(bda);
       const updateActions = editorAction(inputs, newWizard());
       expect(updateActions.length).to.equal(1);
-      expect(updateActions[0]).to.satisfy(isUpdate);
-      const updateAction = <Update>updateActions[0];
+      expect(updateActions[0]).to.satisfy(isReplace);
+      const updateAction = <Replace>updateActions[0];
       expect(updateAction.old.element).to.not.have.attribute('sAddr');
       expect(updateAction.new.element).to.have.attribute('sAddr', 'mysAddr');
     });
@@ -129,8 +129,8 @@ describe('bda wizards', () => {
       const editorAction = updateBDaAction(bda);
       const updateActions = editorAction(inputs, newWizard());
       expect(updateActions.length).to.equal(1);
-      expect(updateActions[0]).to.satisfy(isUpdate);
-      const updateAction = <Update>updateActions[0];
+      expect(updateActions[0]).to.satisfy(isReplace);
+      const updateAction = <Replace>updateActions[0];
       expect(updateAction.old.element).to.not.have.attribute('valKind');
       expect(updateAction.new.element).to.have.attribute('valKind', 'RO');
     });
@@ -142,8 +142,8 @@ describe('bda wizards', () => {
       const editorAction = updateBDaAction(bda);
       const updateActions = editorAction(inputs, newWizard());
       expect(updateActions.length).to.equal(1);
-      expect(updateActions[0]).to.satisfy(isUpdate);
-      const updateAction = <Update>updateActions[0];
+      expect(updateActions[0]).to.satisfy(isReplace);
+      const updateAction = <Replace>updateActions[0];
       expect(updateAction.old.element).to.not.have.attribute('valImport');
       expect(updateAction.new.element).to.have.attribute('valImport', 'true');
     });

--- a/test/unit/wizards/bda.test.ts
+++ b/test/unit/wizards/bda.test.ts
@@ -158,7 +158,9 @@ describe('bda wizards', () => {
       expect(updateActions[0]).to.satisfy(isCreate);
       const updateAction = <Create>updateActions[0];
       expect(
-        updateAction.new.element.querySelector('Val')?.textContent?.trim()
+        (<Element>updateAction.new.element)
+          .querySelector('Val')
+          ?.textContent?.trim()
       ).to.not.equal('bay-control');
     });
   });
@@ -279,7 +281,9 @@ describe('bda wizards', () => {
       expect(editorAction(inputs, newWizard())[0]).to.satisfy(isCreate);
       const createAction = <Create>editorAction(inputs, newWizard())[0];
       expect(
-        createAction.new.element.querySelector('Val')?.textContent?.trim()
+        (<Element>createAction.new.element)
+          .querySelector('Val')
+          ?.textContent?.trim()
       ).to.equal('8123');
     });
   });

--- a/test/unit/wizards/connectedap.test.ts
+++ b/test/unit/wizards/connectedap.test.ts
@@ -116,8 +116,12 @@ describe('Wizards for SCL element ConnectedAP', () => {
 
       const complexAction = <ComplexAction>actionEvent.args[0][0].detail.action;
 
-      const oldAddress = (<Delete>complexAction.actions[0]).old.element;
-      const newAddress = (<Create>complexAction.actions[1]).new.element;
+      const oldAddress = <Element>(
+        (<Delete>complexAction.actions[0]).old.element
+      );
+      const newAddress = <Element>(
+        (<Create>complexAction.actions[1]).new.element
+      );
 
       expect(
         oldAddress.querySelector<Element>('P[type="IP"]')?.textContent
@@ -138,8 +142,12 @@ describe('Wizards for SCL element ConnectedAP', () => {
 
       const complexAction = <ComplexAction>actionEvent.args[0][0].detail.action;
 
-      const oldAddress = (<Delete>complexAction.actions[0]).old.element;
-      const newAddress = (<Create>complexAction.actions[1]).new.element;
+      const oldAddress = <Element>(
+        (<Delete>complexAction.actions[0]).old.element
+      );
+      const newAddress = <Element>(
+        (<Create>complexAction.actions[1]).new.element
+      );
 
       const oldIP = oldAddress.querySelector<Element>('P[type="IP"]');
       const newIP = newAddress.querySelector<Element>('P[type="IP"]');

--- a/test/unit/wizards/da.test.ts
+++ b/test/unit/wizards/da.test.ts
@@ -9,8 +9,8 @@ import { WizardTextField } from '../../../src/wizard-textfield.js';
 import {
   Create,
   isCreate,
-  isUpdate,
-  Update,
+  isReplace,
+  Replace,
   Wizard,
   WizardInput,
 } from '../../../src/foundation.js';
@@ -87,7 +87,7 @@ describe('da wizards', () => {
       await (<WizardTextField>inputs[0]).requestUpdate();
       const editorAction = updateDaAction(da);
       expect(editorAction(inputs, newWizard()).length).to.equal(1);
-      expect(editorAction(inputs, newWizard())[0]).to.satisfy(isUpdate);
+      expect(editorAction(inputs, newWizard())[0]).to.satisfy(isReplace);
     });
     it('update a DA element when only desc attribute changed', async () => {
       const input = <WizardTextField>inputs[1];
@@ -96,22 +96,22 @@ describe('da wizards', () => {
       await input.requestUpdate();
       const editorAction = updateDaAction(da);
       expect(editorAction(inputs, newWizard()).length).to.equal(1);
-      expect(editorAction(inputs, newWizard())[0]).to.satisfy(isUpdate);
+      expect(editorAction(inputs, newWizard())[0]).to.satisfy(isReplace);
     });
     it('update a DA element when only bType attribute changed', async () => {
       inputs[2].value = 'BOOLEAN';
       await (<WizardSelect>inputs[2]).requestUpdate();
       const editorAction = updateDaAction(da);
       expect(editorAction(inputs, newWizard()).length).to.equal(1);
-      expect(editorAction(inputs, newWizard())[0]).to.satisfy(isUpdate);
+      expect(editorAction(inputs, newWizard())[0]).to.satisfy(isReplace);
     });
     it('update a DA element when type attribute changed to null', async () => {
       inputs[2].value = 'BOOLEAN';
       await (<WizardSelect>inputs[2]).requestUpdate();
       const editorAction = updateDaAction(da);
       expect(editorAction(inputs, newWizard()).length).to.equal(1);
-      expect(editorAction(inputs, newWizard())[0]).to.satisfy(isUpdate);
-      const updateAction = <Update>editorAction(inputs, newWizard())[0];
+      expect(editorAction(inputs, newWizard())[0]).to.satisfy(isReplace);
+      const updateAction = <Replace>editorAction(inputs, newWizard())[0];
       expect(updateAction.old.element).to.have.attribute('type');
       expect(updateAction.new.element).to.not.have.attribute('type');
     });
@@ -123,8 +123,8 @@ describe('da wizards', () => {
       const editorAction = updateDaAction(da);
       const updateActions = editorAction(inputs, newWizard());
       expect(updateActions.length).to.equal(1);
-      expect(updateActions[0]).to.satisfy(isUpdate);
-      const updateAction = <Update>updateActions[0];
+      expect(updateActions[0]).to.satisfy(isReplace);
+      const updateAction = <Replace>updateActions[0];
       expect(updateAction.old.element).to.not.have.attribute('sAddr');
       expect(updateAction.new.element).to.have.attribute('sAddr', 'mysAddr');
     });
@@ -136,8 +136,8 @@ describe('da wizards', () => {
       const editorAction = updateDaAction(da);
       const updateActions = editorAction(inputs, newWizard());
       expect(updateActions.length).to.equal(1);
-      expect(updateActions[0]).to.satisfy(isUpdate);
-      const updateAction = <Update>updateActions[0];
+      expect(updateActions[0]).to.satisfy(isReplace);
+      const updateAction = <Replace>updateActions[0];
       expect(updateAction.old.element).to.not.have.attribute('valKind');
       expect(updateAction.new.element).to.have.attribute('valKind', 'RO');
     });
@@ -149,8 +149,8 @@ describe('da wizards', () => {
       const editorAction = updateDaAction(da);
       const updateActions = editorAction(inputs, newWizard());
       expect(updateActions.length).to.equal(1);
-      expect(updateActions[0]).to.satisfy(isUpdate);
-      const updateAction = <Update>updateActions[0];
+      expect(updateActions[0]).to.satisfy(isReplace);
+      const updateAction = <Replace>updateActions[0];
       expect(updateAction.old.element).to.not.have.attribute('valImport');
       expect(updateAction.new.element).to.have.attribute('valImport', 'true');
     });
@@ -175,8 +175,8 @@ describe('da wizards', () => {
       const editorAction = updateDaAction(da);
       const updateActions = editorAction(inputs, newWizard());
       expect(updateActions.length).to.equal(1);
-      expect(updateActions[0]).to.satisfy(isUpdate);
-      const updateAction = <Update>updateActions[0];
+      expect(updateActions[0]).to.satisfy(isReplace);
+      const updateAction = <Replace>updateActions[0];
       expect(updateAction.old.element).to.have.attribute('fc', 'CF');
       expect(updateAction.new.element).to.have.attribute('fc', 'ST');
     });
@@ -188,8 +188,8 @@ describe('da wizards', () => {
       const editorAction = updateDaAction(da);
       const updateActions = editorAction(inputs, newWizard());
       expect(updateActions.length).to.equal(1);
-      expect(updateActions[0]).to.satisfy(isUpdate);
-      const updateAction = <Update>updateActions[0];
+      expect(updateActions[0]).to.satisfy(isReplace);
+      const updateAction = <Replace>updateActions[0];
       expect(updateAction.old.element).to.not.have.attribute('dchg');
       expect(updateAction.new.element).to.have.attribute('dchg', 'true');
     });
@@ -201,8 +201,8 @@ describe('da wizards', () => {
       const editorAction = updateDaAction(da);
       const updateActions = editorAction(inputs, newWizard());
       expect(updateActions.length).to.equal(1);
-      expect(updateActions[0]).to.satisfy(isUpdate);
-      const updateAction = <Update>updateActions[0];
+      expect(updateActions[0]).to.satisfy(isReplace);
+      const updateAction = <Replace>updateActions[0];
       expect(updateAction.old.element).to.not.have.attribute('qchg');
       expect(updateAction.new.element).to.have.attribute('qchg', 'true');
     });
@@ -214,8 +214,8 @@ describe('da wizards', () => {
       const editorAction = updateDaAction(da);
       const updateActions = editorAction(inputs, newWizard());
       expect(updateActions.length).to.equal(1);
-      expect(updateActions[0]).to.satisfy(isUpdate);
-      const updateAction = <Update>updateActions[0];
+      expect(updateActions[0]).to.satisfy(isReplace);
+      const updateAction = <Replace>updateActions[0];
       expect(updateAction.old.element).to.not.have.attribute('dupd');
       expect(updateAction.new.element).to.have.attribute('dupd', 'true');
     });

--- a/test/unit/wizards/da.test.ts
+++ b/test/unit/wizards/da.test.ts
@@ -165,7 +165,9 @@ describe('da wizards', () => {
       expect(updateActions[0]).to.satisfy(isCreate);
       const updateAction = <Create>updateActions[0];
       expect(
-        updateAction.new.element.querySelector('Val')?.textContent?.trim()
+        (<Element>updateAction.new.element)
+          .querySelector('Val')
+          ?.textContent?.trim()
       ).to.not.equal('direct-with-normal-security');
     });
     it('update a DA element when fc attribute changed', async () => {
@@ -359,7 +361,9 @@ describe('da wizards', () => {
       expect(editorAction(inputs, newWizard())[0]).to.satisfy(isCreate);
       const createAction = <Create>editorAction(inputs, newWizard())[0];
       expect(
-        createAction.new.element.querySelector('Val')?.textContent?.trim()
+        (<Element>createAction.new.element)
+          .querySelector('Val')
+          ?.textContent?.trim()
       ).to.equal('8123');
     });
   });

--- a/test/unit/wizards/dataset.test.ts
+++ b/test/unit/wizards/dataset.test.ts
@@ -9,8 +9,8 @@ import { WizardTextField } from '../../../src/wizard-textfield.js';
 import {
   Delete,
   isDelete,
-  isUpdate,
-  Update,
+  isReplace,
+  Replace,
   Wizard,
   WizardInput,
 } from '../../../src/foundation.js';
@@ -96,9 +96,9 @@ describe('dataset wizards', () => {
         expect(actionEvent).to.be.calledOnce;
 
         const action = actionEvent.args[0][0].detail.action;
-        expect(action).to.satisfy(isUpdate);
+        expect(action).to.satisfy(isReplace);
 
-        const updateAction = <Update>action;
+        const updateAction = <Replace>action;
         expect(updateAction.old.element).to.have.attribute('name', 'myDS');
         expect(updateAction.new.element).to.have.attribute(
           'name',
@@ -161,9 +161,9 @@ describe('dataset wizards', () => {
         expect(actionEvent).to.be.calledThrice;
 
         const action = actionEvent.args[0][0].detail.action;
-        expect(action).to.satisfy(isUpdate);
+        expect(action).to.satisfy(isReplace);
 
-        const updateAction = <Update>action;
+        const updateAction = <Replace>action;
         expect(updateAction.old.element).to.have.attribute(
           'name',
           'GooseDataSet1'
@@ -185,9 +185,9 @@ describe('dataset wizards', () => {
 
         for (let i = 1; i < actionEvent.args.length; i++) {
           const action = actionEvent.args[i][0].detail.action;
-          expect(action).to.satisfy(isUpdate);
+          expect(action).to.satisfy(isReplace);
 
-          const updateAction = <Update>action;
+          const updateAction = <Replace>action;
           expect(updateAction.old.element).to.have.attribute(
             'datSet',
             'GooseDataSet1'
@@ -210,9 +210,9 @@ describe('dataset wizards', () => {
         expect(actionEvent).to.be.calledOnce;
 
         const action = actionEvent.args[0][0].detail.action;
-        expect(action).to.satisfy(isUpdate);
+        expect(action).to.satisfy(isReplace);
 
-        const updateAction = <Update>action;
+        const updateAction = <Replace>action;
         expect(updateAction.old.element).to.not.have.attribute('desc');
         expect(updateAction.new.element).to.have.attribute('desc', 'myDesc');
       });

--- a/test/unit/wizards/foundation.ts
+++ b/test/unit/wizards/foundation.ts
@@ -1,7 +1,13 @@
-import {expect} from "@open-wc/testing";
+import { expect } from '@open-wc/testing';
 
-import {isUpdate, SimpleAction, Update, WizardActor, WizardInput} from "../../../src/foundation.js";
-import {WizardTextField} from "../../../src/wizard-textfield.js";
+import {
+  isReplace,
+  SimpleAction,
+  Replace,
+  WizardActor,
+  WizardInput,
+} from '../../../src/foundation.js';
+import { WizardTextField } from '../../../src/wizard-textfield.js';
 
 const noOp = () => {
   return;
@@ -12,7 +18,10 @@ export const newWizard = (done = noOp) => {
   return element;
 };
 
-export async function setWizardTextFieldValue(field: WizardTextField, value: string | null): Promise<void> {
+export async function setWizardTextFieldValue(
+  field: WizardTextField,
+  value: string | null
+): Promise<void> {
   if (field.nullSwitch && !field.nullSwitch.checked) {
     field.nullSwitch?.click();
   }
@@ -20,38 +29,64 @@ export async function setWizardTextFieldValue(field: WizardTextField, value: str
   await field.requestUpdate();
 }
 
-export function executeWizardUpdateAction(wizardActor: WizardActor, inputs: WizardInput[]): Update {
+export function executeWizardUpdateAction(
+  wizardActor: WizardActor,
+  inputs: WizardInput[]
+): Replace {
   const updateActions = wizardActor(inputs, newWizard());
   expect(updateActions.length).to.equal(1);
-  expect(updateActions[0]).to.satisfy(isUpdate);
-  return <Update>updateActions[0];
+  expect(updateActions[0]).to.satisfy(isReplace);
+  return <Replace>updateActions[0];
 }
 
-export function expectWizardNoUpdateAction(wizardActor: WizardActor, inputs: WizardInput[]): void {
+export function expectWizardNoUpdateAction(
+  wizardActor: WizardActor,
+  inputs: WizardInput[]
+): void {
   const updateActions = wizardActor(inputs, newWizard());
   expect(updateActions).to.be.empty;
 }
 
-export function expectUpdateAction(simpleAction: SimpleAction, tagName: string, attributeName: string,
-                                   oldValue: string | null, newValue: string | null) {
-  expect(simpleAction).to.satisfy(isUpdate);
+export function expectUpdateAction(
+  simpleAction: SimpleAction,
+  tagName: string,
+  attributeName: string,
+  oldValue: string | null,
+  newValue: string | null
+) {
+  expect(simpleAction).to.satisfy(isReplace);
 
-  expect((<Update>simpleAction).old.element.tagName).to.be.equal(tagName);
+  expect((<Replace>simpleAction).old.element.tagName).to.be.equal(tagName);
   if (oldValue === null) {
-    expect((<Update>simpleAction).old.element).to.not.have.attribute(attributeName);
+    expect((<Replace>simpleAction).old.element).to.not.have.attribute(
+      attributeName
+    );
   } else {
-    expect((<Update>simpleAction).old.element).to.have.attribute(attributeName, oldValue);
+    expect((<Replace>simpleAction).old.element).to.have.attribute(
+      attributeName,
+      oldValue
+    );
   }
 
-  expect((<Update>simpleAction).new.element.tagName).to.be.equal(tagName);
+  expect((<Replace>simpleAction).new.element.tagName).to.be.equal(tagName);
   if (newValue === null) {
-    expect((<Update>simpleAction).new.element).to.not.have.attribute(attributeName);
+    expect((<Replace>simpleAction).new.element).to.not.have.attribute(
+      attributeName
+    );
   } else {
-    expect((<Update>simpleAction).new.element).to.have.attribute(attributeName, newValue);
+    expect((<Replace>simpleAction).new.element).to.have.attribute(
+      attributeName,
+      newValue
+    );
   }
 }
 
-export function expectUpdateTextValue(action: Update, parentTagName: string, oldValue: string, newValue: string): void {
+export function expectUpdateTextValue(
+  action: Replace,
+  parentTagName: string,
+  oldValue: string,
+  newValue: string
+): void {
   expect(action.old.element.parentElement!.tagName).to.be.equal(parentTagName);
   expect(action.old.element.textContent).to.be.equal(oldValue);
   expect(action.new.element.textContent).to.be.equal(newValue);

--- a/test/unit/wizards/foundation/references.test.ts
+++ b/test/unit/wizards/foundation/references.test.ts
@@ -1,7 +1,11 @@
-import {expectUpdateAction, expectUpdateTextValue, fetchDoc} from "../foundation.js";
-import {updateReferences} from "../../../../src/wizards/foundation/references.js";
-import {expect} from "@open-wc/testing";
-import {Update} from "../../../../src/foundation.js";
+import {
+  expectUpdateAction,
+  expectUpdateTextValue,
+  fetchDoc,
+} from '../foundation.js';
+import { updateReferences } from '../../../../src/wizards/foundation/references.js';
+import { expect } from '@open-wc/testing';
+import { Replace } from '../../../../src/foundation.js';
 
 describe('Update reference for ', () => {
   let doc: XMLDocument;
@@ -12,31 +16,77 @@ describe('Update reference for ', () => {
     });
 
     it('will update all references to IED1', async function () {
-      const oldName = "IED1"
-      const newName = "NewIED1";
+      const oldName = 'IED1';
+      const newName = 'NewIED1';
       const ied = doc.querySelector(`IED[name="${oldName}"]`)!;
 
       const updateActions = updateReferences(ied, oldName, newName);
       expect(updateActions.length).to.equal(9);
 
-      expectUpdateAction(<Update>updateActions[0], 'Association', 'iedName', oldName, newName);
-      expectUpdateAction(<Update>updateActions[1], 'ClientLN', 'iedName', oldName, newName);
-      expectUpdateAction(<Update>updateActions[3], 'ConnectedAP', 'iedName', oldName, newName);
-      expectUpdateAction(<Update>updateActions[4], 'ExtRef', 'iedName', oldName, newName);
-      expectUpdateAction(<Update>updateActions[8], 'KDC', 'iedName', oldName, newName);
+      expectUpdateAction(
+        <Replace>updateActions[0],
+        'Association',
+        'iedName',
+        oldName,
+        newName
+      );
+      expectUpdateAction(
+        <Replace>updateActions[1],
+        'ClientLN',
+        'iedName',
+        oldName,
+        newName
+      );
+      expectUpdateAction(
+        <Replace>updateActions[3],
+        'ConnectedAP',
+        'iedName',
+        oldName,
+        newName
+      );
+      expectUpdateAction(
+        <Replace>updateActions[4],
+        'ExtRef',
+        'iedName',
+        oldName,
+        newName
+      );
+      expectUpdateAction(
+        <Replace>updateActions[8],
+        'KDC',
+        'iedName',
+        oldName,
+        newName
+      );
     });
 
     it('will update all references to IED2', async function () {
-      const oldName = "IED2"
-      const newName = "NewIED2";
+      const oldName = 'IED2';
+      const newName = 'NewIED2';
       const ied = doc.querySelector(`IED[name="${oldName}"]`)!;
 
       const updateActions = updateReferences(ied, oldName, newName);
       expect(updateActions.length).to.equal(8);
 
-      expectUpdateAction(<Update>updateActions[4], 'LNode', 'iedName', oldName, newName);
-      expectUpdateTextValue(<Update>updateActions[6], 'GSEControl', oldName, newName);
-      expectUpdateTextValue(<Update>updateActions[7], 'SampledValueControl', oldName, newName);
+      expectUpdateAction(
+        <Replace>updateActions[4],
+        'LNode',
+        'iedName',
+        oldName,
+        newName
+      );
+      expectUpdateTextValue(
+        <Replace>updateActions[6],
+        'GSEControl',
+        oldName,
+        newName
+      );
+      expectUpdateTextValue(
+        <Replace>updateActions[7],
+        'SampledValueControl',
+        oldName,
+        newName
+      );
     });
   });
 });

--- a/test/unit/wizards/gse.test.ts
+++ b/test/unit/wizards/gse.test.ts
@@ -90,8 +90,8 @@ describe('gse wizards', () => {
       expect(actions.length).to.equal(2);
       expect(actions[0]).to.satisfy(isDelete);
       expect(actions[1]).to.satisfy(isCreate);
-      const oldElement = (<Delete>actions[0]).old.element;
-      const newElement = (<Create>actions[1]).new.element;
+      const oldElement = <Element>(<Delete>actions[0]).old.element;
+      const newElement = <Element>(<Create>actions[1]).new.element;
       expect(
         oldElement.querySelector('P[type="MAC-Address"]')?.textContent?.trim()
       ).to.equal('01-0C-CD-01-00-10');
@@ -110,8 +110,8 @@ describe('gse wizards', () => {
       expect(actions.length).to.equal(2);
       expect(actions[0]).to.satisfy(isDelete);
       expect(actions[1]).to.satisfy(isCreate);
-      const oldElement = (<Delete>actions[0]).old.element;
-      const newElement = (<Create>actions[1]).new.element;
+      const oldElement = <Element>(<Delete>actions[0]).old.element;
+      const newElement = <Element>(<Create>actions[1]).new.element;
       expect(
         oldElement.querySelector('P[type="APPID"]')?.textContent?.trim()
       ).to.equal('0010');
@@ -130,8 +130,8 @@ describe('gse wizards', () => {
       expect(actions.length).to.equal(2);
       expect(actions[0]).to.satisfy(isDelete);
       expect(actions[1]).to.satisfy(isCreate);
-      const oldElement = (<Delete>actions[0]).old.element;
-      const newElement = (<Create>actions[1]).new.element;
+      const oldElement = <Element>(<Delete>actions[0]).old.element;
+      const newElement = <Element>(<Create>actions[1]).new.element;
       expect(
         oldElement.querySelector('P[type="VLAN-ID"]')?.textContent?.trim()
       ).to.equal('005');
@@ -150,8 +150,8 @@ describe('gse wizards', () => {
       expect(actions.length).to.equal(2);
       expect(actions[0]).to.satisfy(isDelete);
       expect(actions[1]).to.satisfy(isCreate);
-      const oldElement = (<Delete>actions[0]).old.element;
-      const newElement = (<Create>actions[1]).new.element;
+      const oldElement = <Element>(<Delete>actions[0]).old.element;
+      const newElement = <Element>(<Create>actions[1]).new.element;
       expect(
         oldElement.querySelector('P[type="VLAN-PRIORITY"]')?.textContent?.trim()
       ).to.equal('4');

--- a/test/unit/wizards/gse.test.ts
+++ b/test/unit/wizards/gse.test.ts
@@ -11,8 +11,8 @@ import {
   isCreate,
   isDelete,
   isSimple,
-  isUpdate,
-  Update,
+  isReplace,
+  Replace,
   Wizard,
   WizardInput,
 } from '../../../src/foundation.js';
@@ -168,8 +168,8 @@ describe('gse wizards', () => {
       expect(complexAction[0]).to.not.satisfy(isSimple);
       const actions = (<ComplexAction>complexAction[0]).actions;
       expect(actions.length).to.equal(1);
-      expect(actions[0]).to.satisfy(isUpdate);
-      const updateAction = <Update>actions[0];
+      expect(actions[0]).to.satisfy(isReplace);
+      const updateAction = <Replace>actions[0];
       expect(updateAction.old.element.textContent?.trim()).to.equal('10');
       expect(updateAction.new.element.textContent?.trim()).to.equal('15');
     });
@@ -182,8 +182,8 @@ describe('gse wizards', () => {
       expect(complexAction[0]).to.not.satisfy(isSimple);
       const actions = (<ComplexAction>complexAction[0]).actions;
       expect(actions.length).to.equal(1);
-      expect(actions[0]).to.satisfy(isUpdate);
-      const updateAction = <Update>actions[0];
+      expect(actions[0]).to.satisfy(isReplace);
+      const updateAction = <Replace>actions[0];
       expect(updateAction.old.element.textContent?.trim()).to.equal('10000');
       expect(updateAction.new.element.textContent?.trim()).to.equal('65');
     });
@@ -205,8 +205,8 @@ describe('gse wizards', () => {
 
     it('updates a MinTime child element when chenged', () => {
       const editorAction = getMTimeAction('MinTime', oldMinTime, '654', gse);
-      expect(editorAction).to.satisfy(isUpdate);
-      expect((<Update>editorAction).new.element.textContent?.trim()).to.equal(
+      expect(editorAction).to.satisfy(isReplace);
+      expect((<Replace>editorAction).new.element.textContent?.trim()).to.equal(
         '654'
       );
     });
@@ -229,8 +229,8 @@ describe('gse wizards', () => {
         '1234123',
         gse
       );
-      expect(editorAction).to.satisfy(isUpdate);
-      expect((<Update>editorAction).new.element.textContent?.trim()).to.equal(
+      expect(editorAction).to.satisfy(isReplace);
+      expect((<Replace>editorAction).new.element.textContent?.trim()).to.equal(
         '1234123'
       );
     });

--- a/test/unit/wizards/gsecontrol.test.ts
+++ b/test/unit/wizards/gsecontrol.test.ts
@@ -7,8 +7,8 @@ import { MockWizard } from '../../mock-wizard.js';
 import { WizardTextField } from '../../../src/wizard-textfield.js';
 import {
   isDelete,
-  isUpdate,
-  Update,
+  isReplace,
+  Replace,
   Wizard,
   WizardInput,
 } from '../../../src/foundation.js';
@@ -236,8 +236,8 @@ describe('gsecontrol wizards', () => {
       const editorAction = updateGseControlAction(gseControl);
       const updateActions = editorAction(inputs, newWizard());
       expect(updateActions.length).to.equal(1);
-      expect(updateActions[0]).to.satisfy(isUpdate);
-      const updateAction = <Update>updateActions[0];
+      expect(updateActions[0]).to.satisfy(isReplace);
+      const updateAction = <Replace>updateActions[0];
       expect(updateAction.old.element).to.have.attribute('name', 'myCbName');
       expect(updateAction.new.element).to.have.attribute('name', 'myNewCbName');
     });
@@ -249,8 +249,8 @@ describe('gsecontrol wizards', () => {
       const editorAction = updateGseControlAction(gseControl);
       const updateActions = editorAction(inputs, newWizard());
       expect(updateActions.length).to.equal(1);
-      expect(updateActions[0]).to.satisfy(isUpdate);
-      const updateAction = <Update>updateActions[0];
+      expect(updateActions[0]).to.satisfy(isReplace);
+      const updateAction = <Replace>updateActions[0];
       expect(updateAction.old.element).to.not.have.attribute('desc');
       expect(updateAction.new.element).to.have.attribute('desc', 'myDesc');
     });
@@ -261,8 +261,8 @@ describe('gsecontrol wizards', () => {
       const editorAction = updateGseControlAction(gseControl);
       const updateActions = editorAction(inputs, newWizard());
       expect(updateActions.length).to.equal(1);
-      expect(updateActions[0]).to.satisfy(isUpdate);
-      const updateAction = <Update>updateActions[0];
+      expect(updateActions[0]).to.satisfy(isReplace);
+      const updateAction = <Replace>updateActions[0];
       expect(updateAction.old.element).to.have.attribute('type', 'GOOSE');
       expect(updateAction.new.element).to.have.attribute('type', 'GSSE');
     });
@@ -273,8 +273,8 @@ describe('gsecontrol wizards', () => {
       const editorAction = updateGseControlAction(gseControl);
       const updateActions = editorAction(inputs, newWizard());
       expect(updateActions.length).to.equal(1);
-      expect(updateActions[0]).to.satisfy(isUpdate);
-      const updateAction = <Update>updateActions[0];
+      expect(updateActions[0]).to.satisfy(isReplace);
+      const updateAction = <Replace>updateActions[0];
       expect(updateAction.old.element).to.have.attribute('type', 'GOOSE');
       expect(updateAction.new.element).to.not.have.attribute('type');
     });
@@ -286,8 +286,8 @@ describe('gsecontrol wizards', () => {
       const editorAction = updateGseControlAction(gseControl);
       const updateActions = editorAction(inputs, newWizard());
       expect(updateActions.length).to.equal(1);
-      expect(updateActions[0]).to.satisfy(isUpdate);
-      const updateAction = <Update>updateActions[0];
+      expect(updateActions[0]).to.satisfy(isReplace);
+      const updateAction = <Replace>updateActions[0];
       expect(updateAction.old.element).to.have.attribute('appID', 'myAPP/ID');
       expect(updateAction.new.element).to.have.attribute(
         'appID',
@@ -302,8 +302,8 @@ describe('gsecontrol wizards', () => {
       const editorAction = updateGseControlAction(gseControl);
       const updateActions = editorAction(inputs, newWizard());
       expect(updateActions.length).to.equal(1);
-      expect(updateActions[0]).to.satisfy(isUpdate);
-      const updateAction = <Update>updateActions[0];
+      expect(updateActions[0]).to.satisfy(isReplace);
+      const updateAction = <Replace>updateActions[0];
       expect(updateAction.old.element).to.not.have.attribute('fixedOffs');
       expect(updateAction.new.element).to.have.attribute('fixedOffs', 'true');
     });
@@ -315,8 +315,8 @@ describe('gsecontrol wizards', () => {
       const editorAction = updateGseControlAction(gseControl);
       const updateActions = editorAction(inputs, newWizard());
       expect(updateActions.length).to.equal(1);
-      expect(updateActions[0]).to.satisfy(isUpdate);
-      const updateAction = <Update>updateActions[0];
+      expect(updateActions[0]).to.satisfy(isReplace);
+      const updateAction = <Replace>updateActions[0];
       expect(updateAction.old.element).to.not.have.attribute('securityEnabled');
       expect(updateAction.new.element).to.have.attribute(
         'securityEnabled',

--- a/test/unit/wizards/ied.test.ts
+++ b/test/unit/wizards/ied.test.ts
@@ -1,16 +1,21 @@
-import {expect, fixture, html} from '@open-wc/testing';
+import { expect, fixture, html } from '@open-wc/testing';
 
 import '../../mock-wizard.js';
-import {MockWizard} from '../../mock-wizard.js';
+import { MockWizard } from '../../mock-wizard.js';
 
-import {WizardTextField} from '../../../src/wizard-textfield.js';
-import {ComplexAction, isSimple, isUpdate, Update, WizardInput} from '../../../src/foundation.js';
-import {editIEDWizard, updateIED} from '../../../src/wizards/ied.js';
+import { WizardTextField } from '../../../src/wizard-textfield.js';
+import {
+  ComplexAction,
+  isSimple,
+  WizardInput,
+} from '../../../src/foundation.js';
+import { editIEDWizard, updateIED } from '../../../src/wizards/ied.js';
 
 import {
   expectUpdateAction,
   expectWizardNoUpdateAction,
-  fetchDoc, newWizard,
+  fetchDoc,
+  newWizard,
   setWizardTextFieldValue,
 } from './foundation.js';
 
@@ -42,7 +47,13 @@ describe('Wizards for SCL element IED', () => {
     expect(simpleActions.length).to.equal(2);
 
     expectUpdateAction(simpleActions[0], 'IED', 'name', 'IED3', 'OtherIED3');
-    expectUpdateAction(simpleActions[1], 'ConnectedAP', 'iedName', 'IED3', 'OtherIED3');
+    expectUpdateAction(
+      simpleActions[1],
+      'ConnectedAP',
+      'iedName',
+      'IED3',
+      'OtherIED3'
+    );
   });
 
   it('update name should be unique in document', async function () {
@@ -51,7 +62,10 @@ describe('Wizards for SCL element IED', () => {
   });
 
   it('update description should be updated in document', async function () {
-    await setWizardTextFieldValue(<WizardTextField>inputs[1], 'Some description');
+    await setWizardTextFieldValue(
+      <WizardTextField>inputs[1],
+      'Some description'
+    );
 
     const complexAction = updateIED(ied)(inputs, newWizard());
     expect(complexAction.length).to.equal(1);
@@ -60,7 +74,13 @@ describe('Wizards for SCL element IED', () => {
     const simpleActions = (<ComplexAction>complexAction[0]).actions;
     expect(simpleActions.length).to.equal(1);
 
-    expectUpdateAction(simpleActions[0], 'IED', 'desc', null, 'Some description');
+    expectUpdateAction(
+      simpleActions[0],
+      'IED',
+      'desc',
+      null,
+      'Some description'
+    );
   });
 
   it('when no fields changed there will be no update action', async function () {

--- a/test/unit/wizards/optfields.test.ts
+++ b/test/unit/wizards/optfields.test.ts
@@ -5,7 +5,7 @@ import '../../mock-wizard.js';
 import { MockWizard } from '../../mock-wizard.js';
 
 import { WizardSelect } from '../../../src/wizard-select.js';
-import { isUpdate, Update, WizardInput } from '../../../src/foundation.js';
+import { isReplace, Replace, WizardInput } from '../../../src/foundation.js';
 import { editOptFieldsWizard } from '../../../src/wizards/optfields.js';
 
 describe('Wizards for SCL OptFields element', () => {
@@ -66,9 +66,9 @@ describe('Wizards for SCL OptFields element', () => {
       expect(actionEvent).to.be.calledOnce;
 
       const action = actionEvent.args[0][0].detail.action;
-      expect(action).to.satisfy(isUpdate);
+      expect(action).to.satisfy(isReplace);
 
-      const updateAction = <Update>action;
+      const updateAction = <Replace>action;
       expect(updateAction.old.element).to.have.attribute('dataSet', 'true');
       expect(updateAction.new.element).to.have.attribute('dataSet', 'false');
     });
@@ -83,9 +83,9 @@ describe('Wizards for SCL OptFields element', () => {
       expect(actionEvent).to.be.calledOnce;
 
       const action = actionEvent.args[0][0].detail.action;
-      expect(action).to.satisfy(isUpdate);
+      expect(action).to.satisfy(isReplace);
 
-      const updateAction = <Update>action;
+      const updateAction = <Replace>action;
       expect(updateAction.old.element).to.have.attribute('dataSet', 'true');
       expect(updateAction.new.element).to.not.have.attribute('dataSet');
     });
@@ -101,9 +101,9 @@ describe('Wizards for SCL OptFields element', () => {
       expect(actionEvent).to.be.calledOnce;
 
       const action = actionEvent.args[0][0].detail.action;
-      expect(action).to.satisfy(isUpdate);
+      expect(action).to.satisfy(isReplace);
 
-      const updateAction = <Update>action;
+      const updateAction = <Replace>action;
       expect(updateAction.old.element).to.not.have.attribute('seqNum');
       expect(updateAction.new.element).to.have.attribute('seqNum', 'true');
     });
@@ -119,9 +119,9 @@ describe('Wizards for SCL OptFields element', () => {
       expect(actionEvent).to.be.calledOnce;
 
       const action = actionEvent.args[0][0].detail.action;
-      expect(action).to.satisfy(isUpdate);
+      expect(action).to.satisfy(isReplace);
 
-      const updateAction = <Update>action;
+      const updateAction = <Replace>action;
       expect(updateAction.old.element).to.not.have.attribute('timeStamp');
       expect(updateAction.new.element).to.have.attribute('timeStamp', 'true');
     });
@@ -137,9 +137,9 @@ describe('Wizards for SCL OptFields element', () => {
       expect(actionEvent).to.be.calledOnce;
 
       const action = actionEvent.args[0][0].detail.action;
-      expect(action).to.satisfy(isUpdate);
+      expect(action).to.satisfy(isReplace);
 
-      const updateAction = <Update>action;
+      const updateAction = <Replace>action;
       expect(updateAction.old.element).to.not.have.attribute('reasonCode');
       expect(updateAction.new.element).to.have.attribute('reasonCode', 'true');
     });
@@ -155,9 +155,9 @@ describe('Wizards for SCL OptFields element', () => {
       expect(actionEvent).to.be.calledOnce;
 
       const action = actionEvent.args[0][0].detail.action;
-      expect(action).to.satisfy(isUpdate);
+      expect(action).to.satisfy(isReplace);
 
-      const updateAction = <Update>action;
+      const updateAction = <Replace>action;
       expect(updateAction.old.element).to.not.have.attribute('dataRef');
       expect(updateAction.new.element).to.have.attribute('dataRef', 'true');
     });
@@ -173,9 +173,9 @@ describe('Wizards for SCL OptFields element', () => {
       expect(actionEvent).to.be.calledOnce;
 
       const action = actionEvent.args[0][0].detail.action;
-      expect(action).to.satisfy(isUpdate);
+      expect(action).to.satisfy(isReplace);
 
-      const updateAction = <Update>action;
+      const updateAction = <Replace>action;
       expect(updateAction.old.element).to.not.have.attribute('entryID');
       expect(updateAction.new.element).to.have.attribute('entryID', 'true');
     });
@@ -191,9 +191,9 @@ describe('Wizards for SCL OptFields element', () => {
       expect(actionEvent).to.be.calledOnce;
 
       const action = actionEvent.args[0][0].detail.action;
-      expect(action).to.satisfy(isUpdate);
+      expect(action).to.satisfy(isReplace);
 
-      const updateAction = <Update>action;
+      const updateAction = <Replace>action;
       expect(updateAction.old.element).to.not.have.attribute('configRef');
       expect(updateAction.new.element).to.have.attribute('configRef', 'true');
     });
@@ -208,9 +208,9 @@ describe('Wizards for SCL OptFields element', () => {
       expect(actionEvent).to.be.calledOnce;
 
       const action = actionEvent.args[0][0].detail.action;
-      expect(action).to.satisfy(isUpdate);
+      expect(action).to.satisfy(isReplace);
 
-      const updateAction = <Update>action;
+      const updateAction = <Replace>action;
       expect(updateAction.old.element).to.have.attribute('bufOvfl', 'true');
       expect(updateAction.new.element).to.have.attribute('bufOvfl', 'false');
     });

--- a/test/unit/wizards/reportcontrol.test.ts
+++ b/test/unit/wizards/reportcontrol.test.ts
@@ -8,8 +8,8 @@ import { MockWizard } from '../../mock-wizard.js';
 import {
   isCreate,
   isDelete,
-  isUpdate,
-  Update,
+  isReplace,
+  Replace,
   WizardInput,
 } from '../../../src/foundation.js';
 import { WizardTextField } from '../../../src/wizard-textfield.js';
@@ -152,9 +152,9 @@ describe('Wizards for SCL ReportControl element', () => {
       expect(actionEvent).to.be.calledOnce;
 
       const action = actionEvent.args[0][0].detail.action;
-      expect(action).to.satisfy(isUpdate);
+      expect(action).to.satisfy(isReplace);
 
-      const updateAction = <Update>action;
+      const updateAction = <Replace>action;
       expect(updateAction.old.element).to.have.attribute('name', 'ReportCb');
       expect(updateAction.new.element).to.have.attribute('name', 'myNewCbName');
     });
@@ -170,9 +170,9 @@ describe('Wizards for SCL ReportControl element', () => {
       expect(actionEvent).to.be.calledOnce;
 
       const action = actionEvent.args[0][0].detail.action;
-      expect(action).to.satisfy(isUpdate);
+      expect(action).to.satisfy(isReplace);
 
-      const updateAction = <Update>action;
+      const updateAction = <Replace>action;
       expect(updateAction.old.element).to.not.have.attribute('desc');
       expect(updateAction.new.element).to.have.attribute('desc', 'myDesc');
     });
@@ -187,9 +187,9 @@ describe('Wizards for SCL ReportControl element', () => {
       expect(actionEvent).to.be.calledOnce;
 
       const action = actionEvent.args[0][0].detail.action;
-      expect(action).to.satisfy(isUpdate);
+      expect(action).to.satisfy(isReplace);
 
-      const updateAction = <Update>action;
+      const updateAction = <Replace>action;
       expect(updateAction.old.element).to.have.attribute('rptID', 'reportCb1');
       expect(updateAction.new.element).to.have.attribute(
         'rptID',
@@ -207,9 +207,9 @@ describe('Wizards for SCL ReportControl element', () => {
       expect(actionEvent).to.be.calledOnce;
 
       const action = actionEvent.args[0][0].detail.action;
-      expect(action).to.satisfy(isUpdate);
+      expect(action).to.satisfy(isReplace);
 
-      const updateAction = <Update>action;
+      const updateAction = <Replace>action;
       expect(updateAction.old.element).to.have.attribute('indexed', 'true');
       expect(updateAction.new.element).to.have.attribute('indexed', 'false');
     });
@@ -224,9 +224,9 @@ describe('Wizards for SCL ReportControl element', () => {
       expect(actionEvent).to.be.calledOnce;
 
       const action = actionEvent.args[0][0].detail.action;
-      expect(action).to.satisfy(isUpdate);
+      expect(action).to.satisfy(isReplace);
 
-      const updateAction = <Update>action;
+      const updateAction = <Replace>action;
       expect(updateAction.old.element).to.have.attribute('bufTime', '100');
       expect(updateAction.new.element).to.have.attribute('bufTime', '54');
     });
@@ -242,9 +242,9 @@ describe('Wizards for SCL ReportControl element', () => {
       expect(actionEvent).to.be.calledOnce;
 
       const action = actionEvent.args[0][0].detail.action;
-      expect(action).to.satisfy(isUpdate);
+      expect(action).to.satisfy(isReplace);
 
-      const updateAction = <Update>action;
+      const updateAction = <Replace>action;
       expect(updateAction.old.element).to.not.have.attribute('intgPd');
       expect(updateAction.new.element).to.have.attribute('intgPd', '1000');
     });
@@ -259,9 +259,9 @@ describe('Wizards for SCL ReportControl element', () => {
       expect(actionEvent).to.be.calledOnce;
 
       const action = actionEvent.args[0][0].detail.action;
-      expect(action).to.satisfy(isUpdate);
+      expect(action).to.satisfy(isReplace);
 
-      const updateAction = <Update>action;
+      const updateAction = <Replace>action;
       expect(updateAction.new.element.tagName).to.equal('RptEnabled');
       expect(updateAction.old.element.tagName).to.equal('RptEnabled');
       expect(updateAction.old.element).to.have.attribute('max', '5');
@@ -310,7 +310,7 @@ describe('Wizards for SCL ReportControl element', () => {
         const action = actionEvent.args[0][0].detail.action;
         expect(action).to.satisfy(isCreate);
 
-        const updateAction = <Update>action;
+        const updateAction = <Replace>action;
         expect(updateAction.new.element.tagName).to.equal('RptEnabled');
         expect(updateAction.new.element).to.have.attribute('max', '6');
       });

--- a/test/unit/wizards/sampledvaluecontrol.test.ts
+++ b/test/unit/wizards/sampledvaluecontrol.test.ts
@@ -6,8 +6,8 @@ import { MockWizard } from '../../mock-wizard.js';
 
 import {
   isDelete,
-  isUpdate,
-  Update,
+  isReplace,
+  Replace,
   WizardInput,
 } from '../../../src/foundation.js';
 import {
@@ -151,9 +151,9 @@ describe('Wizards for SCL element SampledValueControl', () => {
       expect(actionEvent).to.be.calledOnce;
 
       const action = actionEvent.args[0][0].detail.action;
-      expect(action).to.satisfy(isUpdate);
+      expect(action).to.satisfy(isReplace);
 
-      const updateAction = <Update>action;
+      const updateAction = <Replace>action;
       expect(updateAction.old.element).to.have.attribute('name', 'MSVCB01');
       expect(updateAction.new.element).to.have.attribute('name', 'myNewCbName');
     });
@@ -169,9 +169,9 @@ describe('Wizards for SCL element SampledValueControl', () => {
       expect(actionEvent).to.be.calledOnce;
 
       const action = actionEvent.args[0][0].detail.action;
-      expect(action).to.satisfy(isUpdate);
+      expect(action).to.satisfy(isReplace);
 
-      const updateAction = <Update>action;
+      const updateAction = <Replace>action;
       expect(updateAction.old.element).to.not.have.attribute('desc');
       expect(updateAction.new.element).to.have.attribute('desc', 'myDesc');
     });
@@ -186,9 +186,9 @@ describe('Wizards for SCL element SampledValueControl', () => {
       expect(actionEvent).to.be.calledOnce;
 
       const action = actionEvent.args[0][0].detail.action;
-      expect(action).to.satisfy(isUpdate);
+      expect(action).to.satisfy(isReplace);
 
-      const updateAction = <Update>action;
+      const updateAction = <Replace>action;
       expect(updateAction.old.element).to.have.attribute(
         'smvID',
         'some/reference'
@@ -210,9 +210,9 @@ describe('Wizards for SCL element SampledValueControl', () => {
       expect(actionEvent).to.be.calledOnce;
 
       const action = actionEvent.args[0][0].detail.action;
-      expect(action).to.satisfy(isUpdate);
+      expect(action).to.satisfy(isReplace);
 
-      const updateAction = <Update>action;
+      const updateAction = <Replace>action;
       expect(updateAction.old.element).to.not.have.attribute('smpMod');
       expect(updateAction.new.element).to.have.attribute('smpMod', 'SmpPerSec');
     });
@@ -227,9 +227,9 @@ describe('Wizards for SCL element SampledValueControl', () => {
       expect(actionEvent).to.be.calledOnce;
 
       const action = actionEvent.args[0][0].detail.action;
-      expect(action).to.satisfy(isUpdate);
+      expect(action).to.satisfy(isReplace);
 
-      const updateAction = <Update>action;
+      const updateAction = <Replace>action;
       expect(updateAction.old.element).to.have.attribute('smpRate', '80');
       expect(updateAction.new.element).to.have.attribute('smpRate', '4000');
     });
@@ -244,9 +244,9 @@ describe('Wizards for SCL element SampledValueControl', () => {
       expect(actionEvent).to.be.calledOnce;
 
       const action = actionEvent.args[0][0].detail.action;
-      expect(action).to.satisfy(isUpdate);
+      expect(action).to.satisfy(isReplace);
 
-      const updateAction = <Update>action;
+      const updateAction = <Replace>action;
       expect(updateAction.old.element).to.have.attribute('nofASDU', '1');
       expect(updateAction.new.element).to.have.attribute('nofASDU', '2');
     });
@@ -262,9 +262,9 @@ describe('Wizards for SCL element SampledValueControl', () => {
       expect(actionEvent).to.be.calledOnce;
 
       const action = actionEvent.args[0][0].detail.action;
-      expect(action).to.satisfy(isUpdate);
+      expect(action).to.satisfy(isReplace);
 
-      const updateAction = <Update>action;
+      const updateAction = <Replace>action;
       expect(updateAction.old.element).to.not.have.attribute('securityEnable');
       expect(updateAction.new.element).to.have.attribute(
         'securityEnable',

--- a/test/unit/wizards/smv.test.ts
+++ b/test/unit/wizards/smv.test.ts
@@ -213,8 +213,12 @@ describe('Wizards for SCL element SMV', () => {
 
       const complexAction = <ComplexAction>actionEvent.args[0][0].detail.action;
 
-      const oldAddress = (<Delete>complexAction.actions[0]).old.element;
-      const newAddress = (<Create>complexAction.actions[1]).new.element;
+      const oldAddress = <Element>(
+        (<Delete>complexAction.actions[0]).old.element
+      );
+      const newAddress = <Element>(
+        (<Create>complexAction.actions[1]).new.element
+      );
 
       expect(
         oldAddress.querySelector<Element>('P[type="MAC-Address"]')?.textContent
@@ -234,8 +238,12 @@ describe('Wizards for SCL element SMV', () => {
 
       const complexAction = <ComplexAction>actionEvent.args[0][0].detail.action;
 
-      const oldAddress = (<Delete>complexAction.actions[0]).old.element;
-      const newAddress = (<Create>complexAction.actions[1]).new.element;
+      const oldAddress = <Element>(
+        (<Delete>complexAction.actions[0]).old.element
+      );
+      const newAddress = <Element>(
+        (<Create>complexAction.actions[1]).new.element
+      );
 
       expect(
         oldAddress.querySelector<Element>('P[type="APPID"]')?.textContent
@@ -255,8 +263,12 @@ describe('Wizards for SCL element SMV', () => {
 
       const complexAction = <ComplexAction>actionEvent.args[0][0].detail.action;
 
-      const oldAddress = (<Delete>complexAction.actions[0]).old.element;
-      const newAddress = (<Create>complexAction.actions[1]).new.element;
+      const oldAddress = <Element>(
+        (<Delete>complexAction.actions[0]).old.element
+      );
+      const newAddress = <Element>(
+        (<Create>complexAction.actions[1]).new.element
+      );
 
       expect(
         oldAddress.querySelector<Element>('P[type="VLAN-ID"]')?.textContent
@@ -278,8 +290,12 @@ describe('Wizards for SCL element SMV', () => {
 
       const complexAction = <ComplexAction>actionEvent.args[0][0].detail.action;
 
-      const oldAddress = (<Delete>complexAction.actions[0]).old.element;
-      const newAddress = (<Create>complexAction.actions[1]).new.element;
+      const oldAddress = <Element>(
+        (<Delete>complexAction.actions[0]).old.element
+      );
+      const newAddress = <Element>(
+        (<Create>complexAction.actions[1]).new.element
+      );
 
       expect(
         oldAddress.querySelector<Element>('P[type="VLAN-PRIORITY"]')

--- a/test/unit/wizards/smvopts.test.ts
+++ b/test/unit/wizards/smvopts.test.ts
@@ -5,7 +5,7 @@ import '../../mock-wizard.js';
 import { MockWizard } from '../../mock-wizard.js';
 
 import { WizardCheckbox } from '../../../src/wizard-checkbox.js';
-import { isUpdate, Update } from '../../../src/foundation.js';
+import { isReplace, Replace } from '../../../src/foundation.js';
 import { editSmvOptsWizard } from '../../../src/wizards/smvopts.js';
 
 describe('Wizards for SCL SmvOpts element', () => {
@@ -66,9 +66,9 @@ describe('Wizards for SCL SmvOpts element', () => {
       expect(actionEvent).to.be.calledOnce;
 
       const action = actionEvent.args[0][0].detail.action;
-      expect(action).to.satisfy(isUpdate);
+      expect(action).to.satisfy(isReplace);
 
-      const updateAction = <Update>action;
+      const updateAction = <Replace>action;
       expect(updateAction.old.element).to.have.attribute('dataSet', 'true');
       expect(updateAction.new.element).to.have.attribute('dataSet', 'false');
     });
@@ -83,9 +83,9 @@ describe('Wizards for SCL SmvOpts element', () => {
       expect(actionEvent).to.be.calledOnce;
 
       const action = actionEvent.args[0][0].detail.action;
-      expect(action).to.satisfy(isUpdate);
+      expect(action).to.satisfy(isReplace);
 
-      const updateAction = <Update>action;
+      const updateAction = <Replace>action;
       expect(updateAction.old.element).to.have.attribute('dataSet', 'true');
       expect(updateAction.new.element).to.not.have.attribute('dataSet');
     });
@@ -100,9 +100,9 @@ describe('Wizards for SCL SmvOpts element', () => {
       expect(actionEvent).to.be.calledOnce;
 
       const action = actionEvent.args[0][0].detail.action;
-      expect(action).to.satisfy(isUpdate);
+      expect(action).to.satisfy(isReplace);
 
-      const updateAction = <Update>action;
+      const updateAction = <Replace>action;
       expect(updateAction.old.element).to.have.attribute('refreshTime', 'true');
       expect(updateAction.new.element).to.have.attribute(
         'refreshTime',
@@ -121,9 +121,9 @@ describe('Wizards for SCL SmvOpts element', () => {
       expect(actionEvent).to.be.calledOnce;
 
       const action = actionEvent.args[0][0].detail.action;
-      expect(action).to.satisfy(isUpdate);
+      expect(action).to.satisfy(isReplace);
 
-      const updateAction = <Update>action;
+      const updateAction = <Replace>action;
       expect(updateAction.old.element).to.not.have.attribute('sampleRate');
       expect(updateAction.new.element).to.have.attribute('sampleRate', 'true');
     });
@@ -139,9 +139,9 @@ describe('Wizards for SCL SmvOpts element', () => {
       expect(actionEvent).to.be.calledOnce;
 
       const action = actionEvent.args[0][0].detail.action;
-      expect(action).to.satisfy(isUpdate);
+      expect(action).to.satisfy(isReplace);
 
-      const updateAction = <Update>action;
+      const updateAction = <Replace>action;
       expect(updateAction.old.element).to.not.have.attribute('security');
       expect(updateAction.new.element).to.have.attribute('security', 'true');
     });
@@ -157,9 +157,9 @@ describe('Wizards for SCL SmvOpts element', () => {
       expect(actionEvent).to.be.calledOnce;
 
       const action = actionEvent.args[0][0].detail.action;
-      expect(action).to.satisfy(isUpdate);
+      expect(action).to.satisfy(isReplace);
 
-      const updateAction = <Update>action;
+      const updateAction = <Replace>action;
       expect(updateAction.old.element).to.not.have.attribute('synchSourceId');
       expect(updateAction.new.element).to.have.attribute(
         'synchSourceId',

--- a/test/unit/wizards/subnetwork.test.ts
+++ b/test/unit/wizards/subnetwork.test.ts
@@ -167,7 +167,7 @@ describe('Wizards for SCL element SubNetwork', () => {
         expect(actionEvent.args[0][0].detail.action).to.satisfy(isDelete);
 
         const updateAction = <Delete>actionEvent.args[0][0].detail.action;
-        expect(updateAction.old.element.innerHTML.trim()).to.equal('100.0');
+        expect(updateAction.old.element.textContent?.trim()).to.equal('100.0');
         expect(updateAction.old.element).to.not.have.attribute('multiplier');
       });
     });
@@ -210,7 +210,7 @@ describe('Wizards for SCL element SubNetwork', () => {
         expect(actionEvent.args[0][0].detail.action).to.satisfy(isCreate);
 
         const updateAction = <Create>actionEvent.args[0][0].detail.action;
-        expect(updateAction.new.element.innerHTML.trim()).to.equal('100.0');
+        expect(updateAction.new.element.textContent?.trim()).to.equal('100.0');
         expect(updateAction.new.element).to.have.attribute('multiplier', 'M');
       });
 
@@ -230,7 +230,7 @@ describe('Wizards for SCL element SubNetwork', () => {
         expect(actionEvent.args[0][0].detail.action).to.satisfy(isCreate);
 
         const updateAction = <Create>actionEvent.args[0][0].detail.action;
-        expect(updateAction.new.element.innerHTML.trim()).to.equal('');
+        expect(updateAction.new.element.textContent?.trim()).to.equal('');
         expect(updateAction.new.element).to.have.attribute('multiplier');
       });
 
@@ -250,7 +250,7 @@ describe('Wizards for SCL element SubNetwork', () => {
         expect(actionEvent.args[0][0].detail.action).to.satisfy(isCreate);
 
         const updateAction = <Create>actionEvent.args[0][0].detail.action;
-        expect(updateAction.new.element.innerHTML.trim()).to.equal('100.0');
+        expect(updateAction.new.element.textContent?.trim()).to.equal('100.0');
         expect(updateAction.new.element).to.not.have.attribute('multiplier');
       });
     });
@@ -310,12 +310,15 @@ describe('Wizards for SCL element SubNetwork', () => {
       );
       expect(updateAction.new.element).to.have.a.attribute('desc', '');
       expect(updateAction.new.element).to.have.a.attribute('type', '8-MMS');
-      expect(updateAction.new.element.querySelector('BitRate')).to.exist;
+      expect((<Element>updateAction.new.element).querySelector('BitRate')).to
+        .exist;
       expect(
-        updateAction.new.element.querySelector('BitRate')
+        (<Element>updateAction.new.element).querySelector('BitRate')
       ).to.have.attribute('multiplier', 'M');
       expect(
-        updateAction.new.element.querySelector('BitRate')?.textContent?.trim()
+        (<Element>updateAction.new.element)
+          .querySelector('BitRate')
+          ?.textContent?.trim()
       ).to.equal('100');
     });
 
@@ -353,7 +356,8 @@ describe('Wizards for SCL element SubNetwork', () => {
       );
       expect(updateAction.new.element).to.not.have.a.attribute('desc');
       expect(updateAction.new.element).to.not.have.a.attribute('type');
-      expect(updateAction.new.element.querySelector('BitRate')).to.not.exist;
+      expect((<Element>updateAction.new.element).querySelector('BitRate')).to
+        .not.exist;
     });
   });
 });

--- a/test/unit/wizards/subnetwork.test.ts
+++ b/test/unit/wizards/subnetwork.test.ts
@@ -9,8 +9,8 @@ import {
   isCreate,
   isDelete,
   WizardInput,
-  isUpdate,
-  Update,
+  isReplace,
+  Replace,
   Delete,
   Create,
 } from '../../../src/foundation.js';
@@ -76,9 +76,9 @@ describe('Wizards for SCL element SubNetwork', () => {
         await element.requestUpdate();
 
         expect(actionEvent).to.be.calledOnce;
-        expect(actionEvent.args[0][0].detail.action).to.satisfy(isUpdate);
+        expect(actionEvent.args[0][0].detail.action).to.satisfy(isReplace);
 
-        const updateAction = <Update>actionEvent.args[0][0].detail.action;
+        const updateAction = <Replace>actionEvent.args[0][0].detail.action;
         expect(updateAction.old.element).to.have.a.attribute(
           'name',
           'StationBus'
@@ -101,9 +101,9 @@ describe('Wizards for SCL element SubNetwork', () => {
         await element.requestUpdate();
 
         expect(actionEvent).to.be.calledOnce;
-        expect(actionEvent.args[0][0].detail.action).to.satisfy(isUpdate);
+        expect(actionEvent.args[0][0].detail.action).to.satisfy(isReplace);
 
-        const updateAction = <Update>actionEvent.args[0][0].detail.action;
+        const updateAction = <Replace>actionEvent.args[0][0].detail.action;
         expect(updateAction.old.element).to.not.have.a.attribute('desc');
         expect(updateAction.new.element).to.have.a.attribute(
           'desc',
@@ -120,9 +120,9 @@ describe('Wizards for SCL element SubNetwork', () => {
         await element.requestUpdate();
 
         expect(actionEvent).to.be.calledOnce;
-        expect(actionEvent.args[0][0].detail.action).to.satisfy(isUpdate);
+        expect(actionEvent.args[0][0].detail.action).to.satisfy(isReplace);
 
-        const updateAction = <Update>actionEvent.args[0][0].detail.action;
+        const updateAction = <Replace>actionEvent.args[0][0].detail.action;
         expect(updateAction.old.element).to.have.a.attribute('type', '8-MMS');
         expect(updateAction.new.element).to.have.a.attribute(
           'type',
@@ -142,9 +142,9 @@ describe('Wizards for SCL element SubNetwork', () => {
         await element.requestUpdate();
 
         expect(actionEvent).to.be.calledOnce;
-        expect(actionEvent.args[0][0].detail.action).to.satisfy(isUpdate);
+        expect(actionEvent.args[0][0].detail.action).to.satisfy(isReplace);
 
-        const updateAction = <Update>actionEvent.args[0][0].detail.action;
+        const updateAction = <Replace>actionEvent.args[0][0].detail.action;
         expect(updateAction.old.element.innerHTML.trim()).to.equal('100.0');
         expect(updateAction.old.element).to.not.have.attribute('multiplier');
         expect(updateAction.new.element.innerHTML.trim()).to.equal('200.');

--- a/test/unit/wizards/trgops.test.ts
+++ b/test/unit/wizards/trgops.test.ts
@@ -4,7 +4,7 @@ import { SinonSpy, spy } from 'sinon';
 import '../../mock-wizard.js';
 import { MockWizard } from '../../mock-wizard.js';
 
-import { isUpdate, Update, WizardInput } from '../../../src/foundation.js';
+import { isReplace, Replace, WizardInput } from '../../../src/foundation.js';
 import { WizardSelect } from '../../../src/wizard-select.js';
 import { editTrgOpsWizard } from '../../../src/wizards/trgops.js';
 
@@ -66,9 +66,9 @@ describe('Wizards for SCL TrgOps element', () => {
       expect(actionEvent).to.be.calledOnce;
 
       const action = actionEvent.args[0][0].detail.action;
-      expect(action).to.satisfy(isUpdate);
+      expect(action).to.satisfy(isReplace);
 
-      const updateAction = <Update>action;
+      const updateAction = <Replace>action;
       expect(updateAction.old.element).to.have.attribute('dchg', 'true');
       expect(updateAction.new.element).to.have.attribute('dchg', 'false');
     });
@@ -84,9 +84,9 @@ describe('Wizards for SCL TrgOps element', () => {
       expect(actionEvent).to.be.calledOnce;
 
       const action = actionEvent.args[0][0].detail.action;
-      expect(action).to.satisfy(isUpdate);
+      expect(action).to.satisfy(isReplace);
 
-      const updateAction = <Update>action;
+      const updateAction = <Replace>action;
       expect(updateAction.old.element).to.not.have.attribute('qchg');
       expect(updateAction.new.element).to.have.attribute('qchg', 'false');
     });
@@ -102,9 +102,9 @@ describe('Wizards for SCL TrgOps element', () => {
       expect(actionEvent).to.be.calledOnce;
 
       const action = actionEvent.args[0][0].detail.action;
-      expect(action).to.satisfy(isUpdate);
+      expect(action).to.satisfy(isReplace);
 
-      const updateAction = <Update>action;
+      const updateAction = <Replace>action;
       expect(updateAction.old.element).to.not.have.attribute('dupd');
       expect(updateAction.new.element).to.have.attribute('dupd', 'true');
     });
@@ -119,9 +119,9 @@ describe('Wizards for SCL TrgOps element', () => {
       expect(actionEvent).to.be.calledOnce;
 
       const action = actionEvent.args[0][0].detail.action;
-      expect(action).to.satisfy(isUpdate);
+      expect(action).to.satisfy(isReplace);
 
-      const updateAction = <Update>action;
+      const updateAction = <Replace>action;
       expect(updateAction.old.element).to.have.attribute('gi', 'false');
       expect(updateAction.new.element).to.have.attribute('gi', 'true');
     });
@@ -137,9 +137,9 @@ describe('Wizards for SCL TrgOps element', () => {
       expect(actionEvent).to.be.calledOnce;
 
       const action = actionEvent.args[0][0].detail.action;
-      expect(action).to.satisfy(isUpdate);
+      expect(action).to.satisfy(isReplace);
 
-      const updateAction = <Update>action;
+      const updateAction = <Replace>action;
       expect(updateAction.old.element).to.not.have.attribute('period');
       expect(updateAction.new.element).to.have.attribute('period', 'true');
     });

--- a/test/unit/zeroline/BayEditor.test.ts
+++ b/test/unit/zeroline/BayEditor.test.ts
@@ -1,6 +1,6 @@
 import { fixture, html, expect } from '@open-wc/testing';
 
-import { WizardInput, isCreate, isUpdate } from '../../../src/foundation.js';
+import { WizardInput, isCreate, isReplace } from '../../../src/foundation.js';
 
 import '../../../src/wizard-textfield.js';
 import { createAction } from '../../../src/wizards/bay.js';
@@ -59,7 +59,7 @@ describe('BayEditor', () => {
 
     it('returns a WizardAction which returns an Update EditorAction', () => {
       const wizardAction = updateNamingAction(element);
-      expect(wizardAction(inputs, newWizard())[0]).to.satisfy(isUpdate);
+      expect(wizardAction(inputs, newWizard())[0]).to.satisfy(isReplace);
     });
 
     describe('with no change in element Bay', () => {

--- a/test/unit/zeroline/SubstationEditor.test.ts
+++ b/test/unit/zeroline/SubstationEditor.test.ts
@@ -1,7 +1,7 @@
 import { fixture, html, expect } from '@open-wc/testing';
 
 import '../../../src/wizard-textfield.js';
-import { WizardInput, isCreate, isUpdate } from '../../../src/foundation.js';
+import { WizardInput, isCreate, isReplace } from '../../../src/foundation.js';
 import { updateNamingAction } from '../../../src/wizards/foundation/actions.js';
 import { createAction } from '../../../src/wizards/substation.js';
 
@@ -58,7 +58,7 @@ describe('SubstationEditor', () => {
 
     it('returns a WizardAction which returns an Update EditorAction', () => {
       const wizardAction = updateNamingAction(element);
-      expect(wizardAction(inputs, newWizard())[0]).to.satisfy(isUpdate);
+      expect(wizardAction(inputs, newWizard())[0]).to.satisfy(isReplace);
     });
 
     describe('with no change in element Substation', () => {

--- a/test/unit/zeroline/VoltageLevelEditor.test.ts
+++ b/test/unit/zeroline/VoltageLevelEditor.test.ts
@@ -4,7 +4,7 @@ import '../../../src/wizard-textfield.js';
 import {
   WizardInput,
   isCreate,
-  isUpdate,
+  isReplace,
   isDelete,
 } from '../../../src/foundation.js';
 import {
@@ -69,7 +69,7 @@ describe('VoltageLevelEditor', () => {
 
         it('returns a WizardAction with the first returned EditorAction beeing an Update', () => {
           const wizardAction = updateAction(element);
-          expect(wizardAction(inputs, newWizard())[0]).to.satisfy(isUpdate);
+          expect(wizardAction(inputs, newWizard())[0]).to.satisfy(isReplace);
         });
 
         it('returns a WizardAction with the second returned EditorAction beeing a Create', () => {
@@ -96,12 +96,12 @@ describe('VoltageLevelEditor', () => {
 
         it('returns a WizardAction with the first returned EditorAction beeing an Update', () => {
           const wizardAction = updateAction(element);
-          expect(wizardAction(inputs, newWizard())[0]).to.satisfy(isUpdate);
+          expect(wizardAction(inputs, newWizard())[0]).to.satisfy(isReplace);
         });
 
         it('returns a WizardAction with the second returned EditorAction beeing a Update', () => {
           const wizardAction = updateAction(element);
-          expect(wizardAction(inputs, newWizard())[1]).to.satisfy(isUpdate);
+          expect(wizardAction(inputs, newWizard())[1]).to.satisfy(isReplace);
         });
       });
 
@@ -123,7 +123,7 @@ describe('VoltageLevelEditor', () => {
 
         it('returns a WizardAction with the first returned EditorAction beeing an Update', () => {
           const wizardAction = updateAction(element);
-          expect(wizardAction(inputs, newWizard())[0]).to.satisfy(isUpdate);
+          expect(wizardAction(inputs, newWizard())[0]).to.satisfy(isReplace);
         });
       });
 
@@ -196,7 +196,7 @@ describe('VoltageLevelEditor', () => {
 
         it('returns a WizardAction with the first returned EditorAction beeing an Update', () => {
           const wizardAction = updateAction(element);
-          expect(wizardAction(inputs, newWizard())[0]).to.satisfy(isUpdate);
+          expect(wizardAction(inputs, newWizard())[0]).to.satisfy(isReplace);
         });
 
         it('returns a WizardAction with the second returned EditorAction beeing a Delete', () => {


### PR DESCRIPTION
The first step of the refactor...the action `Update` has been renamed to `Replace`.
2nd step will be allow to `Node` in `Delete` and `Create`