### PR TITLE
feat(foundation): add EditorAction type Update

### DIFF
--- a/src/foundation.ts
+++ b/src/foundation.ts
@@ -10,7 +10,7 @@ import { WizardTextField } from './wizard-textfield.js';
 import { WizardSelect } from './wizard-select.js';
 import { WizardCheckbox } from './wizard-checkbox.js';
 
-export type SimpleAction = Create | Replace | Delete | Move;
+export type SimpleAction = Update | Create | Replace | Delete | Move;
 export type ComplexAction = {
   actions: SimpleAction[];
   title: string;
@@ -44,6 +44,14 @@ export interface Replace {
   derived?: boolean;
   checkValidity?: () => boolean;
 }
+/** Swaps `element`s `oldAttributes` with `newAttributes` */
+export interface Update {
+  element: Element;
+  oldAttributes: Record<string, string | null>;
+  newAttributes: Record<string, string | null>;
+  derived?: boolean;
+  checkValidity?: () => boolean;
+}
 
 export function isCreate(action: EditorAction): action is Create {
   return (
@@ -73,6 +81,15 @@ export function isReplace(action: EditorAction): action is Replace {
     (action as Replace).old?.element !== undefined &&
     (action as Move).new?.parent === undefined &&
     (action as Replace).new?.element !== undefined
+  );
+}
+export function isUpdate(action: EditorAction): action is Update {
+  return (
+    (action as Replace).old === undefined &&
+    (action as Replace).new === undefined &&
+    (action as Update).element !== undefined &&
+    (action as Update).newAttributes !== undefined &&
+    (action as Update).oldAttributes !== undefined
   );
 }
 export function isSimple(action: EditorAction): action is SimpleAction {
@@ -111,7 +128,26 @@ export function invert(action: EditorAction): EditorAction {
     };
   else if (isReplace(action))
     return { new: action.old, old: action.new, ...metaData };
+  else if (isUpdate(action))
+    return {
+      element: action.element,
+      oldAttributes: action.newAttributes,
+      newAttributes: action.oldAttributes,
+      ...metaData,
+    };
   else return unreachable('Unknown EditorAction type in invert.');
+}
+//** return `Update` action for `element` adding `oldAttributes` */
+export function createUpdateAction(
+  element: Element,
+  newAttributes: Record<string, string | null>
+): Update {
+  const oldAttributes: Record<string, string | null> = {};
+  Array.from(element.attributes).forEach(attr => {
+    oldAttributes[attr.name] = attr.value;
+  });
+
+  return { element, oldAttributes, newAttributes };
 }
 
 /** Represents some intended modification of a `Document` being edited. */

--- a/test/integration/Editing.test.ts
+++ b/test/integration/Editing.test.ts
@@ -245,5 +245,33 @@ describe('Editing-Logging integration', () => {
     });
   });
 
+  describe('has an Update EditorAction type that', () => {
+    let updateAction: Update;
+    beforeEach(() => {
+      const newAttributes: Record<string, string | null> = {};
+      newAttributes['name'] = 'Q03';
+
+      updateAction = createUpdateAction(element, newAttributes);
+    });
+
+    it('can undo', () => {
+      elm.dispatchEvent(newActionEvent(updateAction));
+      expect(element).to.have.attribute('name', 'Q03');
+      expect(element).to.not.have.attribute('desc');
+
+      elm.undo();
+      expect(element).to.have.attribute('name', 'Q01');
+      expect(element).to.have.attribute('desc', 'Bay');
+    });
+
+    it('can redo', () => {
+      elm.dispatchEvent(newActionEvent(updateAction));
+
+      elm.undo();
+      elm.redo();
+
+      expect(element).to.have.attribute('name', 'Q03');
+      expect(element).to.not.have.attribute('desc');
+    });
   });
 });

--- a/test/integration/Editing.test.ts
+++ b/test/integration/Editing.test.ts
@@ -3,7 +3,11 @@ import { expect, fixture, html } from '@open-wc/testing';
 import '../mock-editor-logger.js';
 import { MockEditorLogger } from '../mock-editor-logger.js';
 
