### PR TITLE
feat(foundation): add schema attribute definition parser

### DIFF
--- a/src/editors/singlelinediagram/wizards/foundation.ts
+++ b/src/editors/singlelinediagram/wizards/foundation.ts
@@ -6,7 +6,7 @@ import {
   EditorAction,
   getValue,
   WizardActor,
-  WizardInput,
+  WizardInputElement,
 } from '../../../foundation.js';
 import { SCL_COORDINATES_NAMESPACE } from "../foundation.js";
 
@@ -48,7 +48,7 @@ function updateXYAttribute(element: Element, attributeName: string, value: strin
 }
 
 export function updateNamingAndCoordinatesAction(element: Element): WizardActor {
-  return (inputs: WizardInput[]): EditorAction[] => {
+  return (inputs: WizardInputElement[]): EditorAction[] => {
     const name = getValue(inputs.find(i => i.label === 'name')!)!;
     const desc = getValue(inputs.find(i => i.label === 'desc')!);
     const xCoordinate = getValue(inputs.find(i => i.label === 'xCoordinate')!);

--- a/src/editors/substation/guess-wizard.ts
+++ b/src/editors/substation/guess-wizard.ts
@@ -13,7 +13,7 @@ import {
   EditorAction,
   Wizard,
   WizardActor,
-  WizardInput,
+  WizardInputElement,
 } from '../../foundation.js';
 
 let bayNum = 1;
@@ -169,7 +169,7 @@ function createBayElement(
 
 function guessBasedOnCSWI(doc: XMLDocument): WizardActor {
   return (
-    inputs: WizardInput[],
+    inputs: WizardInputElement[],
     wizard: Element,
     list?: List | null
   ): EditorAction[] => {

--- a/src/editors/templates/datype-wizards.ts
+++ b/src/editors/templates/datype-wizards.ts
@@ -26,7 +26,7 @@ import {
   selector,
   Wizard,
   WizardActor,
-  WizardInput,
+  WizardInputElement,
 } from '../../foundation.js';
 import { createBDAWizard, editBDAWizard } from '../../wizards/bda.js';
 import {
@@ -36,7 +36,7 @@ import {
 } from './foundation.js';
 
 function updateDATpyeAction(element: Element): WizardActor {
-  return (inputs: WizardInput[]): EditorAction[] => {
+  return (inputs: WizardInputElement[]): EditorAction[] => {
     const id = getValue(inputs.find(i => i.label === 'id')!)!;
     const desc = getValue(inputs.find(i => i.label === 'desc')!);
 
@@ -171,7 +171,7 @@ function addPredefinedDAType(
   parent: Element,
   templates: XMLDocument
 ): WizardActor {
-  return (inputs: WizardInput[]): EditorAction[] => {
+  return (inputs: WizardInputElement[]): EditorAction[] => {
     const id = getValue(inputs.find(i => i.label === 'id')!);
 
     if (!id) return [];

--- a/src/editors/templates/dotype-wizards.ts
+++ b/src/editors/templates/dotype-wizards.ts
@@ -26,7 +26,7 @@ import {
   selector,
   Wizard,
   WizardActor,
-  WizardInput,
+  WizardInputElement,
 } from '../../foundation.js';
 import { createDaWizard, editDAWizard } from '../../wizards/da.js';
 import { patterns } from '../../wizards/foundation/limits.js';
@@ -40,7 +40,7 @@ import {
 } from './foundation.js';
 
 function updateSDoAction(element: Element): WizardActor {
-  return (inputs: WizardInput[]): EditorAction[] => {
+  return (inputs: WizardInputElement[]): EditorAction[] => {
     const name = getValue(inputs.find(i => i.label === 'name')!)!;
     const desc = getValue(inputs.find(i => i.label === 'desc')!);
     const type = getValue(inputs.find(i => i.label === 'type')!)!;
@@ -62,7 +62,7 @@ function updateSDoAction(element: Element): WizardActor {
 }
 
 function createSDoAction(parent: Element): WizardActor {
-  return (inputs: WizardInput[]): EditorAction[] => {
+  return (inputs: WizardInputElement[]): EditorAction[] => {
     const name = getValue(inputs.find(i => i.label === 'name')!)!;
     const desc = getValue(inputs.find(i => i.label === 'desc')!);
     const type = getValue(inputs.find(i => i.label === 'type')!);
@@ -182,7 +182,7 @@ function addPredefinedDOType(
   parent: Element,
   templates: XMLDocument
 ): WizardActor {
-  return (inputs: WizardInput[]): EditorAction[] => {
+  return (inputs: WizardInputElement[]): EditorAction[] => {
     const id = getValue(inputs.find(i => i.label === 'id')!);
 
     if (!id) return [];
@@ -307,7 +307,7 @@ export function createDOTypeWizard(
 }
 
 function updateDOTypeAction(element: Element): WizardActor {
-  return (inputs: WizardInput[]): EditorAction[] => {
+  return (inputs: WizardInputElement[]): EditorAction[] => {
     const id = getValue(inputs.find(i => i.label === 'id')!)!;
     const desc = getValue(inputs.find(i => i.label === 'desc')!);
     const cdc = getValue(inputs.find(i => i.label === 'CDC')!)!;

--- a/src/editors/templates/enumtype-wizard.ts
+++ b/src/editors/templates/enumtype-wizard.ts
@@ -26,7 +26,7 @@ import {
   selector,
   Wizard,
   WizardActor,
-  WizardInput,
+  WizardInputElement,
 } from '../../foundation.js';
 import { CreateOptions, UpdateOptions, WizardOptions } from './foundation.js';
 
@@ -40,7 +40,7 @@ function nextOrd(parent: Element): string {
 }
 
 function createEnumValAction(parent: Element): WizardActor {
-  return (inputs: WizardInput[]): EditorAction[] => {
+  return (inputs: WizardInputElement[]): EditorAction[] => {
     const value = getValue(inputs.find(i => i.label === 'value')!);
     const desc = getValue(inputs.find(i => i.label === 'desc')!);
     const ord =
@@ -65,7 +65,7 @@ function createEnumValAction(parent: Element): WizardActor {
 }
 
 function updateEnumValAction(element: Element): WizardActor {
-  return (inputs: WizardInput[]): EditorAction[] => {
+  return (inputs: WizardInputElement[]): EditorAction[] => {
     const value = getValue(inputs.find(i => i.label === 'value')!) ?? '';
     const desc = getValue(inputs.find(i => i.label === 'desc')!);
     const ord =
@@ -172,7 +172,7 @@ function eNumValWizard(options: WizardOptions): Wizard {
 }
 
 function createAction(parent: Element, templates: XMLDocument): WizardActor {
-  return (inputs: WizardInput[]): EditorAction[] => {
+  return (inputs: WizardInputElement[]): EditorAction[] => {
     const id = getValue(inputs.find(i => i.label === 'id')!);
 
     if (!id) return [];
@@ -255,7 +255,7 @@ export function createEnumTypeWizard(
 }
 
 function updateEnumTpyeAction(element: Element): WizardActor {
-  return (inputs: WizardInput[]): EditorAction[] => {
+  return (inputs: WizardInputElement[]): EditorAction[] => {
     const id = getValue(inputs.find(i => i.label === 'id')!)!;
     const desc = getValue(inputs.find(i => i.label === 'desc')!);
 

--- a/src/editors/templates/foundation.ts
+++ b/src/editors/templates/foundation.ts
@@ -1,17 +1,8 @@
-import { css, html, TemplateResult } from 'lit-element';
-import { ifDefined } from 'lit-html/directives/if-defined';
+import { css } from 'lit-element';
 
 import '@material/mwc-list/mwc-list-item';
 
-import {
-  cloneElement,
-  Create,
-  EditorAction,
-  getValue,
-  isPublic,
-  WizardActor,
-  WizardInput,
-} from '../../foundation.js';
+import { Create, isPublic } from '../../foundation.js';
 
 export interface UpdateOptions {
   identity: string | null;

--- a/src/editors/templates/lnodetype-wizard.ts
+++ b/src/editors/templates/lnodetype-wizard.ts
@@ -30,7 +30,7 @@ import {
   selector,
   Wizard,
   WizardActor,
-  WizardInput,
+  WizardInputElement,
 } from '../../foundation.js';
 import { WizardSelect } from '../../wizard-select.js';
 import {
@@ -43,7 +43,7 @@ import {
 } from './foundation.js';
 
 function updateDoAction(element: Element): WizardActor {
-  return (inputs: WizardInput[]): EditorAction[] => {
+  return (inputs: WizardInputElement[]): EditorAction[] => {
     const name = getValue(inputs.find(i => i.label === 'name')!)!;
     const desc = getValue(inputs.find(i => i.label === 'desc')!);
     const type = getValue(inputs.find(i => i.label === 'type')!)!;
@@ -78,7 +78,7 @@ function updateDoAction(element: Element): WizardActor {
 }
 
 function createDoAction(parent: Element): WizardActor {
-  return (inputs: WizardInput[]): EditorAction[] => {
+  return (inputs: WizardInputElement[]): EditorAction[] => {
     const name = getValue(inputs.find(i => i.label === 'name')!)!;
     const desc = getValue(inputs.find(i => i.label === 'desc')!);
     const type = getValue(inputs.find(i => i.label === 'type')!);
@@ -255,7 +255,7 @@ function getAllDataObjects(nsd74: XMLDocument, base: string): Element[] {
 }
 
 function createNewLNodeType(parent: Element, element: Element): WizardActor {
-  return (_: WizardInput[], wizard: Element): EditorAction[] => {
+  return (_: WizardInputElement[], wizard: Element): EditorAction[] => {
     const selected = Array.from(
       wizard.shadowRoot!.querySelectorAll<WizardSelect>('wizard-select')
     ).filter(select => select.maybeValue);
@@ -368,7 +368,7 @@ function startLNodeTypeCreate(
   templates: XMLDocument,
   nsd74: XMLDocument
 ): WizardActor {
-  return (inputs: WizardInput[], wizard: Element): EditorAction[] => {
+  return (inputs: WizardInputElement[], wizard: Element): EditorAction[] => {
     const id = getValue(inputs.find(i => i.label === 'id')!);
     if (!id) return [];
 
@@ -517,7 +517,7 @@ export function createLNodeTypeWizard(
 }
 
 function updateLNodeTypeAction(element: Element): WizardActor {
-  return (inputs: WizardInput[]): EditorAction[] => {
+  return (inputs: WizardInputElement[]): EditorAction[] => {
     const id = getValue(inputs.find(i => i.label === 'id')!)!;
     const desc = getValue(inputs.find(i => i.label === 'desc')!);
     const lnClass = getValue(inputs.find(i => i.label === 'lnClass')!)!;

--- a/src/foundation.ts
+++ b/src/foundation.ts
@@ -225,10 +225,77 @@ export function getMultiplier(input: WizardInputElement): string | null {
   else return null;
 }
 
+/** Inputs as `TextField`, `Select` or `Checkbox `used in`wizard-dialog` */
+export type WizardInput =
+  | WizardInputTextField
+  | WizardInputSelect
+  | WizardInputCheckbox;
+
+interface WizardInputBase {
+  /** maps attribute key */
+  label: string;
+  /** maps attribute value */
+  maybeValue: string | null;
+  /** whether attribute is optional */
+  nullable?: boolean;
+  /** whether the input shall be disabled */
+  disabled?: boolean;
+  /** helper text */
+  helper?: string;
+  /** initial focused element in `wizard-dialog` (once per dialog) */
+  dialogInitialFocus?: boolean;
+}
+
+interface WizardInputTextField extends WizardInputBase {
+  kind: 'TextField';
+  /** wether the input might be empty string */
+  required?: boolean;
+  /** pattern definition from schema */
+  pattern?: string;
+  /** minimal characters allowed */
+  minLength?: number;
+  /** maximal characters allowed */
+  maxLength?: number;
+  /** message text explaining invalid inputs */
+  validationMessage?: string;
+  /** suffix definition - overwrites unit multiplier definition */
+  suffix?: string;
+  /** SI unit for specific suffix definition */
+  unit?: string;
+  /** in comibination with unit defines specific suffix */
+  multiplier?: string | null;
+  /** array of multipliers allowed for the input */
+  multipliers?: (string | null)[];
+  /** used for specific input type e.g. number */
+  type?: string;
+  /** minimal valid number in combination with type number */
+  min?: number;
+  /** maximal valid number in combination with type number */
+  max?: number;
+  /** value displaxed when input is nulled */
+  default?: string;
+}
+
+interface WizardInputSelect extends WizardInputBase {
+  kind: 'Select';
+  /** selectabled values */
+  values: string[];
+  /** value displayed with input is nulled */
+  default?: string;
+  /** message explaining invalid inputs */
+  valadationMessage?: string;
+}
+
+interface WizardInputCheckbox extends WizardInputBase {
+  kind: 'Checkbox';
+  /** wether checkbox is checked with nulled input */
+  default?: boolean;
+}
+
 /** Represents a page of a wizard dialog */
 export interface WizardPage {
   title: string;
-  content?: TemplateResult[];
+  content?: (TemplateResult | WizardInput)[];
   primary?: {
     icon: string;
     label: string;

--- a/src/foundation.ts
+++ b/src/foundation.ts
@@ -171,7 +171,7 @@ export function newActionEvent<T extends EditorAction>(
 
 export const wizardInputSelector =
   'wizard-textfield, mwc-textfield, ace-editor, mwc-select,wizard-select, wizard-checkbox';
-export type WizardInput =
+export type WizardInputElement =
   | WizardTextField
   | TextField
   | (AceEditor & { checkValidity: () => boolean; label: string })
@@ -183,7 +183,7 @@ export type WizardAction = EditorAction | WizardFactory;
 
 /** @returns [[`EditorAction`]]s to dispatch on [[`WizardDialog`]] commit. */
 export type WizardActor = (
-  inputs: WizardInput[],
+  inputs: WizardInputElement[],
   wizard: Element,
   list?: List | null
 ) => WizardAction[];
@@ -195,21 +195,21 @@ export function isWizardFactory(
 }
 
 /** @returns the validity of `input` depending on type. */
-export function checkValidity(input: WizardInput): boolean {
+export function checkValidity(input: WizardInputElement): boolean {
   if (input instanceof WizardTextField || input instanceof Select)
     return input.checkValidity();
   else return true;
 }
 
 /** reports the validity of `input` depending on type. */
-export function reportValidity(input: WizardInput): boolean {
+export function reportValidity(input: WizardInputElement): boolean {
   if (input instanceof WizardTextField || input instanceof Select)
     return input.reportValidity();
   else return true;
 }
 
 /** @returns the `value` or `maybeValue` of `input` depending on type. */
-export function getValue(input: WizardInput): string | null {
+export function getValue(input: WizardInputElement): string | null {
   if (
     input instanceof WizardTextField ||
     input instanceof WizardSelect ||
@@ -220,7 +220,7 @@ export function getValue(input: WizardInput): string | null {
 }
 
 /** @returns the `multiplier` of `input` if available. */
-export function getMultiplier(input: WizardInput): string | null {
+export function getMultiplier(input: WizardInputElement): string | null {
   if (input instanceof WizardTextField) return input.multiplier;
   else return null;
 }

--- a/src/foundation.ts
+++ b/src/foundation.ts
@@ -10,6 +10,12 @@ import { WizardTextField } from './wizard-textfield.js';
 import { WizardSelect } from './wizard-select.js';
 import { WizardCheckbox } from './wizard-checkbox.js';
 
+export {
+  schemaAttributeDefinition,
+  AttributeDefinition,
+  AttributeRestriction,
+} from './foundation/schema/attributes.js';
+
 export type SimpleAction = Update | Create | Replace | Delete | Move;
 export type ComplexAction = {
   actions: SimpleAction[];

--- a/src/foundation/schema/attributes.ts
+++ b/src/foundation/schema/attributes.ts
@@ -1,0 +1,190 @@
+export interface AttributeDefinition {
+  name: string;
+  type: string;
+  required: boolean;
+  default: string | null;
+  enumeration: string[];
+  restriction: AttributeRestriction;
+}
+
+export interface AttributeRestriction {
+  base?: string;
+  pattern?: string;
+  maxLength?: string;
+  minLength?: string;
+}
+
+function getEnumeration(
+  base: string | null | undefined,
+  schema: XMLDocument
+): string[] {
+  if (!base) return [];
+
+  const simpleType = schema.querySelector(`simpleType[name="${base}"]`);
+
+  const union = simpleType?.querySelector('union');
+  if (union) {
+    const memberTypes = union.getAttribute('memberTypes')?.split(' ') ?? [];
+    const enumeration = memberTypes.flatMap(base =>
+      getEnumeration(base, schema)
+    );
+
+    return enumeration;
+  }
+
+  const enumerations = <string[]>Array.from(
+    simpleType?.querySelectorAll('enumeration') ?? []
+  )
+    .map(enumeration => enumeration.getAttribute('value'))
+    .filter(value => value);
+
+  return enumerations;
+}
+
+function getAttributeRestriction(
+  base: string | null | undefined,
+  schema: XMLDocument
+): AttributeRestriction {
+  if (!base) return {};
+
+  const simpleType = schema.querySelector(`simpleType[name="${base}"]`);
+
+  const union = simpleType?.querySelector('union');
+  if (union) {
+    const memberTypes = union.getAttribute('memberTypes')?.split(' ') ?? [];
+    const restrictions = memberTypes.map(base =>
+      getAttributeRestriction(base, schema)
+    );
+
+    const pattern = restrictions
+      .filter(restriction => restriction.pattern)
+      .map(restriction => restriction.pattern)
+      .join('|');
+
+    const definedMinLengths = restrictions.filter(
+      restriction => restriction.minLength
+    );
+
+    const minLength = definedMinLengths.length
+      ? Math.min(
+          ...definedMinLengths.map(restriction =>
+            parseInt(restriction.minLength!)
+          )
+        ) + ''
+      : undefined;
+
+    const definedMaxLengths = restrictions.filter(
+      restriction => restriction.maxLength
+    );
+
+    const maxLength = definedMaxLengths.length
+      ? Math.max(
+          ...definedMaxLengths.map(restriction =>
+            parseInt(restriction.maxLength!)
+          )
+        ) + ''
+      : undefined;
+
+    const base = restrictions[0]?.base;
+
+    return { base, pattern, maxLength, minLength };
+  }
+
+  const restrictionElement = simpleType?.querySelector('restriction');
+
+  const maxLenght = restrictionElement
+    ?.querySelector('restriction > maxLength')
+    ?.getAttribute('value');
+  const minLength = restrictionElement
+    ?.querySelector('restriction > minLength')
+    ?.getAttribute('value');
+  const length = restrictionElement
+    ?.querySelector('restriction > length')
+    ?.getAttribute('value');
+  const pattern = Array.from(
+    restrictionElement?.querySelectorAll(
+      'restriction > pattern,restriction > enumeration'
+    ) ?? []
+  )
+    .map(pattern => pattern.getAttribute('value')!)
+    .join('|');
+
+  const restriction = getAttributeRestriction(
+    restrictionElement?.getAttribute('base'),
+    schema
+  );
+
+  if (base.startsWith('xs:')) restriction['base'] = base;
+  if (maxLenght) restriction['maxLength'] = maxLenght;
+  if (minLength) restriction['minLength'] = minLength;
+  if (!minLength && !maxLenght && length) {
+    restriction['maxLength'] = length;
+    restriction['minLength'] = length;
+  }
+  if (pattern) restriction['pattern'] = pattern;
+
+  return restriction;
+}
+
+function getSchemaElementsAttribute(
+  base: string | null,
+  schema: XMLDocument
+): Element[] {
+  if (!base) return [];
+
+  const complexType = schema.querySelector(`complexType[name="${base}"]`);
+  if (!complexType) return [];
+
+  const extention = complexType.querySelector('complexContent > extension');
+  if (!extention) return [];
+
+  const referencedBase = extention.getAttribute('base');
+  const attributes = Array.from(
+    complexType.querySelectorAll('complexContent > extension > attribute')
+  );
+
+  const attributeGroups = Array.from(
+    complexType.querySelectorAll('complexContent > extension > attributeGroup')
+  );
+
+  const attributesFromGroup = attributeGroups.flatMap(attributeGroup =>
+    Array.from(
+      schema.querySelectorAll<Element>(
+        `attributeGroup[name="${attributeGroup.getAttribute(
+          'ref'
+        )}"] > attribute`
+      )
+    )
+  );
+
+  return [
+    ...attributes,
+    ...attributesFromGroup,
+    ...getSchemaElementsAttribute(referencedBase, schema),
+  ];
+}
+
+export function schemaAttributeDefinition(
+  tagName: string,
+  schema: XMLDocument
+): AttributeDefinition[] {
+  const base = 't' + tagName;
+
+  return getSchemaElementsAttribute(base, schema).map(attribute => {
+    const name = attribute.getAttribute('name')!;
+    const required = attribute.getAttribute('use') === 'true';
+    const inCaseMissing = attribute.getAttribute('default');
+    const type = attribute.getAttribute('type')!;
+    const enumeration = getEnumeration(type, schema);
+    const restriction = getAttributeRestriction(type, schema);
+
+    return {
+      name,
+      type,
+      required,
+      default: inCaseMissing,
+      enumeration,
+      restriction,
+    };
+  });
+}

--- a/src/menu/NewProject.ts
+++ b/src/menu/NewProject.ts
@@ -12,13 +12,13 @@ import {
   newOpenDocEvent,
   newWizardEvent,
   Wizard,
-  WizardInput,
+  WizardInputElement,
 } from '../foundation.js';
 import { newEmptySCD, SupportedVersion } from '../schemas.js';
 
 export default class NewProjectPlugin extends LitElement {
   private createNewProject(
-    inputs: WizardInput[],
+    inputs: WizardInputElement[],
     wizard: Element
   ): EditorAction[] {
     const docName = inputs[0].value?.match(/\.s[sc]d$/i)

--- a/src/menu/UpdateDescriptionABB.ts
+++ b/src/menu/UpdateDescriptionABB.ts
@@ -16,7 +16,7 @@ import {
   Wizard,
   WizardAction,
   WizardActor,
-  WizardInput,
+  WizardInputElement,
 } from '../foundation.js';
 
 interface addDescItem {
@@ -27,7 +27,7 @@ interface addDescItem {
 
 function addDescriptionAction(doc: XMLDocument): WizardActor {
   return (
-    _: WizardInput[],
+    _: WizardInputElement[],
     wizard: Element,
     list: List | null | undefined
   ): WizardAction[] => {

--- a/src/menu/UpdateDescriptionSEL.ts
+++ b/src/menu/UpdateDescriptionSEL.ts
@@ -16,7 +16,7 @@ import {
   Wizard,
   WizardAction,
   WizardActor,
-  WizardInput,
+  WizardInputElement,
 } from '../foundation.js';
 
 interface SignalDescription {
@@ -61,7 +61,7 @@ function addDescriptionToSEL(
 
 function addDescriptionAction(doc: XMLDocument): WizardActor {
   return (
-    _: WizardInput[],
+    _: WizardInputElement[],
     wizard: Element,
     list: List | null | undefined
   ): WizardAction[] => {

--- a/src/wizard-dialog.ts
+++ b/src/wizard-dialog.ts
@@ -8,6 +8,7 @@ import {
   TemplateResult,
   html,
 } from 'lit-element';
+import { ifDefined } from 'lit-html/directives/if-defined';
 import { get, translate } from 'lit-translate';
 
 import '@material/mwc-button';
@@ -17,6 +18,9 @@ import { Dialog } from '@material/mwc-dialog';
 import { List } from '@material/mwc-list';
 
 import 'ace-custom-element';
+import './wizard-checkbox.js';
+import './wizard-textfield.js';
+import './wizard-select.js';
 import {
   newActionEvent,
   Wizard,
@@ -31,7 +35,60 @@ import {
   Delete,
   Create,
   identity,
+  WizardInput,
 } from './foundation.js';
+
+function renderWizardInput(
+  input: TemplateResult | WizardInput
+): TemplateResult {
+  if (input instanceof TemplateResult) return input;
+
+  if (input.kind === 'Checkbox')
+    return html`<wizard-checkbox
+      ?nullable=${input.nullable}
+      ?defaultChecked=${input.default}
+      ?dialogInitialFocus=${input.dialogInitialFocus}
+      label="${input.label}"
+      helper="${ifDefined(input.helper)}"
+      .maybeValue=${input.maybeValue}
+    ></wizard-checkbox>`;
+
+  if (input.kind === 'Select')
+    return html`<wizard-select
+      ?nullable=${input.nullable}
+      ?dialogInitialFocus=${input.dialogInitialFocus}
+      label="${input.label}"
+      helper="${ifDefined(input.helper)}"
+      defaultValue="${ifDefined(input.default)}"
+      validationMessage="${ifDefined(input.valadationMessage)}"
+      .maybeValue=${input.maybeValue}
+      >${input.values.map(
+        value => html`<mwc-list-item value="${value}">${value}</mwc-list-item>`
+      )}</wizard-select
+    >`;
+
+  return html`<wizard-textfield
+    ?nullable=${input.nullable}
+    ?required=${input.required}
+    ?disabled=${input.disabled}
+    ?dialogInitialFocus=${input.dialogInitialFocus}
+    label="${input.label}"
+    defaultValue="${ifDefined(input.default)}"
+    helper="${ifDefined(input.helper)}"
+    validationMessage="${ifDefined(input.helper)}"
+    unit="${ifDefined(input.unit)}"
+    .multipliers=${input.multipliers ?? []}
+    .multiplier=${input.multiplier ?? null}
+    suffix="${ifDefined(input.suffix)}"
+    .maybeValue=${input.maybeValue}
+    pattern="${ifDefined(input.pattern)}"
+    minLength="${ifDefined(input.minLength)}"
+    maxLength="${ifDefined(input.maxLength)}"
+    type="${ifDefined(input.type)}"
+    min="${ifDefined(input.min)}"
+    max="${ifDefined(input.max)}"
+  ></wizard-textfield>`;
+}
 
 function dialogInputs(dialog?: Dialog): WizardInputElement[] {
   return Array.from(dialog?.querySelectorAll(wizardInputSelector) ?? []);
@@ -208,7 +265,7 @@ export class WizardDialog extends LitElement {
               mode="ace/mode/xml"
               value="${new XMLSerializer().serializeToString(page.element)}"
             ></ace-editor>`
-          : page.content}
+          : page.content?.map(renderWizardInput)}
       </div>
       ${index > 0
         ? html`<mwc-button

--- a/src/wizard-dialog.ts
+++ b/src/wizard-dialog.ts
@@ -20,7 +20,7 @@ import 'ace-custom-element';
 import {
   newActionEvent,
   Wizard,
-  WizardInput,
+  WizardInputElement,
   WizardPage,
   newWizardEvent,
   WizardActor,
@@ -33,7 +33,7 @@ import {
   identity,
 } from './foundation.js';
 
-function dialogInputs(dialog?: Dialog): WizardInput[] {
+function dialogInputs(dialog?: Dialog): WizardInputElement[] {
   return Array.from(dialog?.querySelectorAll(wizardInputSelector) ?? []);
 }
 
@@ -87,7 +87,7 @@ export class WizardDialog extends LitElement {
   @queryAll('mwc-dialog')
   dialogs!: NodeListOf<Dialog>;
   @queryAll(wizardInputSelector)
-  inputs!: NodeListOf<WizardInput>;
+  inputs!: NodeListOf<WizardInputElement>;
 
   /** The `Dialog` showing the active [[`WizardPage`]]. */
   get dialog(): Dialog | undefined {

--- a/src/wizards/address.ts
+++ b/src/wizards/address.ts
@@ -11,7 +11,7 @@ import {
   createElement,
   Delete,
   getValue,
-  WizardInput,
+  WizardInputElement,
 } from '../foundation.js';
 import {
   pTypesGSESMV,
@@ -57,7 +57,7 @@ function isEqualAddress(oldAddr: Element, newAdddr: Element): boolean {
 }
 
 function createAddressElement(
-  inputs: WizardInput[],
+  inputs: WizardInputElement[],
   parent: Element,
   instType: boolean
 ): Element {
@@ -83,7 +83,7 @@ function createAddressElement(
 
 export function updateAddress(
   parent: Element,
-  inputs: WizardInput[],
+  inputs: WizardInputElement[],
   instType: boolean
 ): (Create | Delete)[] {
   const actions: (Create | Delete)[] = [];

--- a/src/wizards/bay.ts
+++ b/src/wizards/bay.ts
@@ -8,7 +8,7 @@ import {
   getValue,
   Wizard,
   WizardActor,
-  WizardInput,
+  WizardInputElement,
 } from '../foundation.js';
 import { updateNamingAction } from './foundation/actions.js';
 
@@ -32,7 +32,7 @@ export function renderBayWizard(name: string | null, desc: string | null): Templ
 }
 
 export function createAction(parent: Element): WizardActor {
-  return (inputs: WizardInput[]): EditorAction[] => {
+  return (inputs: WizardInputElement[]): EditorAction[] => {
     const name = getValue(inputs.find(i => i.label === 'name')!);
     const desc = getValue(inputs.find(i => i.label === 'desc')!);
     const element = createElement(parent.ownerDocument, 'Bay', {

--- a/src/wizards/bda.ts
+++ b/src/wizards/bda.ts
@@ -13,12 +13,12 @@ import {
   newWizardEvent,
   Wizard,
   WizardActor,
-  WizardInput,
+  WizardInputElement,
 } from '../foundation.js';
 import { getValAction, wizardContent } from './abstractda.js';
 
 export function updateBDaAction(element: Element): WizardActor {
-  return (inputs: WizardInput[]): EditorAction[] => {
+  return (inputs: WizardInputElement[]): EditorAction[] => {
     const name = getValue(inputs.find(i => i.label === 'name')!)!;
     const desc = getValue(inputs.find(i => i.label === 'desc')!);
     const bType = getValue(inputs.find(i => i.label === 'bType')!)!;
@@ -141,7 +141,7 @@ export function editBDAWizard(element: Element): Wizard {
 }
 
 export function createBDaAction(parent: Element): WizardActor {
-  return (inputs: WizardInput[]): EditorAction[] => {
+  return (inputs: WizardInputElement[]): EditorAction[] => {
     const name = getValue(inputs.find(i => i.label === 'name')!)!;
     const desc = getValue(inputs.find(i => i.label === 'desc')!);
     const bType = getValue(inputs.find(i => i.label === 'bType')!)!;

--- a/src/wizards/clientln.ts
+++ b/src/wizards/clientln.ts
@@ -15,7 +15,7 @@ import {
   Wizard,
   WizardAction,
   WizardActor,
-  WizardInput,
+  WizardInputElement,
 } from '../foundation.js';
 import { clientIcon } from '../icons/icons.js';
 import { openCommunicationMappingWizard } from './commmap-wizards.js';
@@ -112,7 +112,7 @@ function hasClientLN(cb: Element, identity: string): boolean {
 }
 
 function addClientLnAction(doc: XMLDocument): WizardActor {
-  return (inputs: WizardInput[], wizard: Element): WizardAction[] => {
+  return (inputs: WizardInputElement[], wizard: Element): WizardAction[] => {
     const cbSelected = <ListItemBase[]>(
       (<List>wizard.shadowRoot!.querySelector('#sourcelist')).selected
     );
@@ -272,7 +272,7 @@ export function createClientLnWizard(
 
 function disconnectClientLnAction(elements: Element[]): WizardActor {
   return (
-    inputs: WizardInput[],
+    inputs: WizardInputElement[],
     wizard: Element,
     list?: List | null
   ): WizardAction[] => {

--- a/src/wizards/conductingequipment.ts
+++ b/src/wizards/conductingequipment.ts
@@ -13,7 +13,7 @@ import {
   isPublic,
   Wizard,
   WizardActor,
-  WizardInput,
+  WizardInputElement,
 } from '../foundation.js';
 import { updateNamingAction } from './foundation/actions.js';
 
@@ -237,7 +237,7 @@ export function renderConductingEquipmentWizard(
 }
 
 export function createAction(parent: Element): WizardActor {
-  return (inputs: WizardInput[]): EditorAction[] => {
+  return (inputs: WizardInputElement[]): EditorAction[] => {
     const name = getValue(inputs.find(i => i.label === 'name')!);
     const desc = getValue(inputs.find(i => i.label === 'desc')!);
     const proxyType = getValue(inputs.find(i => i.label === 'type')!);

--- a/src/wizards/connectedap.ts
+++ b/src/wizards/connectedap.ts
@@ -17,7 +17,7 @@ import {
   EditorAction,
   Wizard,
   WizardActor,
-  WizardInput,
+  WizardInputElement,
   compareNames,
   getValue,
   createElement,
@@ -48,7 +48,7 @@ function compareAccessPointConnection(
 
 function createConnectedApAction(parent: Element): WizardActor {
   return (
-    _: WizardInput[],
+    _: WizardInputElement[],
     __: Element,
     list?: List | null
   ): EditorAction[] => {
@@ -136,7 +136,7 @@ function isEqualAddress(oldAddress: Element, newAddress: Element): boolean {
 }
 
 function createAddressElement(
-  inputs: WizardInput[],
+  inputs: WizardInputElement[],
   parent: Element,
   typeRestriction: boolean
 ): Element {
@@ -163,7 +163,7 @@ function createAddressElement(
 }
 
 function updateConnectedApAction(parent: Element): WizardActor {
-  return (inputs: WizardInput[], wizard: Element): EditorAction[] => {
+  return (inputs: WizardInputElement[], wizard: Element): EditorAction[] => {
     const typeRestriction: boolean =
       (<Checkbox>wizard.shadowRoot?.querySelector('#typeRestriction'))
         ?.checked ?? false;

--- a/src/wizards/controlwithiedname.ts
+++ b/src/wizards/controlwithiedname.ts
@@ -15,7 +15,7 @@ import {
   Wizard,
   WizardAction,
   WizardActor,
-  WizardInput,
+  WizardInputElement,
 } from '../foundation.js';
 
 import { inputIcon } from '../icons/icons.js';
@@ -149,7 +149,7 @@ function disconnectExtRefs(extRefs: Element[]): EditorAction[] {
 
 function disconnect(extRef: Element[]): WizardActor {
   return (
-    inputs: WizardInput[],
+    inputs: WizardInputElement[],
     wizard: Element,
     list?: List | null
   ): WizardAction[] => {

--- a/src/wizards/da.ts
+++ b/src/wizards/da.ts
@@ -16,7 +16,7 @@ import {
   newWizardEvent,
   Wizard,
   WizardActor,
-  WizardInput,
+  WizardInputElement,
 } from '../foundation.js';
 import { getValAction, wizardContent } from './abstractda.js';
 import { functionalConstraintEnum } from './foundation/enums.js';
@@ -61,7 +61,7 @@ export function renderDa(
 }
 
 export function updateDaAction(element: Element): WizardActor {
-  return (inputs: WizardInput[]): EditorAction[] => {
+  return (inputs: WizardInputElement[]): EditorAction[] => {
     const name = getValue(inputs.find(i => i.label === 'name')!)!;
     const desc = getValue(inputs.find(i => i.label === 'desc')!);
     const bType = getValue(inputs.find(i => i.label === 'bType')!)!;
@@ -204,7 +204,7 @@ export function editDAWizard(element: Element): Wizard {
 }
 
 export function createDaAction(parent: Element): WizardActor {
-  return (inputs: WizardInput[]): EditorAction[] => {
+  return (inputs: WizardInputElement[]): EditorAction[] => {
     const name = getValue(inputs.find(i => i.label === 'name')!)!;
     const desc = getValue(inputs.find(i => i.label === 'desc')!);
     const bType = getValue(inputs.find(i => i.label === 'bType')!)!;

--- a/src/wizards/dataset.ts
+++ b/src/wizards/dataset.ts
@@ -17,12 +17,12 @@ import {
   Wizard,
   WizardAction,
   WizardActor,
-  WizardInput,
+  WizardInputElement,
 } from '../foundation.js';
 import { createFCDAsWizard } from './fcda.js';
 
 function updateDataSetAction(element: Element): WizardActor {
-  return (inputs: WizardInput[], wizard: Element): WizardAction[] => {
+  return (inputs: WizardInputElement[], wizard: Element): WizardAction[] => {
     const name = inputs.find(i => i.label === 'name')!.value!;
     const desc = getValue(inputs.find(i => i.label === 'desc')!);
     const oldName = element.getAttribute('name');

--- a/src/wizards/fcda.ts
+++ b/src/wizards/fcda.ts
@@ -7,7 +7,7 @@ import {
   Wizard,
   WizardAction,
   WizardActor,
-  WizardInput,
+  WizardInputElement,
 } from '../foundation.js';
 import { FinderList } from '../finder-list.js';
 import {
@@ -73,7 +73,7 @@ export function newFCDA(parent: Element, path: string[]): Element | undefined {
 }
 
 function createFCDAsAction(parent: Element): WizardActor {
-  return (inputs: WizardInput[], wizard: Element): WizardAction[] => {
+  return (inputs: WizardInputElement[], wizard: Element): WizardAction[] => {
     const finder = wizard.shadowRoot!.querySelector<FinderList>('finder-list');
     const paths = finder?.paths ?? [];
 

--- a/src/wizards/foundation/actions.ts
+++ b/src/wizards/foundation/actions.ts
@@ -3,11 +3,11 @@ import {
   EditorAction,
   getValue,
   WizardActor,
-  WizardInput,
+  WizardInputElement,
 } from '../../foundation.js';
 
 export function updateNamingAction(element: Element): WizardActor {
-  return (inputs: WizardInput[]): EditorAction[] => {
+  return (inputs: WizardInputElement[]): EditorAction[] => {
     const name = getValue(inputs.find(i => i.label === 'name')!)!;
     const desc = getValue(inputs.find(i => i.label === 'desc')!);
 

--- a/src/wizards/gse.ts
+++ b/src/wizards/gse.ts
@@ -13,7 +13,7 @@ import {
   SimpleAction,
   Wizard,
   WizardActor,
-  WizardInput,
+  WizardInputElement,
 } from '../foundation.js';
 import { renderGseSmvAddress, updateAddress } from './address.js';
 
@@ -56,7 +56,7 @@ export function getMTimeAction(
 }
 
 export function updateGSEAction(element: Element): WizardActor {
-  return (inputs: WizardInput[], wizard: Element): EditorAction[] => {
+  return (inputs: WizardInputElement[], wizard: Element): EditorAction[] => {
     const complexAction: ComplexAction = {
       actions: [],
       title: get('gse.action.addaddress', {

--- a/src/wizards/gsecontrol.ts
+++ b/src/wizards/gsecontrol.ts
@@ -24,7 +24,7 @@ import {
   selector,
   Wizard,
   WizardActor,
-  WizardInput,
+  WizardInputElement,
 } from '../foundation.js';
 import { maxLength, patterns } from './foundation/limits.js';
 import { editDataSetWizard } from './dataset.js';
@@ -154,7 +154,7 @@ export function removeGseControl(element: Element): Delete[] {
 }
 
 export function updateGseControlAction(element: Element): WizardActor {
-  return (inputs: WizardInput[]): EditorAction[] => {
+  return (inputs: WizardInputElement[]): EditorAction[] => {
     const name = inputs.find(i => i.label === 'name')!.value!;
     const desc = getValue(inputs.find(i => i.label === 'desc')!);
     const type = getValue(inputs.find(i => i.label === 'type')!);

--- a/src/wizards/ied.ts
+++ b/src/wizards/ied.ts
@@ -9,7 +9,7 @@ import {
   isPublic,
   Wizard,
   WizardActor,
-  WizardInput,
+  WizardInputElement,
 } from '../foundation.js';
 import {patterns} from "./foundation/limits.js";
 import {updateReferences} from "./foundation/references.js";
@@ -22,7 +22,7 @@ const iedNamePattern = "[A-Za-z][0-9A-Za-z_]{0,2}|" +
   "Non[0-9A-Za-df-z_]";
 
 export function updateIED(element: Element): WizardActor {
-  return (inputs: WizardInput[]): EditorAction[] => {
+  return (inputs: WizardInputElement[]): EditorAction[] => {
     const name = getValue(inputs.find(i => i.label === 'name')!)!;
     const oldName = element.getAttribute('name');
     const desc = getValue(inputs.find(i => i.label === 'desc')!);

--- a/src/wizards/lnode.ts
+++ b/src/wizards/lnode.ts
@@ -20,7 +20,7 @@ import {
   selector,
   Wizard,
   WizardActor,
-  WizardInput,
+  WizardInputElement,
 } from '../foundation.js';
 
 /** Description of a `ListItem` representing an `IED` or `LN[0]` */
@@ -122,7 +122,7 @@ function includesLNode(anyln: Element, lnodes: Element[]): boolean {
  */
 export function lNodeWizardAction(parent: Element): WizardActor {
   return (
-    inputs: WizardInput[],
+    inputs: WizardInputElement[],
     wizard: Element,
     list?: List | null
   ): EditorAction[] => {

--- a/src/wizards/optfields.ts
+++ b/src/wizards/optfields.ts
@@ -11,7 +11,7 @@ import {
   Wizard,
   WizardAction,
   WizardActor,
-  WizardInput,
+  WizardInputElement,
 } from '../foundation.js';
 
 interface ContentOptions {
@@ -40,7 +40,7 @@ export function contentOptFieldsWizard(
 }
 
 function updateOptFieldsAction(element: Element): WizardActor {
-  return (inputs: WizardInput[]): WizardAction[] => {
+  return (inputs: WizardInputElement[]): WizardAction[] => {
     const seqNum = getValue(inputs.find(i => i.label === 'seqNum')!);
     const timeStamp = getValue(inputs.find(i => i.label === 'timeStamp')!);
     const dataSet = getValue(inputs.find(i => i.label === 'dataSet')!);

--- a/src/wizards/reportcontrol.ts
+++ b/src/wizards/reportcontrol.ts
@@ -26,7 +26,7 @@ import {
   SimpleAction,
   Wizard,
   WizardActor,
-  WizardInput,
+  WizardInputElement,
   Delete,
   getUniqueElementName,
 } from '../foundation.js';
@@ -117,7 +117,7 @@ function contentReportControlWizard(options: ContentOptions): TemplateResult[] {
 }
 
 function createReportControlAction(parent: Element): WizardActor {
-  return (inputs: WizardInput[], wizard: Element) => {
+  return (inputs: WizardInputElement[], wizard: Element) => {
     // create ReportControl element
     const reportControlAttrs: Record<string, string | null> = {};
     const reportKeys = [
@@ -285,7 +285,7 @@ export function createReportControlWizard(ln0OrLn: Element): Wizard {
 }
 
 function openReportControlCreateWizard(doc: XMLDocument): WizardActor {
-  return (_: WizardInput[], wizard: Element) => {
+  return (_: WizardInputElement[], wizard: Element) => {
     const finder = wizard.shadowRoot?.querySelector<FinderList>('finder-list');
     const path = finder?.path ?? [];
 
@@ -391,7 +391,7 @@ function getRptEnabledAction(
 }
 
 function updateReportControlAction(element: Element): WizardActor {
-  return (inputs: WizardInput[]): EditorAction[] => {
+  return (inputs: WizardInputElement[]): EditorAction[] => {
     const attributes: Record<string, string | null> = {};
     const attributeKeys = [
       'name',

--- a/src/wizards/sampledvaluecontrol.ts
+++ b/src/wizards/sampledvaluecontrol.ts
@@ -23,7 +23,7 @@ import {
   selector,
   Wizard,
   WizardActor,
-  WizardInput,
+  WizardInputElement,
 } from '../foundation.js';
 import { securityEnableEnum, smpModEnum } from './foundation/enums.js';
 import { maxLength, patterns } from './foundation/limits.js';
@@ -180,7 +180,7 @@ function contentSampledValueControlWizard(
 }
 
 function updateSampledValueControlAction(element: Element): WizardActor {
-  return (inputs: WizardInput[]): EditorAction[] => {
+  return (inputs: WizardInputElement[]): EditorAction[] => {
     const attributes: Record<string, string | null> = {};
     const attributeKeys = [
       'name',

--- a/src/wizards/smv.ts
+++ b/src/wizards/smv.ts
@@ -8,12 +8,12 @@ import {
   Wizard,
   WizardAction,
   WizardActor,
-  WizardInput,
+  WizardInputElement,
 } from '../foundation.js';
 import { renderGseSmvAddress, updateAddress } from './address.js';
 
 export function updateSmvAction(element: Element): WizardActor {
-  return (inputs: WizardInput[], wizard: Element): WizardAction[] => {
+  return (inputs: WizardInputElement[], wizard: Element): WizardAction[] => {
     const complexAction: ComplexAction = {
       actions: [],
       title: get('smv.action.addaddress', {

--- a/src/wizards/smvopts.ts
+++ b/src/wizards/smvopts.ts
@@ -7,7 +7,7 @@ import {
   Wizard,
   WizardAction,
   WizardActor,
-  WizardInput,
+  WizardInputElement,
 } from '../foundation.js';
 
 interface ContentOptions {
@@ -31,7 +31,7 @@ function contentSmvOptsWizard(option: ContentOptions): TemplateResult[] {
 }
 
 function updateSmvOptsAction(element: Element): WizardActor {
-  return (inputs: WizardInput[]): WizardAction[] => {
+  return (inputs: WizardInputElement[]): WizardAction[] => {
     const attributes: Record<string, string | null> = {};
     const attributeKeys = [
       'refreshTime',

--- a/src/wizards/subnetwork.ts
+++ b/src/wizards/subnetwork.ts
@@ -11,7 +11,7 @@ import {
   patterns,
   Wizard,
   WizardActor,
-  WizardInput,
+  WizardInputElement,
 } from '../foundation.js';
 
 /** Initial attribute values suggested for `SubNetwork` creation */
@@ -68,7 +68,7 @@ function contentSubNetwork(options: ContentOptions): TemplateResult[] {
 }
 
 export function createSubNetworkAction(parent: Element): WizardActor {
-  return (inputs: WizardInput[]): EditorAction[] => {
+  return (inputs: WizardInputElement[]): EditorAction[] => {
     const name = getValue(inputs.find(i => i.label === 'name')!);
     const desc = getValue(inputs.find(i => i.label === 'desc')!);
     const type = getValue(inputs.find(i => i.label === 'type')!);
@@ -160,7 +160,7 @@ function getBitRateAction(
 }
 
 function updateSubNetworkAction(element: Element): WizardActor {
-  return (inputs: WizardInput[]): EditorAction[] => {
+  return (inputs: WizardInputElement[]): EditorAction[] => {
     const name = inputs.find(i => i.label === 'name')!.value!;
     const desc = getValue(inputs.find(i => i.label === 'desc')!);
     const type = getValue(inputs.find(i => i.label === 'type')!);

--- a/src/wizards/substation.ts
+++ b/src/wizards/substation.ts
@@ -12,7 +12,7 @@ import {
   newWizardEvent,
   Wizard,
   WizardActor,
-  WizardInput,
+  WizardInputElement,
 } from '../foundation.js';
 import { updateNamingAction } from './foundation/actions.js';
 import { guessVoltageLevel } from '../editors/substation/guess-wizard.js';
@@ -46,7 +46,7 @@ function render(
 }
 
 export function createAction(parent: Element): WizardActor {
-  return (inputs: WizardInput[], wizard: Element): EditorAction[] => {
+  return (inputs: WizardInputElement[], wizard: Element): EditorAction[] => {
     const name = getValue(inputs.find(i => i.label === 'name')!);
     const desc = getValue(inputs.find(i => i.label === 'desc')!);
     const guess = wizard.shadowRoot?.querySelector('mwc-checkbox')?.checked;

--- a/src/wizards/trgops.ts
+++ b/src/wizards/trgops.ts
@@ -11,7 +11,7 @@ import {
   Wizard,
   WizardAction,
   WizardActor,
-  WizardInput,
+  WizardInputElement,
 } from '../foundation.js';
 
 interface ContentOptions {
@@ -35,7 +35,7 @@ export function contentTrgOpsWizard(option: ContentOptions): TemplateResult[] {
 }
 
 function updateTrgOpsAction(element: Element): WizardActor {
-  return (inputs: WizardInput[]): WizardAction[] => {
+  return (inputs: WizardInputElement[]): WizardAction[] => {
     const dchg = getValue(inputs.find(i => i.label === 'dchg')!);
     const qchg = getValue(inputs.find(i => i.label === 'qchg')!);
     const dupd = getValue(inputs.find(i => i.label === 'dupd')!);

--- a/src/wizards/voltagelevel.ts
+++ b/src/wizards/voltagelevel.ts
@@ -11,7 +11,7 @@ import {
   patterns,
   Wizard,
   WizardActor,
-  WizardInput,
+  WizardInputElement,
 } from '../foundation.js';
 
 const initial = {
@@ -82,7 +82,7 @@ function render(
 }
 
 export function createAction(parent: Element): WizardActor {
-  return (inputs: WizardInput[]): EditorAction[] => {
+  return (inputs: WizardInputElement[]): EditorAction[] => {
     const name = getValue(inputs.find(i => i.label === 'name')!);
     const desc = getValue(inputs.find(i => i.label === 'desc')!);
     const nomFreq = getValue(inputs.find(i => i.label === 'nomFreq')!);
@@ -179,7 +179,7 @@ function getVoltageAction(
 }
 
 export function updateAction(element: Element): WizardActor {
-  return (inputs: WizardInput[]): EditorAction[] => {
+  return (inputs: WizardInputElement[]): EditorAction[] => {
     const name = inputs.find(i => i.label === 'name')!.value!;
     const desc = getValue(inputs.find(i => i.label === 'desc')!);
     const nomFreq = getValue(inputs.find(i => i.label === 'nomFreq')!);

--- a/test/unit/__snapshots__/wizard-dialog.test.snap.js
+++ b/test/unit/__snapshots__/wizard-dialog.test.snap.js
@@ -13,3 +13,59 @@ snapshots["wizard-dialog with a nonempty wizard property in pro mode switches to
 `;
 /* end snapshot wizard-dialog with a nonempty wizard property in pro mode switches to code editor view on code toggle button click */
 
+snapshots["wizard-dialog with content definition throught WizardInput s for a specific WizardInputs of the kind Checkbox the dom looks like the latest snapshot"] = 
+`<wizard-checkbox
+  defaultchecked=""
+  label="myLabel"
+  nullable=""
+>
+</wizard-checkbox>
+`;
+/* end snapshot wizard-dialog with content definition throught WizardInput s for a specific WizardInputs of the kind Checkbox the dom looks like the latest snapshot */
+
+snapshots["wizard-dialog with content definition throught WizardInput s for another WizardInputs of the kind Checkbox the dom looks like the latest snapshot"] = 
+`<wizard-checkbox
+  label="myLabel"
+  nullable=""
+>
+</wizard-checkbox>
+`;
+/* end snapshot wizard-dialog with content definition throught WizardInput s for another WizardInputs of the kind Checkbox the dom looks like the latest snapshot */
+
+snapshots["wizard-dialog with content definition throught WizardInput s for a specific WizardInput of the kind Select the dom looks like the latest snapshot"] = 
+`<wizard-select label="myLabel">
+  <mwc-list-item
+    activated=""
+    aria-disabled="false"
+    aria-selected="true"
+    mwc-list-item=""
+    role="option"
+    selected=""
+    tabindex="0"
+    value="multi1"
+  >
+    multi1
+  </mwc-list-item>
+  <mwc-list-item
+    aria-disabled="false"
+    mwc-list-item=""
+    role="option"
+    tabindex="-1"
+    value="multi2"
+  >
+    multi2
+  </mwc-list-item>
+</wizard-select>
+`;
+/* end snapshot wizard-dialog with content definition throught WizardInput s for a specific WizardInput of the kind Select the dom looks like the latest snapshot */
+
+snapshots["wizard-dialog with content definition throught WizardInput s for a specific WizardInput of the kind TextField the dom looks like the latest snapshot"] = 
+`<wizard-textfield
+  disabled=""
+  label="myLabel"
+  nullable=""
+>
+</wizard-textfield>
+`;
+/* end snapshot wizard-dialog with content definition throught WizardInput s for a specific WizardInput of the kind TextField the dom looks like the latest snapshot */
+

--- a/test/unit/editors/ied/__snapshots__/da-container.test.snap.js
+++ b/test/unit/editors/ied/__snapshots__/da-container.test.snap.js
@@ -61,3 +61,40 @@ snapshots["with a DA element and child elements are toggled looks like the lates
 `;
 /* end snapshot with a DA element and child elements are toggled looks like the latest snapshot */
 
+snapshots["looks like the latest snapshot with a DA element containing and a DAI"] = 
+`<action-pane
+  icon="done"
+  tabindex="0"
+>
+  <abbr slot="action">
+    <mwc-icon-button
+      icon="info"
+      title="ctlModel"
+    >
+    </mwc-icon-button>
+  </abbr>
+  <h6>
+    status-only
+  </h6>
+</action-pane>
+`;
+/* end snapshot looks like the latest snapshot with a DA element containing and a DAI */
+
+snapshots["with a DA element looks like the latest snapshot"] = 
+`<action-pane
+  icon=""
+  tabindex="0"
+>
+  <abbr slot="action">
+    <mwc-icon-button
+      icon="info"
+      title="ctlModel"
+    >
+    </mwc-icon-button>
+  </abbr>
+  <h6>
+  </h6>
+</action-pane>
+`;
+/* end snapshot with a DA element looks like the latest snapshot */
+

--- a/test/unit/editors/ied/__snapshots__/do-container.test.snap.js
+++ b/test/unit/editors/ied/__snapshots__/do-container.test.snap.js
@@ -62,3 +62,64 @@ snapshots["looks like the latest snapshot with a SDO element and child elements 
 `;
 /* end snapshot looks like the latest snapshot with a SDO element and child elements are toggled. */
 
+snapshots["looks like the latest snapshot with a DO element."] = 
+`<action-pane
+  icon=""
+  tabindex="0"
+>
+  <abbr slot="action">
+    <mwc-icon-button
+      icon="info"
+      title="Mod"
+    >
+    </mwc-icon-button>
+  </abbr>
+  <abbr
+    slot="action"
+    title="[iededitor.toggleChildElements]"
+  >
+    <mwc-icon-button-toggle
+      id="toggleButton"
+      officon="keyboard_arrow_down"
+      onicon="keyboard_arrow_up"
+    >
+    </mwc-icon-button-toggle>
+  </abbr>
+</action-pane>
+`;
+/* end snapshot looks like the latest snapshot with a DO element. */
+
+ainer>
+  </da-container>
+  <da-container>
+  </da-container>
+  <da-container>
+  </da-container>
+  <da-container>
+  </da-container>
+  <da-container>
+  </da-container>
+  <da-container>
+  </da-container>
+  <da-container>
+  </da-container>
+  <da-container>
+  </da-container>
+  <da-container>
+  </da-container>
+  <da-container>
+  </da-container>
+  <da-container>
+  </da-container>
+  <da-container>
+  </da-container>
+  <da-container>
+  </da-container>
+  <do-container>
+  </do-container>
+  <do-container>
+  </do-container>
+</action-pane>
+`;
+/* end snapshot looks like the latest snapshot with a DO element and child elements are toggled. */
+

--- a/test/unit/editors/singlelinediagram/wizards/bay.test.ts
+++ b/test/unit/editors/singlelinediagram/wizards/bay.test.ts
@@ -10,7 +10,7 @@ import {
 } from '../../../wizards/foundation.js';
 
 import { WizardTextField } from '../../../../../src/wizard-textfield.js';
-import { WizardInput } from '../../../../../src/foundation.js';
+import { WizardInputElement } from '../../../../../src/foundation.js';
 import { editBayWizard } from '../../../../../src/editors/singlelinediagram/wizards/bay.js';
 import { updateNamingAndCoordinatesAction } from '../../../../../src/editors/singlelinediagram/wizards/foundation.js';
 
@@ -18,7 +18,7 @@ describe('Wizards for SCL element Bay (X/Y)', () => {
   let doc: XMLDocument;
   let bay: Element;
   let element: MockWizard;
-  let inputs: WizardInput[];
+  let inputs: WizardInputElement[];
 
   beforeEach(async () => {
     doc = await fetchDoc('/test/testfiles/valid2007B4withSubstationXY.scd');

--- a/test/unit/editors/singlelinediagram/wizards/conductingequipment.test.ts
+++ b/test/unit/editors/singlelinediagram/wizards/conductingequipment.test.ts
@@ -10,7 +10,7 @@ import {
 } from '../../../wizards/foundation.js';
 
 import { WizardTextField } from '../../../../../src/wizard-textfield.js';
-import { WizardInput } from '../../../../../src/foundation.js';
+import { WizardInputElement } from '../../../../../src/foundation.js';
 import { editConductingEquipmentWizard } from '../../../../../src/editors/singlelinediagram/wizards/conductingequipment.js';
 import { updateNamingAndCoordinatesAction } from '../../../../../src/editors/singlelinediagram/wizards/foundation.js';
 
@@ -18,7 +18,7 @@ describe('Wizards for SCL element Conducting Equipment (X/Y)', () => {
   let doc: XMLDocument;
   let conductingEquipment: Element;
   let element: MockWizard;
-  let inputs: WizardInput[];
+  let inputs: WizardInputElement[];
 
   beforeEach(async () => {
     doc = await fetchDoc('/test/testfiles/valid2007B4withSubstationXY.scd');

--- a/test/unit/editors/singlelinediagram/wizards/powertransformer.test.ts
+++ b/test/unit/editors/singlelinediagram/wizards/powertransformer.test.ts
@@ -10,7 +10,7 @@ import {
 } from '../../../wizards/foundation.js';
 
 import { WizardTextField } from '../../../../../src/wizard-textfield.js';
-import { WizardInput } from '../../../../../src/foundation.js';
+import { WizardInputElement } from '../../../../../src/foundation.js';
 import { editPowerTransformerWizard } from '../../../../../src/editors/singlelinediagram/wizards/powertransformer.js';
 import { updateNamingAndCoordinatesAction } from '../../../../../src/editors/singlelinediagram/wizards/foundation.js';
 
@@ -18,7 +18,7 @@ describe('Wizards for SCL element Power Transformer (X/Y)', () => {
   let doc: XMLDocument;
   let powerTransformer: Element;
   let element: MockWizard;
-  let inputs: WizardInput[];
+  let inputs: WizardInputElement[];
 
   beforeEach(async () => {
     doc = await fetchDoc('/test/testfiles/valid2007B4withSubstationXY.scd');

--- a/test/unit/editors/templates/datype.test.ts
+++ b/test/unit/editors/templates/datype.test.ts
@@ -9,15 +9,15 @@ import {
   identity,
   isSimple,
   Replace,
-  WizardInput,
+  WizardInputElement,
 } from '../../../../src/foundation.js';
 import { editDaTypeWizard } from '../../../../src/editors/templates/datype-wizards.js';
 
 describe('wizards for DAType element', () => {
   let doc: XMLDocument;
   let element: MockWizard;
-  let inputs: WizardInput[];
-  let input: WizardInput | undefined;
+  let inputs: WizardInputElement[];
+  let input: WizardInputElement | undefined;
 
   let primaryAction: HTMLElement;
 

--- a/test/unit/editors/templates/dotype.test.ts
+++ b/test/unit/editors/templates/dotype.test.ts
@@ -9,15 +9,15 @@ import {
   identity,
   isSimple,
   Replace,
-  WizardInput,
+  WizardInputElement,
 } from '../../../../src/foundation.js';
 import { dOTypeWizard } from '../../../../src/editors/templates/dotype-wizards.js';
 
 describe('wizards for DOType element', () => {
   let doc: XMLDocument;
   let element: MockWizard;
-  let inputs: WizardInput[];
-  let input: WizardInput | undefined;
+  let inputs: WizardInputElement[];
+  let input: WizardInputElement | undefined;
 
   let primaryAction: HTMLElement;
 

--- a/test/unit/editors/templates/enumtype.test.ts
+++ b/test/unit/editors/templates/enumtype.test.ts
@@ -9,15 +9,15 @@ import {
   identity,
   isSimple,
   Replace,
-  WizardInput,
+  WizardInputElement,
 } from '../../../../src/foundation.js';
 import { eNumTypeEditWizard } from '../../../../src/editors/templates/enumtype-wizard.js';
 
 describe('wizards for EnumType element', () => {
   let doc: XMLDocument;
   let element: MockWizard;
-  let inputs: WizardInput[];
-  let input: WizardInput | undefined;
+  let inputs: WizardInputElement[];
+  let input: WizardInputElement | undefined;
 
   let primaryAction: HTMLElement;
 

--- a/test/unit/editors/templates/lnodetype-wizard.test.ts
+++ b/test/unit/editors/templates/lnodetype-wizard.test.ts
@@ -10,7 +10,7 @@ import {
   identity,
   isSimple,
   Replace,
-  WizardInput,
+  WizardInputElement,
 } from '../../../../src/foundation.js';
 import { lNodeTypeWizard } from '../../../../src/editors/templates/lnodetype-wizard.js';
 import { regExp, regexString } from '../../../foundation.js';
@@ -18,8 +18,8 @@ import { regExp, regexString } from '../../../foundation.js';
 describe('wizards for LNodeType element', () => {
   let doc: XMLDocument;
   let element: MockWizard;
-  let inputs: WizardInput[];
-  let input: WizardInput | undefined;
+  let inputs: WizardInputElement[];
+  let input: WizardInputElement | undefined;
 
   let primaryAction: HTMLElement;
 

--- a/test/unit/foundation/schema/attribute.test.ts
+++ b/test/unit/foundation/schema/attribute.test.ts
@@ -1,0 +1,386 @@
+import { expect } from '@open-wc/testing';
+
+import { getSchema } from '../../../../src/schemas.js';
+import { schemaAttributeDefinition } from '../../../../src/foundation.js';
+
+const schema2007B4: XMLDocument = <XMLDocument>(
+  new DOMParser().parseFromString(
+    getSchema('2007', 'B', '4'),
+    'application/xml'
+  )
+);
+
+const schema2007B: XMLDocument = <XMLDocument>(
+  new DOMParser().parseFromString(getSchema('2007', 'B', ''), 'application/xml')
+);
+
+const schema2003: XMLDocument = <XMLDocument>(
+  new DOMParser().parseFromString(getSchema('', '', ''), 'application/xml')
+);
+
+describe('schema spcific functions', () => {
+  describe('allow to get attribute definition from schema that', () => {
+    it('returns empty array for invalid tagName', () =>
+      expect(schemaAttributeDefinition('nonsence', schema2007B4)).to.be.empty);
+
+    describe('for element SampledValueControl', () => {
+      describe('and version 2003', () => {
+        const attributes = schemaAttributeDefinition(
+          'SampledValueControl',
+          schema2003
+        );
+
+        it('return the correct number of attributes ', () =>
+          expect(attributes).to.have.length(8));
+
+        it('return an optional pattern', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'name')?.restriction
+              .base
+          ).to.equal('xs:normalizedString'));
+
+        it('return an optional pattern', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'name')?.restriction
+              .pattern
+          ).to.be.undefined);
+
+        it('return an optional minLength', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'name')?.restriction
+              .minLength
+          ).to.equal('1'));
+
+        it('return an otional maxLength', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'name')?.restriction
+              .maxLength
+          ).to.be.undefined);
+      });
+
+      describe('and version 2007B', () => {
+        const attributes = schemaAttributeDefinition(
+          'SampledValueControl',
+          schema2007B
+        );
+
+        it('return the correct number of attributes ', () =>
+          expect(attributes).to.have.length(10));
+
+        it('return an optional pattern', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'name')?.restriction
+              .base
+          ).to.equal('xs:Name'));
+
+        it('return an optional pattern', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'name')?.restriction
+              .pattern
+          ).to.equal('[A-Za-z][0-9A-Za-z_]*'));
+
+        it('return an optional minLength', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'name')?.restriction
+              .minLength
+          ).to.be.undefined);
+
+        it('return an otional maxLength', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'name')?.restriction
+              .maxLength
+          ).to.equal('32'));
+
+        it('return enumerations values', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'securityEnable')
+              ?.enumeration
+          ).to.deep.equal(['None', 'Signature', 'SignatureAndEncryption']));
+      });
+
+      describe('and version 2007B4', () => {
+        const attributes = schemaAttributeDefinition(
+          'SampledValueControl',
+          schema2007B4
+        );
+
+        it('return the correct number of attributes ', () =>
+          expect(attributes).to.have.length(10));
+
+        it('return an optional pattern', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'name')?.restriction
+              .base
+          ).to.equal('xs:Name'));
+
+        it('return an optional pattern', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'name')?.restriction
+              .pattern
+          ).to.equal('[A-Za-z][0-9A-Za-z_]*'));
+
+        it('return an optional minLength', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'name')?.restriction
+              .minLength
+          ).to.be.undefined);
+
+        it('return an otional maxLength', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'name')?.restriction
+              .maxLength
+          ).to.equal('32'));
+      });
+    });
+
+    describe('for element IED', () => {
+      describe('and version 2003', () => {
+        const attributes = schemaAttributeDefinition('IED', schema2003);
+
+        it('return the correct number of attributes ', () =>
+          expect(attributes).to.have.length(5));
+
+        it('return an optional pattern', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'name')?.restriction
+              .base
+          ).to.equal('xs:normalizedString'));
+
+        it('return an optional pattern', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'name')?.restriction
+              .pattern
+          ).to.be.undefined);
+
+        it('return an optional minLength', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'name')?.restriction
+              .minLength
+          ).to.equal('1'));
+
+        it('return an otional maxLength', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'name')?.restriction
+              .maxLength
+          ).to.be.undefined);
+      });
+
+      describe('and version 2007B', () => {
+        const attributes = schemaAttributeDefinition('IED', schema2007B);
+
+        it('return the correct number of attributes ', () =>
+          expect(attributes).to.have.length(10));
+
+        it('return an optional pattern', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'name')?.restriction
+              .base
+          ).to.equal('xs:Name'));
+
+        it('return an optional pattern', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'name')?.restriction
+              .pattern
+          ).to.equal('[A-Za-z][0-9A-Za-z_]*'));
+
+        it('return an optional minLength', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'name')?.restriction
+              .minLength
+          ).to.be.undefined);
+
+        it('return an otional maxLength', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'name')?.restriction
+              .maxLength
+          ).to.equal('64'));
+      });
+
+      describe('and version 2007B$', () => {
+        const attributes = schemaAttributeDefinition('IED', schema2007B4);
+
+        it('return the correct number of attributes ', () =>
+          expect(attributes).to.have.length(10));
+
+        it('return an optional pattern', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'name')?.restriction
+              .base
+          ).to.equal('xs:Name'));
+
+        it('return an optional pattern', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'name')?.restriction
+              .pattern
+          ).to.equal(
+            '[A-Za-z][0-9A-Za-z_]{0,2}' +
+              '|[A-Za-z][0-9A-Za-z_]{4,63}' +
+              '|[A-MO-Za-z][0-9A-Za-z_]{3}' +
+              '|N[0-9A-Za-np-z_][0-9A-Za-z_]{2}' +
+              '|No[0-9A-Za-mo-z_][0-9A-Za-z_]' +
+              '|Non[0-9A-Za-df-z_]'
+          ));
+
+        it('return an optional minLength', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'name')?.restriction
+              .minLength
+          ).to.be.undefined);
+
+        it('return an otional maxLength', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'name')?.restriction
+              .maxLength
+          ).to.equal('64'));
+      });
+    });
+
+    describe('for element LNode', () => {
+      describe('and version 2003', () => {
+        const attributes = schemaAttributeDefinition('LNode', schema2003);
+
+        it('returns the correct number of attributes ', () =>
+          expect(attributes).to.have.length(7));
+
+        it('return an optional pattern', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'ldInst')
+              ?.restriction.base
+          ).to.equal('xs:normalizedString'));
+
+        it('return an optional pattern', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'ldInst')
+              ?.restriction.pattern
+          ).to.be.undefined);
+
+        it('return an optional minLength', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'ldInst')
+              ?.restriction.minLength
+          ).to.be.undefined);
+
+        it('return an otional maxLength', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'ldInst')
+              ?.restriction.maxLength
+          ).to.be.undefined);
+      });
+
+      describe('and version 2007B', () => {
+        const attributes = schemaAttributeDefinition('LNode', schema2007B);
+
+        it('return the correct number of attributes ', () =>
+          expect(attributes).to.have.length(7));
+
+        it('return an optional pattern', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'ldInst')
+              ?.restriction.base
+          ).to.equal('xs:normalizedString'));
+
+        it('return an optional pattern', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'ldInst')
+              ?.restriction.pattern
+          ).to.equal('[A-Za-z0-9][0-9A-Za-z_]*'));
+
+        it('return an optional minLength', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'ldInst')
+              ?.restriction.minLength
+          ).to.be.undefined);
+
+        it('return an otional maxLength', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'ldInst')
+              ?.restriction.maxLength
+          ).to.equal('64'));
+      });
+
+      describe('and version 2007B4', () => {
+        const attributes = schemaAttributeDefinition('LNode', schema2007B4);
+
+        it('return the correct number of attributes ', () =>
+          expect(attributes).to.have.length(7));
+
+        it('return an optional pattern', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'lnClass')
+              ?.restriction.base
+          ).to.equal('xs:Name'));
+
+        it('return an optional pattern', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'lnClass')
+              ?.restriction.pattern
+          ).to.equal(
+            'L[A-Z]*|LLN0|LLN0|LPHD|LCCH|LGOS|LSVS|LTIM|LTMS|LTRK|A[A-Z]*' +
+              '|ANCR|ARCO|ARIS|ATCC|AVCO|C[A-Z]*|CALH|CCGR|CILO|CPOW|CSWI|CSYN' +
+              '|F[A-Z]*|FCNT|FCSD|FFIL|FLIM|FPID|FRMP|FSPT|FXOT|FXUT|G[A-Z]*' +
+              '|GAPC|GGIO|GLOG|GSAL|I[A-Z]*|IARC|IHMI|ISAF|ITCI|ITMI|ITPC|K[A-Z]*' +
+              '|KFAN|KFIL|KPMP|KTNK|KVLV|M[A-Z]*|MDIF|MENV|MFLK|MHAI|MHAN|MHYD|MMDC' +
+              '|MMET|MMTN|MMTR|MMXN|MMXU|MSQI|MSTA|P[A-Z]*|PDIF|PDIR|PDIS|PDOP|PDUP' +
+              '|PFRC|PHAR|PHIZ|PIOC|PMRI|PMSS|POPF|PPAM|PRTR|PSCH|PSDE|PTEF|PTHF' +
+              '|PTOC|PTOF|PTOV|PTRC|PTTR|PTUC|PTUF|PTUV|PUPF|PVOC|PVPH|PZSU|Q[A-Z]*' +
+              '|QFVR|QITR|QIUB|QVTR|QVUB|QVVR|R[A-Z]*|RADR|RBDR|RBRF|RDIR|RDRE|RDRS' +
+              '|RFLO|RMXU|RPSB|RREC|RSYN|S[A-Z]*|SARC|SCBR|SIMG|SIML|SLTC|SOPM|SPDC' +
+              '|SPTR|SSWI|STMP|SVBR|T[A-Z]*|TANG|TAXD|TCTR|TDST|TFLW|TFRQ|TGSN|THUM' +
+              '|TLVL|TMGF|TMVM|TPOS|TPRS|TRTN|TSND|TTMP|TTNS|TVBR|TVTR|TWPH|X[A-Z]*' +
+              '|XCBR|XSWI|Y[A-Z]*|YEFN|YLTC|YPSH|YPTR|Z[A-Z]*|ZAXN|ZBAT|ZBSH|ZCAB|ZCAP' +
+              '|ZCON|ZGEN|ZGIL|ZLIN|ZMOT|ZREA|ZRES|ZRRC|ZSAR|ZSCR|ZSMC|ZTCF|ZTCR|[A-Z]+'
+          ));
+
+        it('return an optional minLength', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'lnClass')
+              ?.restriction.minLength
+          ).to.equal('4'));
+
+        it('return an otional maxLength', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'lnClass')
+              ?.restriction.maxLength
+          ).to.equal('4'));
+      });
+    });
+
+    describe('for element PhysConn', () => {
+      describe('and version 2007B4', () => {
+        const attributes = schemaAttributeDefinition('PhysConn', schema2007B4);
+
+        it('returns the correct number of attributes ', () =>
+          expect(attributes).to.have.length(2));
+
+        it('return an optional pattern', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'type')?.restriction
+              .base
+          ).to.equal('xs:normalizedString'));
+
+        it('return an optional pattern', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'type')?.restriction
+              .pattern
+          ).to.equal('Connection|RedConn|[A-Z][0-9A-Za-z\\-]*'));
+
+        it('return an optional minLength', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'type')?.restriction
+              .minLength
+          ).to.be.undefined);
+
+        it('return an otional maxLength', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'type')?.restriction
+              .maxLength
+          ).to.be.undefined);
+
+        it('return an enumeration', () =>
+          expect(
+            attributes.find(attribute => attribute.name === 'type')?.enumeration
+          ).to.deep.equal(['Connection', 'RedConn']));
+      });
+    });
+  });
+});

--- a/test/unit/wizard-dialog.test.ts
+++ b/test/unit/wizard-dialog.test.ts
@@ -8,6 +8,9 @@ import '../../src/wizard-textfield.js';
 import '../../src/wizard-dialog.js';
 import { WizardDialog } from '../../src/wizard-dialog.js';
 import { EditorAction, WizardInputElement } from '../../src/foundation.js';
+import { WizardCheckbox } from '../../src/wizard-checkbox.js';
+import { WizardSelect } from '../../src/wizard-select.js';
+import { WizardTextField } from '../../src/wizard-textfield.js';
 
 describe('wizard-dialog', () => {
   let element: WizardDialog;
@@ -176,6 +179,7 @@ describe('wizard-dialog', () => {
       )).click();
       expect(element.wizard[0].primary).to.not.exist;
     });
+
     it('does not remove primary action as long as no editor action is dispatched', async () => {
       element.wizard = [
         {
@@ -256,6 +260,373 @@ describe('wizard-dialog', () => {
       });
 
       after(() => localStorage.removeItem('mode'));
+    });
+  });
+
+  describe('with content definition throught WizardInput s', () => {
+    describe('for a specific WizardInputs of the kind Checkbox', () => {
+      let checkbox: WizardCheckbox;
+      beforeEach(async () => {
+        element.wizard = [
+          {
+            title: 'Page 1',
+            content: [
+              {
+                kind: 'Checkbox',
+                label: 'myLabel',
+                maybeValue: 'true',
+                nullable: true,
+                default: true,
+              },
+            ],
+          },
+        ];
+        await element.updateComplete;
+
+        checkbox =
+          element.shadowRoot!.querySelector<WizardCheckbox>('wizard-checkbox')!;
+        await checkbox.requestUpdate();
+      });
+
+      it('the dom looks like the latest snapshot', async () =>
+        await expect(checkbox).dom.to.equalSnapshot());
+
+      it('makes sure that wizard-checkbox has correct default value', () =>
+        expect(checkbox.defaultChecked).to.be.true);
+
+      it('makes sure that wizard-checkbox has correct nullable value', () =>
+        expect(checkbox.nullable).to.be.true);
+
+      it('makes sure that wizard-checkbox has correct label', () =>
+        expect(checkbox.label).to.be.equal('myLabel'));
+
+      it('makes sure that wizard-checkbox has correct maybeValue', () =>
+        expect(checkbox.maybeValue).to.be.equal('true'));
+    });
+
+    describe('for another WizardInputs of the kind Checkbox', () => {
+      let checkbox: WizardCheckbox;
+      beforeEach(async () => {
+        element.wizard = [
+          {
+            title: 'Page 1',
+            content: [
+              {
+                kind: 'Checkbox',
+                label: 'myLabel',
+                maybeValue: null,
+                nullable: true,
+                default: false,
+              },
+            ],
+          },
+        ];
+        await element.updateComplete;
+
+        checkbox =
+          element.shadowRoot!.querySelector<WizardCheckbox>('wizard-checkbox')!;
+        await checkbox.requestUpdate();
+      });
+
+      it('the dom looks like the latest snapshot', async () =>
+        await expect(checkbox).dom.to.equalSnapshot());
+
+      it('makes sure that wizard-checkbox has correct default value', () =>
+        expect(checkbox.defaultChecked).to.be.false);
+
+      it('makes sure that wizard-checkbox has correct nullable value', () =>
+        expect(checkbox.nullable).to.be.true);
+
+      it('makes sure that wizard-checkbox has correct label', () =>
+        expect(checkbox.label).to.be.equal('myLabel'));
+
+      it('makes sure that wizard-checkbox has correct maybeValue', async () => {
+        await new Promise(resolve => setTimeout(resolve, 100)); // await animation
+        expect(checkbox.maybeValue).to.be.null;
+      });
+    });
+
+    describe('for a specific WizardInput of the kind Select', () => {
+      let select: WizardSelect;
+      beforeEach(async () => {
+        element.wizard = [
+          {
+            title: 'Page 1',
+            content: [
+              {
+                kind: 'Select',
+                label: 'myLabel',
+                values: ['multi1', 'multi2'],
+                maybeValue: 'multi1',
+              },
+            ],
+          },
+        ];
+        await element.updateComplete;
+
+        select =
+          element.shadowRoot!.querySelector<WizardSelect>('wizard-select')!;
+        await select.requestUpdate();
+      });
+
+      it('the dom looks like the latest snapshot', async () =>
+        await expect(select).dom.to.equalSnapshot());
+
+      it('makes sure that wizard-select has correct default value', () =>
+        expect(select.defaultValue).to.be.equal(''));
+
+      it('makes sure that wizard-select has correct nullable value', () =>
+        expect(select.nullable).to.be.false);
+
+      it('makes sure to not render nullSwitch with missing/false nullable', () =>
+        expect(select.nullSwitch).to.not.exist);
+
+      it('makes sure that wizard-select has correct label', () =>
+        expect(select.label).to.be.equal('myLabel'));
+
+      it('makes sure that wizard-select has correct maybeValue', async () =>
+        expect(select.maybeValue).to.equal('multi1'));
+    });
+
+    describe('for another WizardInput of the kind Select', () => {
+      let select: WizardSelect;
+      beforeEach(async () => {
+        element.wizard = [
+          {
+            title: 'Page 1',
+            content: [
+              {
+                kind: 'Select',
+                label: 'myLabel',
+                values: ['multi1', 'multi2'],
+                maybeValue: null,
+                nullable: true,
+                default: 'multi2',
+              },
+            ],
+          },
+        ];
+        await element.updateComplete;
+
+        select =
+          element.shadowRoot!.querySelector<WizardSelect>('wizard-select')!;
+        await select.requestUpdate();
+      });
+
+      it('makes sure that wizard-select has correct default value', () =>
+        expect(select.defaultValue).to.be.equal('multi2'));
+
+      it('makes sure that wizard-checkbox has correct nullable value', () =>
+        expect(select.nullable).to.be.true);
+
+      it('makes sure that wizard-checkbox has correct label', () =>
+        expect(select.label).to.be.equal('myLabel'));
+
+      it('makes sure that wizard-checkbox has correct maybeValue', async () =>
+        expect(select.maybeValue).to.be.null);
+    });
+
+    describe('for a specific WizardInput of the kind TextField', () => {
+      let textField: WizardTextField;
+      beforeEach(async () => {
+        element.wizard = [
+          {
+            title: 'Page 1',
+            content: [
+              {
+                kind: 'TextField',
+                label: 'myLabel',
+                maybeValue: null,
+                nullable: true,
+              },
+            ],
+          },
+        ];
+        await element.updateComplete;
+
+        textField =
+          element.shadowRoot!.querySelector<WizardTextField>(
+            'wizard-textfield'
+          )!;
+        await textField.requestUpdate();
+      });
+
+      it('the dom looks like the latest snapshot', async () =>
+        await expect(textField).dom.to.equalSnapshot());
+
+      it('makes sure that wizard-textfield has correct default value', () =>
+        expect(textField.defaultValue).to.be.equal(''));
+
+      it('makes sure that wizard-textfield has correct nullable value', () =>
+        expect(textField.nullSwitch).to.exist);
+
+      it('makes sure that wizard-textfield has correct label', () =>
+        expect(textField.label).to.be.equal('myLabel'));
+
+      it('makes sure that wizard-textfield has correct maybeValue', async () =>
+        expect(textField.maybeValue).to.be.null);
+
+      it('does not render multiplier selction with defined multipliers', async () =>
+        expect(textField.multiplierMenu).to.not.exist);
+
+      it('does not render multiplier selction with defined multipliers', async () =>
+        expect(textField.multiplierButton).to.not.exist);
+    });
+
+    describe('for a specific TextField WizardInput with multipliers', () => {
+      let textField: WizardTextField;
+      beforeEach(async () => {
+        element.wizard = [
+          {
+            title: 'Page 1',
+            content: [
+              {
+                kind: 'TextField',
+                label: 'myLabel',
+                maybeValue: 'value',
+                unit: 'V',
+                multipliers: ['', null, 'k', 'M'],
+                multiplier: 'k',
+              },
+            ],
+          },
+        ];
+        await element.updateComplete;
+
+        textField =
+          element.shadowRoot!.querySelector<WizardTextField>(
+            'wizard-textfield'
+          )!;
+        await textField.requestUpdate();
+      });
+
+      it('makes sure that wizard-textfield has correct nullable value', () =>
+        expect(textField.nullSwitch).to.not.exist);
+
+      it('makes sure that wizard-textfield has correct label', () =>
+        expect(textField.label).to.be.equal('myLabel'));
+
+      it('makes sure that wizard-textfield has correct maybeValue', async () =>
+        expect(textField.maybeValue).to.equal('value'));
+
+      it('renders multiplier selction with defined multipliers', async () =>
+        expect(textField.multiplierMenu).to.exist);
+
+      it('renders multiplier selction with defined multipliers', async () =>
+        expect(textField.multiplierButton).to.exist);
+
+      it('shows multiplier and unit as suffix', async () =>
+        expect(textField.suffix).to.equal('kV'));
+    });
+
+    describe('for a specific TextField WizardInput with type number', () => {
+      let textField: WizardTextField;
+      const min = 89;
+      const max = 101;
+
+      beforeEach(async () => {
+        element.wizard = [
+          {
+            title: 'Page 1',
+            content: [
+              {
+                kind: 'TextField',
+                label: 'myLabel',
+                maybeValue: '100',
+                suffix: '#',
+                required: true,
+                type: 'number',
+                min,
+                max,
+              },
+            ],
+          },
+        ];
+        await element.updateComplete;
+
+        textField =
+          element.shadowRoot!.querySelector<WizardTextField>(
+            'wizard-textfield'
+          )!;
+        await textField.requestUpdate();
+      });
+
+      it('does not allow chars other than numbers', async () => {
+        textField.value = 'someString';
+        await textField.requestUpdate();
+        expect(textField.checkValidity()).to.be.false;
+      });
+
+      it('properly set the min attribute', async () => {
+        textField.value = `${min - 1}`;
+        await textField.requestUpdate();
+        expect(textField.checkValidity()).to.be.false;
+
+        textField.value = `${min}`;
+        await textField.requestUpdate();
+        expect(textField.checkValidity()).to.be.true;
+      });
+
+      it('properly set the max attribute', async () => {
+        textField.value = `${max + 1}`;
+        await textField.requestUpdate();
+        expect(textField.checkValidity()).to.be.false;
+
+        textField.value = `${max}`;
+        await textField.requestUpdate();
+        expect(textField.checkValidity()).to.be.true;
+      });
+
+      it('shows multiplier and unit as suffix', async () =>
+        expect(textField.suffix).to.equal('#'));
+    });
+
+    describe('for a specific TextField WizardInput with pattern definition', () => {
+      let textField: WizardTextField;
+      const pattern = '[a-zA-Z][a-zA-Z0-9]*';
+
+      beforeEach(async () => {
+        element.wizard = [
+          {
+            title: 'Page 1',
+            content: [
+              {
+                kind: 'TextField',
+                label: 'myLabel',
+                maybeValue: 'oldIED',
+                pattern,
+                minLength: 3,
+                maxLength: 7,
+              },
+            ],
+          },
+        ];
+        await element.updateComplete;
+
+        textField =
+          element.shadowRoot!.querySelector<WizardTextField>(
+            'wizard-textfield'
+          )!;
+        await textField.requestUpdate();
+      });
+
+      it('does not allow values outside the pattern definition', async () => {
+        textField.value = '0IED';
+        await textField.requestUpdate();
+        expect(textField.checkValidity()).to.be.false;
+      });
+
+      it('does not allow values outside the pattern definition', async () => {
+        textField.value = 'valIED';
+        await textField.requestUpdate();
+        expect(textField.checkValidity()).to.be.true;
+      });
+
+      it('properly set the minLength attribute', async () =>
+        expect(textField.minLength).to.be.equal(3));
+
+      it('properly set the maxLength attribute', async () =>
+        expect(textField.maxLength).to.equal(7));
     });
   });
 });

--- a/test/unit/wizard-dialog.test.ts
+++ b/test/unit/wizard-dialog.test.ts
@@ -7,7 +7,7 @@ import { Button } from '@material/mwc-button';
 import '../../src/wizard-textfield.js';
 import '../../src/wizard-dialog.js';
 import { WizardDialog } from '../../src/wizard-dialog.js';
-import { EditorAction, WizardInput } from '../../src/foundation.js';
+import { EditorAction, WizardInputElement } from '../../src/foundation.js';
 
 describe('wizard-dialog', () => {
   let element: WizardDialog;
@@ -83,7 +83,7 @@ describe('wizard-dialog', () => {
 
     describe('with invalid inputs', () => {
       beforeEach(async () => {
-        element.dialogs[1].querySelector<WizardInput>(
+        element.dialogs[1].querySelector<WizardInputElement>(
           'wizard-textfield'
         )!.value = 'Peter';
         await element.updateComplete;

--- a/test/unit/wizards/address.test.ts
+++ b/test/unit/wizards/address.test.ts
@@ -11,7 +11,7 @@ import {
   isCreate,
   isDelete,
   Wizard,
-  WizardInput,
+  WizardInputElement,
 } from '../../../src/foundation.js';
 import {
   renderGseSmvAddress,
@@ -46,7 +46,7 @@ describe('address', () => {
 
   describe('updateAddress', () => {
     let gse: Element;
-    let inputs: WizardInput[];
+    let inputs: WizardInputElement[];
     let wizard: Wizard;
 
     describe('with exiting address element', () => {

--- a/test/unit/wizards/bda.test.ts
+++ b/test/unit/wizards/bda.test.ts
@@ -11,7 +11,7 @@ import {
   isReplace,
   Replace,
   Wizard,
-  WizardInput,
+  WizardInputElement,
 } from '../../../src/foundation.js';
 import { wizardContent } from '../../../src/wizards/abstractda.js';
 import { createBDaAction, updateBDaAction } from '../../../src/wizards/bda.js';
@@ -29,7 +29,7 @@ describe('bda wizards', () => {
       ).documentElement
     );
 
-    let inputs: WizardInput[];
+    let inputs: WizardInputElement[];
     let wizard: Wizard;
 
     const noOp = () => {
@@ -177,7 +177,7 @@ describe('bda wizards', () => {
       ).documentElement
     );
 
-    let inputs: WizardInput[];
+    let inputs: WizardInputElement[];
     let wizard: Wizard;
 
     const noOp = () => {

--- a/test/unit/wizards/connectedap-pattern.test.ts
+++ b/test/unit/wizards/connectedap-pattern.test.ts
@@ -5,7 +5,7 @@ import '../../mock-wizard.js';
 import { MockWizard } from '../../mock-wizard.js';
 
 import '../../../src/editors/communication/connectedap-editor.js';
-import { WizardInput } from '../../../src/foundation.js';
+import { WizardInputElement } from '../../../src/foundation.js';
 
 import {
   ipV6,
@@ -20,8 +20,8 @@ import { editConnectedApWizard } from '../../../src/wizards/connectedap.js';
 describe('Edit wizard for SCL element ConnectedAP', () => {
   let doc: XMLDocument;
   let element: MockWizard;
-  let inputs: WizardInput[];
-  let input: WizardInput | undefined;
+  let inputs: WizardInputElement[];
+  let input: WizardInputElement | undefined;
 
   beforeEach(async () => {
     element = <MockWizard>await fixture(html`<mock-wizard></mock-wizard>`);

--- a/test/unit/wizards/connectedap.test.ts
+++ b/test/unit/wizards/connectedap.test.ts
@@ -14,7 +14,7 @@ import {
   isDelete,
   isSimple,
   Create,
-  WizardInput,
+  WizardInputElement,
 } from '../../../src/foundation.js';
 import {
   createConnectedApWizard,
@@ -25,8 +25,8 @@ import { ListItemBase } from '@material/mwc-list/mwc-list-item-base';
 describe('Wizards for SCL element ConnectedAP', () => {
   let doc: XMLDocument;
   let element: MockWizard;
-  let inputs: WizardInput[];
-  let input: WizardInput | undefined;
+  let inputs: WizardInputElement[];
+  let input: WizardInputElement | undefined;
   let primaryAction: HTMLElement;
 
   let actionEvent: SinonSpy;

--- a/test/unit/wizards/da.test.ts
+++ b/test/unit/wizards/da.test.ts
@@ -12,7 +12,7 @@ import {
   isReplace,
   Replace,
   Wizard,
-  WizardInput,
+  WizardInputElement,
 } from '../../../src/foundation.js';
 import {
   createDaAction,
@@ -33,7 +33,7 @@ describe('da wizards', () => {
       ).documentElement
     );
 
-    let inputs: WizardInput[];
+    let inputs: WizardInputElement[];
     let wizard: Wizard;
 
     const noOp = () => {
@@ -235,7 +235,7 @@ describe('da wizards', () => {
       ).documentElement
     );
 
-    let inputs: WizardInput[];
+    let inputs: WizardInputElement[];
     let wizard: Wizard;
 
     const noOp = () => {

--- a/test/unit/wizards/dataset.test.ts
+++ b/test/unit/wizards/dataset.test.ts
@@ -12,7 +12,7 @@ import {
   isReplace,
   Replace,
   Wizard,
-  WizardInput,
+  WizardInputElement,
 } from '../../../src/foundation.js';
 
 describe('dataset wizards', () => {
@@ -56,7 +56,7 @@ describe('dataset wizards', () => {
     describe('with stand alone DataSet', () => {
       let dataSet: Element;
       let wizard: Wizard;
-      let inputs: WizardInput[];
+      let inputs: WizardInputElement[];
       let primaryAction: HTMLElement;
 
       beforeEach(async () => {
@@ -110,7 +110,7 @@ describe('dataset wizards', () => {
     describe('with connected DataSet', () => {
       let dataSet: Element;
       let wizard: Wizard;
-      let inputs: WizardInput[];
+      let inputs: WizardInputElement[];
       let primaryAction: HTMLElement;
       let firstFCDA: HTMLElement;
       let thirdFCDA: HTMLElement;

--- a/test/unit/wizards/foundation.ts
+++ b/test/unit/wizards/foundation.ts
@@ -5,7 +5,7 @@ import {
   SimpleAction,
   Replace,
   WizardActor,
-  WizardInput,
+  WizardInputElement,
 } from '../../../src/foundation.js';
 import { WizardTextField } from '../../../src/wizard-textfield.js';
 
@@ -31,7 +31,7 @@ export async function setWizardTextFieldValue(
 
 export function executeWizardUpdateAction(
   wizardActor: WizardActor,
-  inputs: WizardInput[]
+  inputs: WizardInputElement[]
 ): Replace {
   const updateActions = wizardActor(inputs, newWizard());
   expect(updateActions.length).to.equal(1);
@@ -41,7 +41,7 @@ export function executeWizardUpdateAction(
 
 export function expectWizardNoUpdateAction(
   wizardActor: WizardActor,
-  inputs: WizardInput[]
+  inputs: WizardInputElement[]
 ): void {
   const updateActions = wizardActor(inputs, newWizard());
   expect(updateActions).to.be.empty;

--- a/test/unit/wizards/gse.test.ts
+++ b/test/unit/wizards/gse.test.ts
@@ -14,7 +14,7 @@ import {
   isReplace,
   Replace,
   Wizard,
-  WizardInput,
+  WizardInputElement,
 } from '../../../src/foundation.js';
 import {
   editGseWizard,
@@ -48,7 +48,7 @@ describe('gse wizards', () => {
 
   describe('updateGSEAction', () => {
     let gse: Element;
-    let inputs: WizardInput[];
+    let inputs: WizardInputElement[];
     let wizard: Wizard;
 
     const noOp = () => {

--- a/test/unit/wizards/gsecontrol.test.ts
+++ b/test/unit/wizards/gsecontrol.test.ts
@@ -10,7 +10,7 @@ import {
   isReplace,
   Replace,
   Wizard,
-  WizardInput,
+  WizardInputElement,
 } from '../../../src/foundation.js';
 import {
   editGseControlWizard,
@@ -193,7 +193,7 @@ describe('gsecontrol wizards', () => {
       ).documentElement
     );
 
-    let inputs: WizardInput[];
+    let inputs: WizardInputElement[];
     let wizard: Wizard;
 
     const noOp = () => {

--- a/test/unit/wizards/ied.test.ts
+++ b/test/unit/wizards/ied.test.ts
@@ -7,7 +7,7 @@ import { WizardTextField } from '../../../src/wizard-textfield.js';
 import {
   ComplexAction,
   isSimple,
-  WizardInput,
+  WizardInputElement,
 } from '../../../src/foundation.js';
 import { editIEDWizard, updateIED } from '../../../src/wizards/ied.js';
 
@@ -23,7 +23,7 @@ describe('Wizards for SCL element IED', () => {
   let doc: XMLDocument;
   let ied: Element;
   let element: MockWizard;
-  let inputs: WizardInput[];
+  let inputs: WizardInputElement[];
 
   beforeEach(async () => {
     doc = await fetchDoc('/test/testfiles/wizards/ied.scd');

--- a/test/unit/wizards/optfields.test.ts
+++ b/test/unit/wizards/optfields.test.ts
@@ -5,13 +5,13 @@ import '../../mock-wizard.js';
 import { MockWizard } from '../../mock-wizard.js';
 
 import { WizardSelect } from '../../../src/wizard-select.js';
-import { isReplace, Replace, WizardInput } from '../../../src/foundation.js';
+import { isReplace, Replace, WizardInputElement } from '../../../src/foundation.js';
 import { editOptFieldsWizard } from '../../../src/wizards/optfields.js';
 
 describe('Wizards for SCL OptFields element', () => {
   let element: MockWizard;
   let optFields: Element;
-  let inputs: WizardInput[];
+  let inputs: WizardInputElement[];
 
   let primaryAction: HTMLElement;
 

--- a/test/unit/wizards/powertransformer.test.ts
+++ b/test/unit/wizards/powertransformer.test.ts
@@ -4,7 +4,7 @@ import '../../mock-wizard.js';
 import { MockWizard } from '../../mock-wizard.js';
 
 import { WizardTextField } from '../../../src/wizard-textfield.js';
-import { WizardInput } from '../../../src/foundation.js';
+import { WizardInputElement } from '../../../src/foundation.js';
 import { editPowerTransformerWizard } from '../../../src/wizards/powertransformer.js';
 import { updateNamingAction } from '../../../src/wizards/foundation/actions.js';
 
@@ -19,7 +19,7 @@ describe('Wizards for SCL element Power Transformer', () => {
   let doc: XMLDocument;
   let powerTransformer: Element;
   let element: MockWizard;
-  let inputs: WizardInput[];
+  let inputs: WizardInputElement[];
 
   beforeEach(async () => {
     doc = await fetchDoc('/test/testfiles/valid2007B4withSubstationXY.scd');

--- a/test/unit/wizards/reportcontrol.test.ts
+++ b/test/unit/wizards/reportcontrol.test.ts
@@ -13,7 +13,7 @@ import {
   isSimple,
   isReplace,
   Replace,
-  WizardInput,
+  WizardInputElement,
 } from '../../../src/foundation.js';
 import { WizardTextField } from '../../../src/wizard-textfield.js';
 import {
@@ -29,7 +29,7 @@ import { FinderList } from '../../../src/finder-list.js';
 describe('Wizards for SCL ReportControl element', () => {
   let doc: XMLDocument;
   let element: MockWizard;
-  let inputs: WizardInput[];
+  let inputs: WizardInputElement[];
 
   let primaryAction: HTMLElement;
 

--- a/test/unit/wizards/sampledvaluecontrol.test.ts
+++ b/test/unit/wizards/sampledvaluecontrol.test.ts
@@ -8,7 +8,7 @@ import {
   isDelete,
   isReplace,
   Replace,
-  WizardInput,
+  WizardInputElement,
 } from '../../../src/foundation.js';
 import {
   editSampledValueControlWizard,
@@ -22,7 +22,7 @@ import { WizardTextField } from '../../../src/wizard-textfield.js';
 describe('Wizards for SCL element SampledValueControl', () => {
   let doc: XMLDocument;
   let element: MockWizard;
-  let inputs: WizardInput[];
+  let inputs: WizardInputElement[];
 
   let primaryAction: HTMLElement;
 

--- a/test/unit/wizards/smv.test.ts
+++ b/test/unit/wizards/smv.test.ts
@@ -9,7 +9,7 @@ import {
   ComplexAction,
   Create,
   Delete,
-  WizardInput,
+  WizardInputElement,
 } from '../../../src/foundation.js';
 import { editSMvWizard } from '../../../src/wizards/smv.js';
 import { invertedRegex, MAC, regExp } from '../../foundation.js';
@@ -18,8 +18,8 @@ import { WizardTextField } from '../../../src/wizard-textfield.js';
 describe('Wizards for SCL element SMV', () => {
   let doc: XMLDocument;
   let element: MockWizard;
-  let inputs: WizardInput[];
-  let input: WizardInput | undefined;
+  let inputs: WizardInputElement[];
+  let input: WizardInputElement | undefined;
 
   let primaryAction: HTMLElement;
 

--- a/test/unit/wizards/subnetwork.test.ts
+++ b/test/unit/wizards/subnetwork.test.ts
@@ -8,7 +8,7 @@ import { WizardTextField } from '../../../src/wizard-textfield.js';
 import {
   isCreate,
   isDelete,
-  WizardInput,
+  WizardInputElement,
   isReplace,
   Replace,
   Delete,
@@ -22,8 +22,8 @@ import {
 describe('Wizards for SCL element SubNetwork', () => {
   let doc: XMLDocument;
   let element: MockWizard;
-  let inputs: WizardInput[];
-  let input: WizardInput | undefined;
+  let inputs: WizardInputElement[];
+  let input: WizardInputElement | undefined;
   let primaryAction: HTMLElement;
 
   let actionEvent: SinonSpy;

--- a/test/unit/wizards/trgops.test.ts
+++ b/test/unit/wizards/trgops.test.ts
@@ -4,14 +4,14 @@ import { SinonSpy, spy } from 'sinon';
 import '../../mock-wizard.js';
 import { MockWizard } from '../../mock-wizard.js';
 
-import { isReplace, Replace, WizardInput } from '../../../src/foundation.js';
+import { isReplace, Replace, WizardInputElement } from '../../../src/foundation.js';
 import { WizardSelect } from '../../../src/wizard-select.js';
 import { editTrgOpsWizard } from '../../../src/wizards/trgops.js';
 
 describe('Wizards for SCL TrgOps element', () => {
   let element: MockWizard;
   let trgOps: Element;
-  let inputs: WizardInput[];
+  let inputs: WizardInputElement[];
 
   let primaryAction: HTMLElement;
 

--- a/test/unit/zeroline/BayEditor.test.ts
+++ b/test/unit/zeroline/BayEditor.test.ts
@@ -1,6 +1,6 @@
 import { fixture, html, expect } from '@open-wc/testing';
 
-import { WizardInput, isCreate, isReplace } from '../../../src/foundation.js';
+import { WizardInputElement, isCreate, isReplace } from '../../../src/foundation.js';
 
 import '../../../src/wizard-textfield.js';
 import { createAction } from '../../../src/wizards/bay.js';
@@ -16,12 +16,12 @@ describe('BayEditor', () => {
     return element;
   };
 
-  let inputs: WizardInput[];
+  let inputs: WizardInputElement[];
   beforeEach(async () => {
     inputs = await Promise.all(
       ['name', 'desc'].map(
         label =>
-          <Promise<WizardInput>>(
+          <Promise<WizardInputElement>>(
             fixture(html`<wizard-textfield label=${label}></wizard-textfield>`)
           )
       )

--- a/test/unit/zeroline/SubstationEditor.test.ts
+++ b/test/unit/zeroline/SubstationEditor.test.ts
@@ -1,7 +1,7 @@
 import { fixture, html, expect } from '@open-wc/testing';
 
 import '../../../src/wizard-textfield.js';
-import { WizardInput, isCreate, isReplace } from '../../../src/foundation.js';
+import { WizardInputElement, isCreate, isReplace } from '../../../src/foundation.js';
 import { updateNamingAction } from '../../../src/wizards/foundation/actions.js';
 import { createAction } from '../../../src/wizards/substation.js';
 
@@ -15,12 +15,12 @@ describe('SubstationEditor', () => {
     return element;
   };
 
-  let inputs: WizardInput[];
+  let inputs: WizardInputElement[];
   beforeEach(async () => {
     inputs = await Promise.all(
       ['name', 'desc'].map(
         label =>
-          <Promise<WizardInput>>(
+          <Promise<WizardInputElement>>(
             fixture(html`<wizard-textfield label=${label}></wizard-textfield>`)
           )
       )

--- a/test/unit/zeroline/VoltageLevelEditor.test.ts
+++ b/test/unit/zeroline/VoltageLevelEditor.test.ts
@@ -2,7 +2,7 @@ import { fixture, html, expect } from '@open-wc/testing';
 
 import '../../../src/wizard-textfield.js';
 import {
-  WizardInput,
+  WizardInputElement,
   isCreate,
   isReplace,
   isDelete,
@@ -23,12 +23,12 @@ describe('VoltageLevelEditor', () => {
       return element;
     };
 
-    let inputs: WizardInput[];
+    let inputs: WizardInputElement[];
     beforeEach(async () => {
       inputs = await Promise.all(
         ['name', 'desc', 'nomFreq', 'numPhases', 'Voltage'].map(
           label =>
-            <Promise<WizardInput>>(
+            <Promise<WizardInputElement>>(
               fixture(
                 html`<wizard-textfield label=${label}></wizard-textfield>`
               )
@@ -154,12 +154,12 @@ describe('VoltageLevelEditor', () => {
       return element;
     };
 
-    let inputs: WizardInput[];
+    let inputs: WizardInputElement[];
     beforeEach(async () => {
       inputs = await Promise.all(
         ['name', 'desc', 'nomFreq', 'numPhases', 'Voltage'].map(
           label =>
-            <Promise<WizardInput>>(
+            <Promise<WizardInputElement>>(
               fixture(
                 html`<wizard-textfield label=${label}></wizard-textfield>`
               )


### PR DESCRIPTION
This is the second of three PRs that is aiming to simplify wizard-dialog definition for co-developers of OpenSCD as well as plug-in contributors. The basic idea behind the function `schemaAttributeDefinition` is to get the attributes' definition for a specific element. Say you want to manipulate the `name` attribute of the element `GSEControl` in a standard way this function will tell you if there are restrictions for this attribute like pattern, minLength, maxLength its base type and or enumerations.
