### PR TITLE
feat(wizard-dialog): allow used-defined actions in menu

### DIFF
--- a/src/foundation.ts
+++ b/src/foundation.ts
@@ -225,6 +225,16 @@ export function getMultiplier(input: WizardInput): string | null {
   else return null;
 }
 
+/** @returns [[`WizardAction`]]s to dispatch on [[`WizardDialog`]] menu action. */
+export type WizardMenuActor = () => WizardAction[];
+
+/** User interactions rendered in the wizard-dialog menu */
+interface MenuAction {
+  label: string;
+  icon?: string;
+  action: WizardMenuActor;
+}
+
 /** Represents a page of a wizard dialog */
 export interface WizardPage {
   title: string;
@@ -242,6 +252,7 @@ export interface WizardPage {
   };
   initial?: boolean;
   element?: Element;
+  menuActions?: MenuAction[];
 }
 export type Wizard = WizardPage[];
 export type WizardFactory = () => Wizard;
@@ -2307,10 +2318,7 @@ export const tags: Record<
     identity: namingIdentity,
     selector: namingSelector,
     parents: ['SCL'],
-    children: [...tEquipmentContainerSequence,
-      'VoltageLevel',
-      'Function',
-    ],
+    children: [...tEquipmentContainerSequence, 'VoltageLevel', 'Function'],
   },
   SupSubscription: {
     identity: singletonIdentity,
@@ -2387,11 +2395,7 @@ export const tags: Record<
     identity: namingIdentity,
     selector: namingSelector,
     parents: ['Substation'],
-    children: [...tEquipmentContainerSequence,
-      'Voltage',
-      'Bay',
-      'Function',
-    ],
+    children: [...tEquipmentContainerSequence, 'Voltage', 'Bay', 'Function'],
   },
 };
 

--- a/test/unit/__snapshots__/wizard-dialog.test.snap.js
+++ b/test/unit/__snapshots__/wizard-dialog.test.snap.js
@@ -13,3 +13,60 @@ snapshots["wizard-dialog with a nonempty wizard property in pro mode switches to
 `;
 /* end snapshot wizard-dialog with a nonempty wizard property in pro mode switches to code editor view on code toggle button click */
 
+snapshots["wizard-dialog with user defined menu actions set looks like its snapshot"] = 
+`<mwc-dialog
+  defaultaction="close"
+  heading="Page 1"
+  open=""
+>
+  <nav>
+    <mwc-icon-button icon="more_vert">
+    </mwc-icon-button>
+    <mwc-menu
+      class="actions-menu"
+      corner="BOTTOM_RIGHT"
+      menucorner="END"
+    >
+      <mwc-list-item
+        aria-disabled="false"
+        graphic="icon"
+        mwc-list-item=""
+        role="menuitem"
+        tabindex="-1"
+      >
+        <span>
+          remove
+        </span>
+        <mwc-icon slot="graphic">
+          delete
+        </mwc-icon>
+      </mwc-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        graphic="icon"
+        mwc-list-item=""
+        role="menuitem"
+        tabindex="-1"
+      >
+        <span>
+          remove
+        </span>
+        <mwc-icon slot="graphic">
+          delete
+        </mwc-icon>
+      </mwc-list-item>
+    </mwc-menu>
+  </nav>
+  <div id="wizard-content">
+  </div>
+  <mwc-button
+    dialogaction="close"
+    label="[cancel]"
+    slot="secondaryAction"
+    style="--mdc-theme-primary: var(--mdc-theme-error)"
+  >
+  </mwc-button>
+</mwc-dialog>
+`;
+/* end snapshot wizard-dialog with user defined menu actions set looks like its snapshot */
+

--- a/test/unit/wizard-dialog.test.ts
+++ b/test/unit/wizard-dialog.test.ts
@@ -15,6 +15,32 @@ describe('wizard-dialog', () => {
     element = await fixture(html`<wizard-dialog></wizard-dialog>`);
   });
 
+  describe('with user defined menu actions set', () => {
+    beforeEach(async () => {
+      element.wizard = [
+        {
+          title: 'Page 1',
+          menuActions: [
+            {
+              icon: 'delete',
+              label: 'remove',
+              action: () => [],
+            },
+            {
+              icon: 'delete',
+              label: 'remove',
+              action: () => [],
+            },
+          ],
+        },
+      ];
+      await element.updateComplete;
+    });
+
+    it('looks like its snapshot', async () =>
+      await expect(element).shadowDom.to.equalSnapshot());
+  });
+
   describe('with an empty wizard property', () => {
     it('shows no dialog', () =>
       expect(element).property('dialog').to.not.exist);


### PR DESCRIPTION
Triggered by @danyill I was thinking how to get rid of the buttons in the wizard content. @danyill rightly so pointed out that those buttons/actions should be allocated like the primary/secondary action not in the content of the wizard. 

This mock puts the in a menu that can be open on icon-button click in the right upper corner of the wizard. You can test it working with `EnumType`s in the template editor: 

1. go to Template editor
2. go to EnumType list
3. click on any of the list items
4. see the more vert icon button on the right upper corner
5. click and try the behaviour
6. compare to e.g. DAType list -> wizard


@Sander3003 @Flurb @dlabordus @ca-d @danyill I would be curious about your take on it. If this is a viable option, I would get rid of the buttons in wizard content