### PR TITLE
refactor(editors/subscriber): minor changes

### DIFF
--- a/src/editors/subscription/foundation.ts
+++ b/src/editors/subscription/foundation.ts
@@ -1,0 +1,25 @@
+export interface GOOSESelectDetail {
+  iedName: string;
+  gseControl: Element;
+  dataset: Element;
+}
+export type GOOSESelectEvent = CustomEvent<GOOSESelectDetail>;
+export function newGOOSESelectEvent(
+  iedName: string,
+  gseControl: Element,
+  dataset: Element,
+  eventInitDict?: CustomEventInit<GOOSESelectDetail>
+): GOOSESelectEvent {
+  return new CustomEvent<GOOSESelectDetail>('goose-dataset', {
+    bubbles: true,
+    composed: true,
+    ...eventInitDict,
+    detail: { iedName, gseControl, dataset, ...eventInitDict?.detail },
+  });
+}
+
+declare global {
+  interface ElementEventMap {
+    ['goose-dataset']: GOOSESelectEvent;
+  }
+}

--- a/src/editors/subscription/goose-message.ts
+++ b/src/editors/subscription/goose-message.ts
@@ -6,6 +6,10 @@ import {
   property,
   TemplateResult,
 } from 'lit-element';
+
+import '@material/mwc-icon';
+import '@material/mwc-list/mwc-list-item';
+
 import { gooseIcon } from '../../icons.js';
 import { newGOOSESelectEvent } from './foundation.js';
 

--- a/src/editors/subscription/goose-message.ts
+++ b/src/editors/subscription/goose-message.ts
@@ -6,8 +6,8 @@ import {
   property,
   TemplateResult,
 } from 'lit-element';
-import { newGOOSESelectEvent } from '../../foundation.js';
 import { gooseIcon } from '../../icons.js';
