### PR TITLE
fix(editors/template): create element with NS definition

### DIFF
--- a/src/editors/templates/datype-wizards.ts
+++ b/src/editors/templates/datype-wizards.ts
@@ -13,6 +13,7 @@ import { SingleSelectedEvent } from '@material/mwc-list/mwc-list-foundation';
 import '../../wizard-textfield.js';
 import {
   Create,
+  createElement,
   EditorAction,
   getValue,
   identity,
@@ -154,7 +155,7 @@ function addPredefinedDAType(
       : null;
     const element = values.selected
       ? <Element>selectedElement!.cloneNode(true)
-      : parent.ownerDocument.createElement('DAType');
+      : createElement(parent.ownerDocument, 'DAType', {});
 
     element.setAttribute('id', id);
     if (desc) element.setAttribute('desc', desc);

--- a/src/editors/templates/enumtype-wizard.ts
+++ b/src/editors/templates/enumtype-wizard.ts
@@ -188,7 +188,7 @@ function createAction(parent: Element, templates: XMLDocument): WizardActor {
             .querySelector(`EnumType[id="${values.selected.value}"]`)!
             .cloneNode(true)
         )
-      : parent.ownerDocument.createElement('EnumType');
+      : createElement(parent.ownerDocument, 'EnumType', {});
 
     element.setAttribute('id', id);
     if (desc) element.setAttribute('desc', desc);


### PR DESCRIPTION
Creating element without NS definition is not valid for this specific XML files we are working with.