### PR TITLE
refactor(editors/template/enumtype): move buttons in content to menuA…

### DIFF
--- a/src/editors/templates/enumtype-wizard.ts
+++ b/src/editors/templates/enumtype-wizard.ts
@@ -18,17 +18,23 @@ import {
   getValue,
   identity,
   isPublic,
-  newActionEvent,
   newSubWizardEvent,
-  newWizardEvent,
   patterns,
   Replace,
   selector,
   Wizard,
+  WizardAction,
   WizardActor,
   WizardInput,
+  WizardMenuActor,
 } from '../../foundation.js';
 import { CreateOptions, UpdateOptions, WizardOptions } from './foundation.js';
+
+function remove(element: Element): WizardMenuActor {
+  return (): EditorAction[] => {
+    return [{ old: { parent: element.parentElement!, element } }];
+  };
+}
 
 function nextOrd(parent: Element): string {
   const maxOrd = Math.max(
@@ -98,31 +104,20 @@ function eNumValWizard(options: WizardOptions): Wizard {
       )
     ).find(isPublic) ?? null;
 
-  const [title, action, ord, desc, value, deleteButton] = enumval
+  const [title, action, ord, desc, value, menuActions] = enumval
     ? [
         get('enum-val.wizard.title.edit'),
         updateEnumValAction(enumval),
         enumval.getAttribute('ord'),
         enumval.getAttribute('desc'),
         enumval.textContent,
-        html`<mwc-button
-          icon="delete"
-          trailingIcon
-          label=${translate('delete')}
-          @click=${(e: MouseEvent) => {
-            e.target!.dispatchEvent(newWizardEvent());
-            e.target!.dispatchEvent(
-              newActionEvent({
-                old: {
-                  parent: enumval.parentElement!,
-                  element: enumval,
-                  reference: enumval.nextSibling,
-                },
-              })
-            );
-          }}
-          fullwidth
-        ></mwc-button>`,
+        [
+          {
+            icon: 'delete',
+            label: get('remove'),
+            action: remove(enumval),
+          },
+        ],
       ]
     : [
         get('enum-val.wizard.title.add'),
@@ -130,7 +125,7 @@ function eNumValWizard(options: WizardOptions): Wizard {
         nextOrd((<CreateOptions>options).parent),
         null, // desc is uncommon on EnumVal
         '',
-        html``,
+        undefined,
       ];
 
   return [
@@ -142,8 +137,8 @@ function eNumValWizard(options: WizardOptions): Wizard {
         label: 'Save',
         action: action,
       },
+      menuActions,
       content: [
-        deleteButton,
         html`<wizard-textfield
           label="ord"
           helper="${translate('scl.ord')}"
@@ -254,6 +249,12 @@ export function createEnumTypeWizard(
   ];
 }
 
+function openAddEnumVal(parent: Element): WizardMenuActor {
+  return (): WizardAction[] => {
+    return [() => eNumValWizard({ parent })];
+  };
+}
+
 function updateEnumTpyeAction(element: Element): WizardActor {
   return (inputs: WizardInput[]): EditorAction[] => {
     const id = getValue(inputs.find(i => i.label === 'id')!)!;
@@ -302,25 +303,19 @@ export function eNumTypeEditWizard(
         label: get('save'),
         action: updateEnumTpyeAction(enumtype),
       },
+      menuActions: [
+        {
+          label: get('remove'),
+          icon: 'delete',
+          action: remove(enumtype),
+        },
+        {
+          label: get('scl.EnumVal'),
+          icon: 'playlist_add',
+          action: openAddEnumVal(enumtype),
+        },
+      ],
       content: [
-        html`<mwc-button
-          icon="delete"
-          trailingIcon
-          label="${translate('remove')}"
-          @click=${(e: MouseEvent) => {
-            e.target!.dispatchEvent(newWizardEvent());
-            e.target!.dispatchEvent(
-              newActionEvent({
-                old: {
-                  parent: enumtype.parentElement!,
-                  element: enumtype,
-                  reference: enumtype.nextSibling,
-                },
-              })
-            );
-          }}
-          fullwidth
-        ></mwc-button> `,
         html`<wizard-textfield
           label="id"
           helper="${translate('scl.id')}"
@@ -338,41 +333,30 @@ export function eNumTypeEditWizard(
           nullable
           pattern="${patterns.normalizedString}"
         ></wizard-textfield>`,
-        html`<mwc-button
-            slot="graphic"
-            icon="playlist_add"
-            label="${translate('scl.EnumVal')}"
-            @click=${(e: Event) => {
-              const wizard = eNumValWizard({
-                parent: enumtype,
-              });
-              if (wizard) e.target!.dispatchEvent(newSubWizardEvent(wizard));
-            }}
-          ></mwc-button>
-          <mwc-list
-            style="margin-top: 0px;"
-            @selected=${(e: SingleSelectedEvent) => {
-              const wizard = eNumValWizard({
-                identity: (<ListItem>(<List>e.target).selected).value,
-                doc,
-              });
-              if (wizard) e.target!.dispatchEvent(newSubWizardEvent(wizard));
-            }}
-            >${Array.from(enumtype.querySelectorAll('EnumVal')).map(
-              enumval =>
-                html`<mwc-list-item
-                  graphic="icon"
-                  hasMeta
-                  tabindex="0"
-                  value="${identity(enumval)}"
+        html`<mwc-list
+          style="margin-top: 0px;"
+          @selected=${(e: SingleSelectedEvent) => {
+            const wizard = eNumValWizard({
+              identity: (<ListItem>(<List>e.target).selected).value,
+              doc,
+            });
+            if (wizard) e.target!.dispatchEvent(newSubWizardEvent(wizard));
+          }}
+          >${Array.from(enumtype.querySelectorAll('EnumVal')).map(
+            enumval =>
+              html`<mwc-list-item
+                graphic="icon"
+                hasMeta
+                tabindex="0"
+                value="${identity(enumval)}"
+              >
+                <span>${enumval.textContent ?? ''}</span>
+                <span slot="graphic"
+                  >${enumval.getAttribute('ord') ?? '-1'}</span
                 >
-                  <span>${enumval.textContent ?? ''}</span>
-                  <span slot="graphic"
-                    >${enumval.getAttribute('ord') ?? '-1'}</span
-                  >
-                </mwc-list-item>`
-            )}</mwc-list
-          > `,
+              </mwc-list-item>`
+          )}</mwc-list
+        > `,
       ],
     },
   ];

--- a/src/foundation.ts
+++ b/src/foundation.ts
@@ -225,6 +225,16 @@ export function getMultiplier(input: WizardInput): string | null {
   else return null;
 }
 
+/** @returns [[`WizardAction`]]s to dispatch on [[`WizardDialog`]] menu action. */
+export type WizardMenuActor = () => WizardAction[];
+
+/** User interactions rendered in the wizard-dialog menu */
+interface MenuAction {
+  label: string;
+  icon?: string;
+  action: WizardMenuActor;
+}
+
 /** Represents a page of a wizard dialog */
 export interface WizardPage {
   title: string;
@@ -242,6 +252,7 @@ export interface WizardPage {
   };
   initial?: boolean;
   element?: Element;
+  menuActions?: MenuAction[];
 }
 export type Wizard = WizardPage[];
 export type WizardFactory = () => Wizard;
@@ -2307,10 +2318,7 @@ export const tags: Record<
     identity: namingIdentity,
     selector: namingSelector,
     parents: ['SCL'],
-    children: [...tEquipmentContainerSequence,
-      'VoltageLevel',
-      'Function',
-    ],
+    children: [...tEquipmentContainerSequence, 'VoltageLevel', 'Function'],
   },
   SupSubscription: {
     identity: singletonIdentity,
@@ -2387,11 +2395,7 @@ export const tags: Record<
     identity: namingIdentity,
     selector: namingSelector,
     parents: ['Substation'],
-    children: [...tEquipmentContainerSequence,
-      'Voltage',
-      'Bay',
-      'Function',
-    ],
+    children: [...tEquipmentContainerSequence, 'Voltage', 'Bay', 'Function'],
   },
 };
 

--- a/test/integration/editors/templates/__snapshots__/enumtype-wizarding.test.snap.js
+++ b/test/integration/editors/templates/__snapshots__/enumtype-wizarding.test.snap.js
@@ -1372,14 +1372,45 @@ snapshots["EnumType wizards defines an eNumTypeEditWizard looks like the latest 
   heading="[enum.wizard.title.edit]"
   open=""
 >
-  <div id="wizard-content">
-    <mwc-button
-      fullwidth=""
-      icon="delete"
-      label="[remove]"
-      trailingicon=""
+  <nav>
+    <mwc-icon-button icon="more_vert">
+    </mwc-icon-button>
+    <mwc-menu
+      class="actions-menu"
+      corner="BOTTOM_RIGHT"
+      menucorner="END"
     >
-    </mwc-button>
+      <mwc-list-item
+        aria-disabled="false"
+        graphic="icon"
+        mwc-list-item=""
+        role="menuitem"
+        tabindex="0"
+      >
+        <span>
+          [remove]
+        </span>
+        <mwc-icon slot="graphic">
+          delete
+        </mwc-icon>
+      </mwc-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        graphic="icon"
+        mwc-list-item=""
+        role="menuitem"
+        tabindex="-1"
+      >
+        <span>
+          [scl.EnumVal]
+        </span>
+        <mwc-icon slot="graphic">
+          playlist_add
+        </mwc-icon>
+      </mwc-list-item>
+    </mwc-menu>
+  </nav>
+  <div id="wizard-content">
     <wizard-textfield
       dialoginitialfocus=""
       helper="[scl.id]"
@@ -1398,12 +1429,6 @@ snapshots["EnumType wizards defines an eNumTypeEditWizard looks like the latest 
       pattern="([ -~]|[]|[ -퟿]|[-�])*"
     >
     </wizard-textfield>
-    <mwc-button
-      icon="playlist_add"
-      label="[scl.EnumVal]"
-      slot="graphic"
-    >
-    </mwc-button>
     <mwc-list style="margin-top: 0px;">
       <mwc-list-item
         aria-disabled="false"
@@ -1507,14 +1532,31 @@ snapshots["EnumType wizards defines a eNumValWizard to edit an existing EnumVal 
   heading="[enum-val.wizard.title.edit]"
   open=""
 >
-  <div id="wizard-content">
-    <mwc-button
-      fullwidth=""
-      icon="delete"
-      label="[delete]"
-      trailingicon=""
+  <nav>
+    <mwc-icon-button icon="more_vert">
+    </mwc-icon-button>
+    <mwc-menu
+      class="actions-menu"
+      corner="BOTTOM_RIGHT"
+      menucorner="END"
     >
-    </mwc-button>
+      <mwc-list-item
+        aria-disabled="false"
+        graphic="icon"
+        mwc-list-item=""
+        role="menuitem"
+        tabindex="0"
+      >
+        <span>
+          [remove]
+        </span>
+        <mwc-icon slot="graphic">
+          delete
+        </mwc-icon>
+      </mwc-list-item>
+    </mwc-menu>
+  </nav>
+  <div id="wizard-content">
     <wizard-textfield
       helper="[scl.ord]"
       label="ord"

--- a/test/integration/editors/templates/enumtype-wizarding.test.ts
+++ b/test/integration/editors/templates/enumtype-wizarding.test.ts
@@ -110,6 +110,7 @@ describe('EnumType wizards', () => {
       (<ListItem>(
         eNumTypeList.querySelector('mwc-list-item[value="#Dummy_ctlModel"]')
       )).click();
+
       await parent.requestUpdate();
       await new Promise(resolve => setTimeout(resolve, 100)); // await animation
       idField = <WizardTextField>(
@@ -121,13 +122,14 @@ describe('EnumType wizards', () => {
         )
       );
       deleteButton = <HTMLElement>(
-        parent.wizardUI.dialog?.querySelector('mwc-button[icon="delete"]')
+        parent.wizardUI.dialog?.querySelectorAll('mwc-menu > mwc-list-item')[0]
       );
     });
 
     it('looks like the latest snapshot', async () => {
       await expect(parent.wizardUI.dialog).to.equalSnapshot();
     });
+
     it('edits EnumType attributes id', async () => {
       expect(doc.querySelector('EnumType[id="Dummy_ctlModel"]')).to.exist;
       idField.value = 'changedEnumType';
@@ -137,6 +139,7 @@ describe('EnumType wizards', () => {
       expect(doc.querySelector('EnumType[id="Dummy_ctlModel"]')).to.not.exist;
       expect(doc.querySelector('EnumType[id="changedEnumType"]')).to.exist;
     });
+
     it('deletes the EnumVal element on delete button click', async () => {
       expect(doc.querySelector('EnumType[id="Dummy_ctlModel"]')).to.exist;
       expect(doc.querySelectorAll('EnumType').length).to.equal(4);
@@ -145,6 +148,7 @@ describe('EnumType wizards', () => {
       expect(doc.querySelector('EnumType[id="Dummy_ctlModel"]')).to.not.exist;
       expect(doc.querySelectorAll('EnumType').length).to.equal(3);
     });
+
     it('does not edit EnumType element without changes', async () => {
       const originData = (<Element>(
         doc.querySelector('EnumType[id="Dummy_ctlModel"]')
@@ -195,13 +199,14 @@ describe('EnumType wizards', () => {
         )
       );
       deleteButton = <HTMLElement>(
-        parent.wizardUI.dialog?.querySelector('mwc-button[icon="delete"]')
+        parent.wizardUI.dialog?.querySelectorAll('mwc-menu > mwc-list-item')[0]
       );
     });
 
     it('looks like the latest snapshot', async () => {
       await expect(parent.wizardUI.dialog).to.equalSnapshot();
     });
+
     it('edits EnumVal attributes ord', async () => {
       expect(
         doc.querySelector('EnumType[id="Dummy_ctlModel"] > EnumVal[ord="1"]')
@@ -217,6 +222,7 @@ describe('EnumType wizards', () => {
         doc.querySelector('EnumType[id="Dummy_ctlModel"] > EnumVal[ord="10"]')
       ).to.exist;
     });
+
     it('edits EnumVal attributes value', async () => {
       expect(
         doc.querySelector('EnumType[id="Dummy_ctlModel"] > EnumVal[ord="1"]')
@@ -234,6 +240,7 @@ describe('EnumType wizards', () => {
         )?.textContent
       ).to.equal('direct-with-normal-security-test');
     });
+
     it('deletes the EnumVal element on delete button click', async () => {
       expect(
         doc.querySelector('EnumType[id="Dummy_ctlModel"] > EnumVal[ord="1"]')
@@ -250,6 +257,7 @@ describe('EnumType wizards', () => {
         doc.querySelectorAll('EnumType[id="Dummy_ctlModel"] > EnumVal').length
       ).to.equal(4);
     });
+
     it('does not edit EnumVal element without changes', async () => {
       const originData = (<Element>(
         doc.querySelector('EnumType[id="Dummy_ctlModel"] > EnumVal[ord="1"]')
@@ -277,7 +285,7 @@ describe('EnumType wizards', () => {
       await parent.requestUpdate();
       await new Promise(resolve => setTimeout(resolve, 100)); // await animation
       (<HTMLElement>(
-        parent.wizardUI.dialog?.querySelector('mwc-button[icon="playlist_add"]')
+        parent.wizardUI.dialog?.querySelectorAll('mwc-menu > mwc-list-item')[1]
       )).click();
       await parent.requestUpdate();
       await new Promise(resolve => setTimeout(resolve, 100)); // await animation

--- a/test/unit/__snapshots__/wizard-dialog.test.snap.js
+++ b/test/unit/__snapshots__/wizard-dialog.test.snap.js
@@ -13,3 +13,60 @@ snapshots["wizard-dialog with a nonempty wizard property in pro mode switches to
 `;
 /* end snapshot wizard-dialog with a nonempty wizard property in pro mode switches to code editor view on code toggle button click */
 
+snapshots["wizard-dialog with user defined menu actions set looks like its snapshot"] = 
+`<mwc-dialog
+  defaultaction="close"
+  heading="Page 1"
+  open=""
+>
+  <nav>
+    <mwc-icon-button icon="more_vert">
+    </mwc-icon-button>
+    <mwc-menu
+      class="actions-menu"
+      corner="BOTTOM_RIGHT"
+      menucorner="END"
+    >
+      <mwc-list-item
+        aria-disabled="false"
+        graphic="icon"
+        mwc-list-item=""
+        role="menuitem"
+        tabindex="-1"
+      >
+        <span>
+          remove
+        </span>
+        <mwc-icon slot="graphic">
+          delete
+        </mwc-icon>
+      </mwc-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        graphic="icon"
+        mwc-list-item=""
+        role="menuitem"
+        tabindex="-1"
+      >
+        <span>
+          remove
+        </span>
+        <mwc-icon slot="graphic">
+          delete
+        </mwc-icon>
+      </mwc-list-item>
+    </mwc-menu>
+  </nav>
+  <div id="wizard-content">
+  </div>
+  <mwc-button
+    dialogaction="close"
+    label="[cancel]"
+    slot="secondaryAction"
+    style="--mdc-theme-primary: var(--mdc-theme-error)"
+  >
+  </mwc-button>
+</mwc-dialog>
+`;
+/* end snapshot wizard-dialog with user defined menu actions set looks like its snapshot */
+

--- a/test/unit/wizard-dialog.test.ts
+++ b/test/unit/wizard-dialog.test.ts
@@ -15,6 +15,32 @@ describe('wizard-dialog', () => {
     element = await fixture(html`<wizard-dialog></wizard-dialog>`);
   });
 
+  describe('with user defined menu actions set', () => {
+    beforeEach(async () => {
+      element.wizard = [
+        {
+          title: 'Page 1',
+          menuActions: [
+            {
+              icon: 'delete',
+              label: 'remove',
+              action: () => [],
+            },
+            {
+              icon: 'delete',
+              label: 'remove',
+              action: () => [],
+            },
+          ],
+        },
+      ];
+      await element.updateComplete;
+    });
+
+    it('looks like its snapshot', async () =>
+      await expect(element).shadowDom.to.equalSnapshot());
+  });
+
   describe('with an empty wizard property', () => {
     it('shows no dialog', () =>
       expect(element).property('dialog').to.not.exist);


### PR DESCRIPTION
This is the first of many refactors to get rid of buttons within wizard-dialog content