-import { newActionEvent } from '../../src/foundation.js';
+import {
+  createUpdateAction,
+  newActionEvent,
+  Update,
+} from '../../src/foundation.js';
 
 describe('Editing-Logging integration', () => {
   let elm: MockEditorLogger;
@@ -22,68 +26,224 @@ describe('Editing-Logging integration', () => {
     element = parent.querySelector('Bay[name="Q01"]')!;
   });
 
-  it('add valid reference onCreate when reference is missing', () => {
-    const newElement = elm.doc!.createElement('Bay');
-    newElement?.setAttribute('name', 'Q03');
+  describe('has a Create EditorAction type that', () => {
+    let newElement: Element;
+    beforeEach(() => {
+      newElement = elm.doc!.createElement('Bay');
+      newElement?.setAttribute('name', 'Q03');
+    });
 
-    elm.dispatchEvent(
-      newActionEvent({
-        new: {
-          parent,
-          element: newElement,
-        },
-      })
-    );
-    expect(parent.querySelector('Bay[name="Q03"]')).to.not.be.null;
-    elm.undo();
-    expect(parent.querySelector('Bay[name="Q03"]')).to.be.null;
-    elm.redo();
-    expect(parent.querySelector('Bay[name="Q03"]')).to.not.be.null;
-    expect(
-      parent.querySelector('Bay[name="Q03"]')?.nextElementSibling
-    ).to.equal(parent.querySelector('Bay[name="Q01"]'));
+    it('can be undone', () => {
+      elm.dispatchEvent(
+        newActionEvent({ new: { parent, element: newElement } })
+      );
+      expect(newElement.parentElement).to.equal(parent);
+
+      elm.undo();
+      expect(newElement.parentElement).to.be.null;
+    });
+
+    it('can be redone', () => {
+      elm.dispatchEvent(
+        newActionEvent({ new: { parent, element: newElement } })
+      );
+
+      elm.undo();
+
+      elm.redo();
+      expect(newElement.parentElement).to.equal(parent);
+    });
+
+    it('automatically assignes a missing reference on redo', () => {
+      elm.dispatchEvent(
+        newActionEvent({ new: { parent, element: newElement } })
+      );
+      elm.undo();
+
+      elm.redo();
+      expect(
+        parent.querySelector('Bay[name="Q03"]')?.nextElementSibling
+      ).to.equal(parent.querySelector('Bay[name="Q01"]'));
+    });
+
+    it('properly uses the reference on redo', () => {
+      const newElement = elm.doc!.createElement('Bay');
+      newElement?.setAttribute('name', 'Q03');
+
+      elm.dispatchEvent(
+        newActionEvent({
+          new: {
+            parent,
+            element: newElement,
+            reference: parent.lastChild,
+          },
+        })
+      );
+
+      elm.undo();
+
+      elm.redo();
+
+      expect(parent.querySelector('Bay[name="Q03"]')?.nextSibling).to.equal(
+        parent.lastChild
+      );
+    });
   });
 
-  it('add valid reference onDelete when reference is missing', () => {
-    elm.dispatchEvent(
-      newActionEvent({
-        old: {
-          parent,
-          element,
-        },
-      })
-    );
-    expect(parent.querySelector('Bay[name="Q01"]')).to.be.null;
-    elm.undo();
-    expect(parent.querySelector('Bay[name="Q01"]')).to.not.be.null;
-    expect(
-      parent.querySelector('Bay[name="Q01"]')?.nextElementSibling
-    ).to.equal(parent.querySelector('Bay[name="Q02"]'));
+  describe('has a Delete EditorAction type that', () => {
+    it('can be ondone', () => {
+      expect(element.parentElement).to.equal(parent);
+
+      elm.dispatchEvent(
+        newActionEvent({
+          old: {
+            parent,
+            element,
+          },
+        })
+      );
+      expect(element.parentElement).to.be.null;
+
+      elm.undo();
+      expect(element.parentElement).to.equal(parent);
+    });
+
+    it('can be rodone', () => {
+      elm.dispatchEvent(
+        newActionEvent({
+          old: {
+            parent,
+            element,
+          },
+        })
+      );
+
+      elm.undo();
+
+      elm.redo();
+      expect(element.parentElement).to.be.null;
+    });
+
+    it('puts the deleted Node back to its original position on undo', () => {
+      const originalNextSibling = element.nextSibling;
+
+      elm.dispatchEvent(
+        newActionEvent({
+          old: {
+            parent,
+            element,
+          },
+        })
+      );
+      elm.undo();
+
+      expect(element.nextSibling).to.equal(originalNextSibling);
+    });
   });
 
-  it('add valid reference onMove when reference is missing', () => {
-    elm.dispatchEvent(
-      newActionEvent({
-        old: {
-          parent,
-          element,
-        },
-        new: {
-          parent: elm.doc!.querySelector('VoltageLevel[name="J1"]')!,
-        },
-      })
-    );
-    expect(parent.querySelector('Bay[name="Q01"]')).to.be.null;
-    expect(elm.doc!.querySelector('VoltageLevel[name="J1"] > Bay[name="Q01"]'))
-      .to.not.be.null;
-    elm.undo();
-    expect(
-      parent.querySelector('Bay[name="Q01"]')?.nextElementSibling
-    ).to.equal(parent.querySelector('Bay[name="Q02"]'));
-    elm.redo();
-    expect(
-      elm.doc!.querySelector('VoltageLevel[name="J1"] > Bay[name="Q01"]')
-        ?.nextElementSibling
-    ).to.equal(elm.doc!.querySelector('VoltageLevel[name="J1"] > Function'));
+  describe('has a Move EditorAction type that', () => {
+    let newParent: Element;
+    beforeEach(() => {
+      newParent = elm.doc!.querySelector('VoltageLevel[name="J1"]')!;
+    });
+
+    it('can be undone', () => {
+      expect(element.parentElement).to.equal(parent);
+
+      elm.dispatchEvent(
+        newActionEvent({ old: { parent, element }, new: { parent: newParent } })
+      );
+      expect(element.parentElement).to.equal(newParent);
+
+      elm.undo();
+      expect(element.parentElement).to.equal(parent);
+    });
+
+    it('can be redone', () => {
+      elm.dispatchEvent(
+        newActionEvent({ old: { parent, element }, new: { parent: newParent } })
+      );
+
+      elm.undo();
+
+      elm.redo();
+      expect(element.parentElement).to.equal(newParent);
+    });
+
+    it('adds the element in a valid location in the new parent', () => {
+      elm.dispatchEvent(
+        newActionEvent({ old: { parent, element }, new: { parent: newParent } })
+      );
+      expect(
+        elm.doc!.querySelector('VoltageLevel[name="J1"] > Bay[name="Q01"]')
+          ?.nextElementSibling
+      ).to.equal(elm.doc!.querySelector('VoltageLevel[name="J1"] > Function'));
+    });
+
+    it('puts the element back to its original postition with parent', () => {
+      elm.dispatchEvent(
+        newActionEvent({ old: { parent, element }, new: { parent: newParent } })
+      );
+
+      elm.undo();
+      expect(
+        parent.querySelector('Bay[name="Q01"]')?.nextElementSibling
+      ).to.equal(parent.querySelector('Bay[name="Q02"]'));
+    });
+  });
+
+  describe('has a Replace EditorAction type that', () => {
+    let newElement: Element;
+    beforeEach(() => {
+      newElement = elm.doc!.createElement('Bay');
+      newElement?.setAttribute('name', 'Q03');
+    });
+
+    it('can be undone', () => {
+      elm.dispatchEvent(
+        newActionEvent({ old: { element }, new: { element: newElement } })
+      );
+
+      elm.undo();
+      expect(newElement.parentElement).to.be.null;
+      expect(element.parentElement).to.equal(parent);
+    });
+
+    it('can be redone', () => {
+      elm.dispatchEvent(
+        newActionEvent({ old: { element }, new: { element: newElement } })
+      );
+
+      elm.undo();
+
+      elm.redo();
+
+      expect(newElement.parentElement).to.equal(parent);
+      expect(element.parentElement).to.be.null;
+    });
+
+    it('correctly copying child elements between element and newElement for multiple undo/redo', () => {
+      const originOldChildCount = element.children.length;
+      const originNewChildCount = newElement.children.length;
+
+      elm.dispatchEvent(
+        newActionEvent({ old: { element }, new: { element: newElement } })
+      );
+      expect(element.children).to.have.lengthOf(originNewChildCount);
+      expect(newElement.children).to.have.lengthOf(originOldChildCount);
+
+      elm.undo();
+      elm.redo();
+
+      elm.undo();
+      expect(element.children).to.have.lengthOf(originOldChildCount);
+      expect(newElement.children).to.have.lengthOf(originNewChildCount);
+
+      elm.redo();
+      expect(element.children).to.have.lengthOf(originNewChildCount);
+      expect(newElement.children).to.have.lengthOf(originOldChildCount);
+    });
+  });
+
   });
 });

--- a/test/unit/Editing.test.ts
+++ b/test/unit/Editing.test.ts
@@ -3,7 +3,7 @@ import { html, fixture, expect } from '@open-wc/testing';
 import './mock-editor.js';
 import { MockEditor } from './mock-editor.js';
 
-import { newActionEvent } from '../../src/foundation.js';
+import { createUpdateAction, newActionEvent } from '../../src/foundation.js';
 
 describe('EditingElement', () => {
   let elm: MockEditor;
@@ -263,6 +263,32 @@ describe('EditingElement', () => {
       elm.doc!.querySelector('VoltageLevel[name="J1"] > Bay[name="Q01"]')
         ?.nextElementSibling
     ).to.be.null;
+  });
+
+  it('updates an element on receiving an Update action', () => {
+    const newAttributes: Record<string, string | null> = {};
+    newAttributes['name'] = 'Q03';
+
+    elm.dispatchEvent(
+      newActionEvent(createUpdateAction(element, newAttributes))
+    );
+
+    expect(element.parentElement).to.equal(parent);
+    expect(element).to.have.attribute('name', 'Q03');
+    expect(element).to.not.have.attribute('desc');
+  });
+
+  it('does not update an element with name conflict', () => {
+    const newAttributes: Record<string, string | null> = {};
+    newAttributes['name'] = 'Q02';
+
+    elm.dispatchEvent(
+      newActionEvent(createUpdateAction(element, newAttributes))
+    );
+
+    expect(element.parentElement).to.equal(parent);
+    expect(element).to.have.attribute('name', 'Q01');
+    expect(element).to.have.attribute('desc', 'Bay');
   });
 
   it('carries out subactions sequentially on receiving a ComplexAction', () => {


### PR DESCRIPTION
We want to introduce a new EditorAction `Update` that allows to keep the `element` in the DOM and use its reference when the identity string cannot be use - e.g. name attribute must be exchanged. The action allows exchange the attributes of `element` with `newAttributes`. Updating children of `element` is out of scope, but can be done using `Create` and `Delete` as those can now be user for any kind of `Node`.