+import { newGOOSESelectEvent } from './foundation.js';
 
 @customElement('goose-message')
 export class GOOSEMessage extends LitElement {

--- a/src/editors/subscription/goose-message.ts
+++ b/src/editors/subscription/goose-message.ts
@@ -17,7 +17,9 @@ export class GOOSEMessage extends LitElement {
 
   private onGooseSelect = () => {
     const ln = this.element.parentElement;
-    const dataset = ln?.querySelector(`DataSet[name=${this.element.getAttribute('datSet')}]`);
+    const dataset = ln?.querySelector(
+      `DataSet[name=${this.element.getAttribute('datSet')}]`
+    );
     this.dispatchEvent(
       newGOOSESelectEvent(
         this.element.closest('IED')?.getAttribute('name') ?? '',
@@ -28,9 +30,7 @@ export class GOOSEMessage extends LitElement {
   };
 
   render(): TemplateResult {
-    return html`<mwc-list-item
-      @click=${this.onGooseSelect}
-      graphic="large">
+    return html`<mwc-list-item @click=${this.onGooseSelect} graphic="large">
       <span>${this.element.getAttribute('name')}</span>
       <mwc-icon slot="graphic">${gooseIcon}</mwc-icon>
     </mwc-list-item>`;

--- a/src/editors/subscription/publisher-goose-list.ts
+++ b/src/editors/subscription/publisher-goose-list.ts
@@ -6,22 +6,27 @@ import {
   property,
   TemplateResult,
 } from 'lit-element';
+import { translate } from 'lit-translate';
+
+import '@material/mwc-icon';
+import '@material/mwc-list';
+import '@material/mwc-list/mwc-list-item';
 
 import './goose-message.js';
-
-import { translate } from 'lit-translate';
 import { compareNames, getNameAttribute } from '../../foundation.js';
 import { styles } from '../templates/foundation.js';
 
 /** An sub element for showing all published GOOSE messages per IED. */
 @customElement('publisher-goose-list')
 export class PublisherGOOSEList extends LitElement {
-  @property()
+  @property({ attribute: false })
   doc!: XMLDocument;
 
-  private get ieds() : Element[] {
-    return (this.doc)
-      ? Array.from(this.doc.querySelectorAll(':root > IED')).sort((a,b) => compareNames(a,b))
+  private get ieds(): Element[] {
+    return this.doc
+      ? Array.from(this.doc.querySelectorAll(':root > IED')).sort((a, b) =>
+          compareNames(a, b)
+        )
       : [];
   }
 
@@ -30,37 +35,40 @@ export class PublisherGOOSEList extends LitElement {
    * @param ied - The IED to search through.
    * @returns All the published GOOSE messages of this specific IED.
    */
-  private getGSEControls(ied: Element) : Element[] {
-    return Array.from(ied.querySelectorAll(':scope > AccessPoint > Server > LDevice > LN0[lnClass="LLN0"] > GSEControl'));
+  private getGSEControls(ied: Element): Element[] {
+    return Array.from(
+      ied.querySelectorAll(
+        ':scope > AccessPoint > Server > LDevice > LN0[lnClass="LLN0"] > GSEControl'
+      )
+    );
   }
 
   render(): TemplateResult {
-    return html`
-    <section>
+    return html` <section>
       <h1>${translate('subscription.publisherGoose.title')}</h1>
       <mwc-list>
         ${this.ieds.map(ied =>
-          ied.querySelector('GSEControl') ?
-            html`
-              <mwc-list-item noninteractive graphic="icon">
-                <span class="iedListTitle">${getNameAttribute(ied)}</span>
-                <mwc-icon slot="graphic">developer_board</mwc-icon>
-              </mwc-list-item>
-              <li divider role="separator"></li>
-              ${this.getGSEControls(ied).map(control =>
-                html`<goose-message
-                  .element=${control}
-                ></goose-message>`)}
-            ` : ``
-          )
-        }
-        </mwc-list>
-      </section>`;
+          ied.querySelector('GSEControl')
+            ? html`
+                <mwc-list-item noninteractive graphic="icon">
+                  <span class="iedListTitle">${getNameAttribute(ied)}</span>
+                  <mwc-icon slot="graphic">developer_board</mwc-icon>
+                </mwc-list-item>
+                <li divider role="separator"></li>
+                ${this.getGSEControls(ied).map(
+                  control =>
+                    html`<goose-message .element=${control}></goose-message>`
+                )}
+              `
+            : ``
+        )}
+      </mwc-list>
+    </section>`;
   }
 
   static styles = css`
     ${styles}
-  
+
     mwc-list {
       height: 100vh;
       overflow-y: scroll;

--- a/src/editors/subscription/subscriber-ied-list.ts
+++ b/src/editors/subscription/subscriber-ied-list.ts
@@ -8,6 +8,11 @@ import {
   TemplateResult,
 } from 'lit-element';
 import { translate } from 'lit-translate';
+
+import '@material/mwc-icon';
+import '@material/mwc-list';
+import '@material/mwc-list/mwc-list-item';
+
 import { styles } from '../templates/foundation.js';
 import { GOOSESelectEvent } from './foundation.js';
 

--- a/src/editors/subscription/subscriber-ied-list.ts
+++ b/src/editors/subscription/subscriber-ied-list.ts
@@ -25,12 +25,12 @@ interface IED {
  * All available FCDA references that are used to link ExtRefs.
  */
 const fcdaReferences = [
-  "ldInst",
-  "lnClass",
-  "lnInst",
-  "prefix",
-  "doName",
-  "daName",
+  'ldInst',
+  'lnClass',
+  'lnInst',
+  'prefix',
+  'doName',
+  'daName',
 ];
 
 /** An sub element for subscribing and unsubscribing IEDs to GOOSE messages. */
@@ -50,7 +50,7 @@ export class SubscriberIEDList extends LitElement {
 
   /** Current selected GSEControl element. */
   gseControl!: Element;
-  
+
   @query('div') subscriberWrapper!: Element;
 
   constructor() {
@@ -58,7 +58,10 @@ export class SubscriberIEDList extends LitElement {
     this.onGOOSEDataSetEvent = this.onGOOSEDataSetEvent.bind(this);
     const openScdElement = document.querySelector('open-scd');
     if (openScdElement) {
-      openScdElement.addEventListener('goose-dataset', this.onGOOSEDataSetEvent);
+      openScdElement.addEventListener(
+        'goose-dataset',
+        this.onGOOSEDataSetEvent
+      );
     }
   }
 
@@ -79,12 +82,12 @@ export class SubscriberIEDList extends LitElement {
       const inputElements = ied.querySelectorAll(`LN0 > Inputs, LN > Inputs`);
 
       let numberOfLinkedExtRefs = 0;
-      
+
       /**
        * If no Inputs element is found, we can safely say it's not subscribed.
        */
       if (!inputElements) {
-        this.availableIeds.push({element: ied});
+        this.availableIeds.push({ element: ied });
         return;
       }
 
@@ -93,33 +96,38 @@ export class SubscriberIEDList extends LitElement {
        */
       dataSet.querySelectorAll('FCDA').forEach(fcda => {
         inputElements.forEach(inputs => {
-          if(inputs.querySelector(`ExtRef[iedName=${event.detail.iedName}]` +
-            `${fcdaReferences.map(fcdaRef =>
-              fcda.getAttribute(fcdaRef)
-                ? `[${fcdaRef}="${fcda.getAttribute(fcdaRef)}"]`
-                : '').join('')
-              }`)) {
-              numberOfLinkedExtRefs++;
-            }
-        })
-      })
+          if (
+            inputs.querySelector(
+              `ExtRef[iedName=${event.detail.iedName}]` +
+                `${fcdaReferences
+                  .map(fcdaRef =>
+                    fcda.getAttribute(fcdaRef)
+                      ? `[${fcdaRef}="${fcda.getAttribute(fcdaRef)}"]`
+                      : ''
+                  )
+                  .join('')}`
+            )
+          ) {
+            numberOfLinkedExtRefs++;
+          }
+        });
+      });
 
       /**
        * Make a distinction between not subscribed at all,
        * partially subscribed and fully subscribed.
        */
       if (numberOfLinkedExtRefs == 0) {
-        this.availableIeds.push({element: ied});
+        this.availableIeds.push({ element: ied });
         return;
       }
 
       if (numberOfLinkedExtRefs == dataSet.querySelectorAll('FCDA').length) {
-        this.subscribedIeds.push({element: ied});
+        this.subscribedIeds.push({ element: ied });
       } else {
-        this.availableIeds.push({element: ied, partial: true});
+        this.availableIeds.push({ element: ied, partial: true });
       }
-      
-    })
+    });
 
     this.requestUpdate();
   }
@@ -134,7 +142,7 @@ export class SubscriberIEDList extends LitElement {
 
   protected updated(): void {
     if (this.subscriberWrapper) {
-      this.subscriberWrapper.scrollTo(0,0);
+      this.subscriberWrapper.scrollTo(0, 0);
     }
   }
 
@@ -144,63 +152,84 @@ export class SubscriberIEDList extends LitElement {
 
     return html`
       <section>
-        <h1>${translate('subscription.subscriberIed.title', {
-          selected: gseControlName ? this.iedName + ' > ' + gseControlName : 'IED'
-        })}</h1>
-        ${this.gseControl ?
-        html`<div class="subscriberWrapper">
-          <mwc-list>
-            <mwc-list-item noninteractive>
-              <span class="iedListTitle">${translate('subscription.subscriberIed.subscribed')}</span>
-            </mwc-list-item>
-            <li divider role="separator"></li>
-            ${this.subscribedIeds.length > 0 ?
-              this.subscribedIeds.map(ied => html`
-              <mwc-list-item graphic="avatar" hasMeta>
-                <span>${ied.element.getAttribute('name')}</span>
-                <mwc-icon slot="graphic">clear</mwc-icon>
-              </mwc-list-item>`)
-              : html`<mwc-list-item graphic="avatar" noninteractive>
-                <span>${translate('subscription.none')}</span>
-              </mwc-list-item>`}
-            </mwc-list>
-            <mwc-list>
+        <h1>
+          ${translate('subscription.subscriberIed.title', {
+            selected: gseControlName
+              ? this.iedName + ' > ' + gseControlName
+              : 'IED',
+          })}
+        </h1>
+        ${this.gseControl
+          ? html`<div class="subscriberWrapper">
+              <mwc-list>
+                <mwc-list-item noninteractive>
+                  <span class="iedListTitle"
+                    >${translate('subscription.subscriberIed.subscribed')}</span
+                  >
+                </mwc-list-item>
+                <li divider role="separator"></li>
+                ${this.subscribedIeds.length > 0
+                  ? this.subscribedIeds.map(
+                      ied => html` <mwc-list-item graphic="avatar" hasMeta>
+                        <span>${ied.element.getAttribute('name')}</span>
+                        <mwc-icon slot="graphic">clear</mwc-icon>
+                      </mwc-list-item>`
+                    )
+                  : html`<mwc-list-item graphic="avatar" noninteractive>
+                      <span>${translate('subscription.none')}</span>
+                    </mwc-list-item>`}
+              </mwc-list>
+              <mwc-list>
+                <mwc-list-item noninteractive>
+                  <span class="iedListTitle"
+                    >${translate(
+                      'subscription.subscriberIed.partiallySubscribed'
+                    )}</span
+                  >
+                </mwc-list-item>
+                <li divider role="separator"></li>
+                ${partialSubscribedIeds.length > 0
+                  ? partialSubscribedIeds.map(
+                      ied => html` <mwc-list-item graphic="avatar" hasMeta>
+                        <span>${ied.element.getAttribute('name')}</span>
+                        <mwc-icon slot="graphic">add</mwc-icon>
+                      </mwc-list-item>`
+                    )
+                  : html`<mwc-list-item graphic="avatar" noninteractive>
+                      <span>${translate('subscription.none')}</span>
+                    </mwc-list-item>`}
+              </mwc-list>
+              <mwc-list>
+                <mwc-list-item noninteractive>
+                  <span class="iedListTitle"
+                    >${translate(
+                      'subscription.subscriberIed.availableToSubscribe'
+                    )}</span
+                  >
+                </mwc-list-item>
+                <li divider role="separator"></li>
+                ${this.availableIeds.length > 0
+                  ? this.availableIeds.map(
+                      ied => html` <mwc-list-item graphic="avatar" hasMeta>
+                        <span>${ied.element.getAttribute('name')}</span>
+                        <mwc-icon slot="graphic">add</mwc-icon>
+                      </mwc-list-item>`
+                    )
+                  : html`<mwc-list-item graphic="avatar" noninteractive>
+                      <span>${translate('subscription.none')}</span>
+                    </mwc-list-item>`}
+              </mwc-list>
+            </div>`
+          : html`<mwc-list>
               <mwc-list-item noninteractive>
-                <span class="iedListTitle">${translate('subscription.subscriberIed.partiallySubscribed')}</span>
-              </mwc-list-item>
-              <li divider role="separator"></li>
-              ${partialSubscribedIeds.length > 0 ?
-                partialSubscribedIeds.map(ied => html`
-                <mwc-list-item graphic="avatar" hasMeta>
-                  <span>${ied.element.getAttribute('name')}</span>
-                  <mwc-icon slot="graphic">add</mwc-icon>
-                </mwc-list-item>`)
-                : html`<mwc-list-item graphic="avatar" noninteractive>
-                <span>${translate('subscription.none')}</span>
-              </mwc-list-item>`}
-            </mwc-list>
-            <mwc-list>
-              <mwc-list-item noninteractive>
-                <span class="iedListTitle">${translate('subscription.subscriberIed.availableToSubscribe')}</span>
-              </mwc-list-item>
-              <li divider role="separator"></li>
-              ${this.availableIeds.length > 0 ?
-                this.availableIeds.map(ied => html`
-                <mwc-list-item graphic="avatar" hasMeta>
-                  <span>${ied.element.getAttribute('name')}</span>
-                  <mwc-icon slot="graphic">add</mwc-icon>
-                </mwc-list-item>`)
-                : html`<mwc-list-item graphic="avatar" noninteractive>
-                <span>${translate('subscription.none')}</span>
-              </mwc-list-item>`}
-            </mwc-list>` : html`<mwc-list>
-              <mwc-list-item noninteractive>
-                <span class="iedListTitle">${translate('subscription.subscriberIed.noGooseMessageSelected')}</span>
+                <span class="iedListTitle">${translate(
+                  'subscription.subscriberIed.noGooseMessageSelected'
+                )}</span>
               </mwc-list-item>
             </mwc-list>
           </div>`}
-        </section>
-      `;
+      </section>
+    `;
   }
 
   static styles = css`
@@ -211,7 +240,7 @@ export class SubscriberIEDList extends LitElement {
       white-space: unset;
       text-overflow: unset;
     }
-    
+
     .subscriberWrapper {
       height: 100vh;
       overflow-y: scroll;

--- a/src/editors/subscription/subscriber-ied-list.ts
+++ b/src/editors/subscription/subscriber-ied-list.ts
@@ -8,8 +8,8 @@ import {
   TemplateResult,
 } from 'lit-element';
 import { translate } from 'lit-translate';
-import { GOOSESelectEvent } from '../../foundation.js';
 import { styles } from '../templates/foundation.js';
+import { GOOSESelectEvent } from './foundation.js';
 
 /**
  * An IED within this IED list has 2 properties:

--- a/src/foundation.ts
+++ b/src/foundation.ts
@@ -280,26 +280,6 @@ export interface ResetDetail {
   kind: 'reset';
 }
 
-export interface GOOSESelectDetail {
-  iedName: string;
-  gseControl: Element;
-  dataset: Element;
-}
-export type GOOSESelectEvent = CustomEvent<GOOSESelectDetail>;
-export function newGOOSESelectEvent(
-  iedName: string,
-  gseControl: Element,
-  dataset: Element,
-  eventInitDict?: CustomEventInit<GOOSESelectDetail>
-): GOOSESelectEvent {
-  return new CustomEvent<GOOSESelectDetail>('goose-dataset', {
-    bubbles: true,
-    composed: true,
-    ...eventInitDict,
-    detail: { iedName, gseControl, dataset, ...eventInitDict?.detail },
-  });
-}
-
 export type LogDetail = InfoDetail | CommitDetail | ResetDetail;
 export type LogEvent = CustomEvent<LogDetail>;
 export function newLogEvent(
@@ -2657,7 +2637,6 @@ declare global {
     ['open-doc']: OpenDocEvent;
     ['wizard']: WizardEvent;
     ['validate']: ValidateEvent;
-    ['goose-dataset']: GOOSESelectEvent;
     ['log']: LogEvent;
     ['issue']: IssueEvent;
   }


### PR DESCRIPTION
I wanted to move the `GOOSEselect` event definition to the foundation of the same plugin. This is not used globally and so long it is, so it should be allocated to the plugin only