### PR TITLE
refactor(editors/template): use subwizard option

### DIFF
--- a/src/editors/templates/datype-wizards.ts
+++ b/src/editors/templates/datype-wizards.ts
@@ -17,6 +17,7 @@ import {
   getValue,
   identity,
   newActionEvent,
+  newSubWizardEvent,
   newWizardEvent,
   patterns,
   selector,
@@ -95,9 +96,8 @@ export function editDaTypeWizard(
             @click=${(e: Event) => {
               if (datype)
                 e.target!.dispatchEvent(
-                  newWizardEvent(createBDAWizard(datype))
+                  newSubWizardEvent(createBDAWizard(datype))
                 );
-              e.target!.dispatchEvent(newWizardEvent());
             }}
           ></mwc-button>
           <mwc-list
@@ -107,8 +107,7 @@ export function editDaTypeWizard(
               const bda = doc.querySelector(selector('BDA', bdaIdentity));
 
               if (bda)
-                e.target!.dispatchEvent(newWizardEvent(editBDAWizard(bda)));
-              e.target!.dispatchEvent(newWizardEvent());
+                e.target!.dispatchEvent(newSubWizardEvent(editBDAWizard(bda)));
             }}
           >
             ${Array.from(datype.querySelectorAll('BDA')).map(

--- a/src/editors/templates/dotype-wizards.ts
+++ b/src/editors/templates/dotype-wizards.ts
@@ -20,6 +20,7 @@ import {
   identity,
   isPublic,
   newActionEvent,
+  newSubWizardEvent,
   newWizardEvent,
   selector,
   Wizard,
@@ -391,8 +392,7 @@ export function dOTypeWizard(
               const wizard = sDOWizard({
                 parent: dotype,
               });
-              if (wizard) e.target!.dispatchEvent(newWizardEvent(wizard));
-              e.target!.dispatchEvent(newWizardEvent());
+              if (wizard) e.target!.dispatchEvent(newSubWizardEvent(wizard));
             }}
           ></mwc-button>
           <mwc-button
@@ -402,8 +402,9 @@ export function dOTypeWizard(
             label="${translate('scl.DA')}"
             @click=${(e: Event) => {
               if (dotype)
-                e.target!.dispatchEvent(newWizardEvent(createDaWizard(dotype)));
-              e.target!.dispatchEvent(newWizardEvent());
+                e.target!.dispatchEvent(
+                  newSubWizardEvent(createDaWizard(dotype))
+                );
             }}
           ></mwc-button>
         </section>`,
@@ -425,8 +426,7 @@ export function dOTypeWizard(
                     doc,
                   });
 
-              if (wizard) e.target!.dispatchEvent(newWizardEvent(wizard));
-              e.target!.dispatchEvent(newWizardEvent());
+              if (wizard) e.target!.dispatchEvent(newSubWizardEvent(wizard));
             }}
           >
             ${Array.from(dotype.querySelectorAll('SDO, DA')).map(

--- a/src/editors/templates/enumtype-wizard.ts
+++ b/src/editors/templates/enumtype-wizard.ts
@@ -19,6 +19,7 @@ import {
   identity,
   isPublic,
   newActionEvent,
+  newSubWizardEvent,
   newWizardEvent,
   patterns,
   selector,
@@ -317,8 +318,7 @@ export function eNumTypeEditWizard(
               const wizard = eNumValWizard({
                 parent: enumtype,
               });
-              if (wizard) e.target!.dispatchEvent(newWizardEvent(wizard));
-              e.target!.dispatchEvent(newWizardEvent());
+              if (wizard) e.target!.dispatchEvent(newSubWizardEvent(wizard));
             }}
           ></mwc-button>
           <mwc-list
@@ -328,8 +328,7 @@ export function eNumTypeEditWizard(
                 identity: (<ListItem>(<List>e.target).selected).value,
                 doc,
               });
-              if (wizard) e.target!.dispatchEvent(newWizardEvent(wizard));
-              e.target!.dispatchEvent(newWizardEvent());
+              if (wizard) e.target!.dispatchEvent(newSubWizardEvent(wizard));
             }}
             >${Array.from(enumtype.querySelectorAll('EnumVal')).map(
               enumval =>

--- a/src/editors/templates/lnodetype-wizard.ts
+++ b/src/editors/templates/lnodetype-wizard.ts
@@ -23,6 +23,7 @@ import {
   identity,
   isPublic,
   newActionEvent,
+  newSubWizardEvent,
   newWizardEvent,
   patterns,
   selector,
@@ -601,8 +602,7 @@ export function lNodeTypeWizard(
             const wizard = dOWizard({
               parent: lnodetype,
             });
-            if (wizard) e.target!.dispatchEvent(newWizardEvent(wizard));
-            e.target!.dispatchEvent(newWizardEvent());
+            if (wizard) e.target!.dispatchEvent(newSubWizardEvent(wizard));
           }}
         ></mwc-button>`,
         html`
@@ -614,8 +614,7 @@ export function lNodeTypeWizard(
                 doc,
               });
 
-              if (wizard) e.target!.dispatchEvent(newWizardEvent(wizard));
-              e.target!.dispatchEvent(newWizardEvent());
+              if (wizard) e.target!.dispatchEvent(newSubWizardEvent(wizard));
             }}
           >
             ${Array.from(lnodetype.querySelectorAll('DO')).map(

--- a/src/wizards/abstractda.ts
+++ b/src/wizards/abstractda.ts
@@ -16,6 +16,8 @@ import { maxLength, patterns } from './foundation/limits.js';
 import { predefinedBasicTypeEnum, valKindEnum } from './foundation/enums.js';
 
 function selectType(e: SelectedEvent, data: Element, Val: string | null): void {
+  if (!e.target || !(e.target as Select).parentElement) return;
+
   const typeSelected = (<Select>e.target).selected?.value;
   const selectedBType = (<WizardSelect>(
     (<Select>e.target).parentElement!.querySelector(


### PR DESCRIPTION
Working in template wizard can be confusing, especially when cancel means starting from scratch. That is why the subwizard option is perfect here.