### PR TITLE
refactor(editors/template/dotype): dotype/sdo wizards use menu actions

### DIFF
--- a/src/editors/templates/dotype-wizards.ts
+++ b/src/editors/templates/dotype-wizards.ts
@@ -19,12 +19,11 @@ import {
   getValue,
   identity,
   isPublic,
-  newActionEvent,
   newSubWizardEvent,
-  newWizardEvent,
   Replace,
   selector,
   Wizard,
+  WizardAction,
   WizardActor,
   WizardInput,
   WizardMenuActor,
@@ -296,6 +295,18 @@ export function createDOTypeWizard(
   ];
 }
 
+function openAddSdo(parent: Element): WizardMenuActor {
+  return (): WizardAction[] => {
+    return [() => sDOWizard({ parent })!];
+  };
+}
+
+function openAddDa(parent: Element): WizardMenuActor {
+  return (): WizardAction[] => {
+    return [() => createDaWizard(parent)!];
+  };
+}
+
 function updateDOTypeAction(element: Element): WizardActor {
   return (inputs: WizardInput[]): EditorAction[] => {
     const id = getValue(inputs.find(i => i.label === 'id')!)!;
@@ -348,25 +359,24 @@ export function dOTypeWizard(
         label: get('save'),
         action: updateDOTypeAction(dotype),
       },
+      menuActions: [
+        {
+          label: get('remove'),
+          icon: 'delete',
+          action: remove(dotype),
+        },
+        {
+          label: get('scl.DO'),
+          icon: 'playlist_add',
+          action: openAddSdo(dotype),
+        },
+        {
+          label: get('scl.DA'),
+          icon: 'playlist_add',
+          action: openAddDa(dotype),
+        },
+      ],
       content: [
-        html`<mwc-button
-          icon="delete"
-          trailingIcon
-          label="${translate('remove')}"
-          @click=${(e: MouseEvent) => {
-            e.target!.dispatchEvent(newWizardEvent());
-            e.target!.dispatchEvent(
-              newActionEvent({
-                old: {
-                  parent: dotype.parentElement!,
-                  element: dotype,
-                  reference: dotype.nextSibling,
-                },
-              })
-            );
-          }}
-          fullwidth
-        ></mwc-button> `,
         html`<wizard-textfield
           label="id"
           helper="${translate('scl.id')}"
@@ -390,32 +400,6 @@ export function dOTypeWizard(
           .maybeValue=${dotype.getAttribute('cdc')}
           pattern="${patterns.normalizedString}"
         ></wizard-textfield>`,
-        html`<section>
-          <mwc-button
-            slot="graphic"
-            icon="playlist_add"
-            trailingIcon
-            label="${translate('scl.DO')}"
-            @click=${(e: Event) => {
-              const wizard = sDOWizard({
-                parent: dotype,
-              });
-              if (wizard) e.target!.dispatchEvent(newSubWizardEvent(wizard));
-            }}
-          ></mwc-button>
-          <mwc-button
-            slot="graphic"
-            icon="playlist_add"
-            trailingIcon
-            label="${translate('scl.DA')}"
-            @click=${(e: Event) => {
-              if (dotype)
-                e.target!.dispatchEvent(
-                  newSubWizardEvent(createDaWizard(dotype))
-                );
-            }}
-          ></mwc-button>
-        </section>`,
         html`
           <mwc-list
             style="margin-top: 0px;"

--- a/src/editors/templates/dotype-wizards.ts
+++ b/src/editors/templates/dotype-wizards.ts
@@ -27,6 +27,7 @@ import {
   Wizard,
   WizardActor,
   WizardInput,
+  WizardMenuActor,
 } from '../../foundation.js';
 import { createDaWizard, editDAWizard } from '../../wizards/da.js';
 import { patterns } from '../../wizards/foundation/limits.js';
@@ -38,6 +39,12 @@ import {
   UpdateOptions,
   WizardOptions,
 } from './foundation.js';
+
+function remove(element: Element): WizardMenuActor {
+  return (): EditorAction[] => {
+    return [{ old: { parent: element.parentElement!, element } }];
+  };
+}
 
 function updateSDoAction(element: Element): WizardActor {
   return (inputs: WizardInput[]): EditorAction[] => {
@@ -96,29 +103,12 @@ function sDOWizard(options: WizardOptions): Wizard | undefined {
       )
     ).find(isPublic) ?? null;
 
-  const [title, action, type, deleteButton, name, desc] = sdo
+  const [title, action, type, menuActions, name, desc] = sdo
     ? [
         get('sdo.wizard.title.edit'),
         updateSDoAction(sdo),
         sdo.getAttribute('type'),
-        html`<mwc-button
-          icon="delete"
-          trailingIcon
-          label="${translate('remove')}"
-          @click=${(e: MouseEvent) => {
-            e.target!.dispatchEvent(newWizardEvent());
-            e.target!.dispatchEvent(
-              newActionEvent({
-                old: {
-                  parent: sdo.parentElement!,
-                  element: sdo,
-                  reference: sdo.nextSibling,
-                },
-              })
-            );
-          }}
-          fullwidth
-        ></mwc-button> `,
+        [{ icon: 'delete', label: get('remove'), action: remove(sdo) }],
         sdo.getAttribute('name'),
         sdo.getAttribute('desc'),
       ]
@@ -126,7 +116,7 @@ function sDOWizard(options: WizardOptions): Wizard | undefined {
         get('sdo.wizard.title.add'),
         createSDoAction((<CreateOptions>options).parent),
         null,
-        html``,
+        undefined,
         '',
         null,
       ];
@@ -140,8 +130,8 @@ function sDOWizard(options: WizardOptions): Wizard | undefined {
       title,
       element: sdo ?? undefined,
       primary: { icon: '', label: get('save'), action },
+      menuActions,
       content: [
-        deleteButton,
         html`<wizard-textfield
           label="name"
           .maybeValue=${name}

--- a/test/integration/editors/templates/__snapshots__/dotype-wizarding.test.snap.js
+++ b/test/integration/editors/templates/__snapshots__/dotype-wizarding.test.snap.js
@@ -1009,14 +1009,31 @@ snapshots["DOType wizards defines a sDOWizard to edit an existing SDO looks like
   heading="[sdo.wizard.title.edit]"
   open=""
 >
-  <div id="wizard-content">
-    <mwc-button
-      fullwidth=""
-      icon="delete"
-      label="[remove]"
-      trailingicon=""
+  <nav>
+    <mwc-icon-button icon="more_vert">
+    </mwc-icon-button>
+    <mwc-menu
+      class="actions-menu"
+      corner="BOTTOM_RIGHT"
+      menucorner="END"
     >
-    </mwc-button>
+      <mwc-list-item
+        aria-disabled="false"
+        graphic="icon"
+        mwc-list-item=""
+        role="menuitem"
+        tabindex="0"
+      >
+        <span>
+          [remove]
+        </span>
+        <mwc-icon slot="graphic">
+          delete
+        </mwc-icon>
+      </mwc-list-item>
+    </mwc-menu>
+  </nav>
+  <div id="wizard-content">
     <wizard-textfield
       dialoginitialfocus=""
       helper="[scl.name]"

--- a/test/integration/editors/templates/__snapshots__/dotype-wizarding.test.snap.js
+++ b/test/integration/editors/templates/__snapshots__/dotype-wizarding.test.snap.js
@@ -723,14 +723,59 @@ snapshots["DOType wizards defines a dOTypeWizard looks like the latest snapshot"
   heading="[dotype.wizard.title.edit]"
   open=""
 >
-  <div id="wizard-content">
-    <mwc-button
-      fullwidth=""
-      icon="delete"
-      label="[remove]"
-      trailingicon=""
+  <nav>
+    <mwc-icon-button icon="more_vert">
+    </mwc-icon-button>
+    <mwc-menu
+      class="actions-menu"
+      corner="BOTTOM_RIGHT"
+      menucorner="END"
     >
-    </mwc-button>
+      <mwc-list-item
+        aria-disabled="false"
+        graphic="icon"
+        mwc-list-item=""
+        role="menuitem"
+        tabindex="0"
+      >
+        <span>
+          [remove]
+        </span>
+        <mwc-icon slot="graphic">
+          delete
+        </mwc-icon>
+      </mwc-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        graphic="icon"
+        mwc-list-item=""
+        role="menuitem"
+        tabindex="-1"
+      >
+        <span>
+          [scl.DO]
+        </span>
+        <mwc-icon slot="graphic">
+          playlist_add
+        </mwc-icon>
+      </mwc-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        graphic="icon"
+        mwc-list-item=""
+        role="menuitem"
+        tabindex="-1"
+      >
+        <span>
+          [scl.DA]
+        </span>
+        <mwc-icon slot="graphic">
+          playlist_add
+        </mwc-icon>
+      </mwc-list-item>
+    </mwc-menu>
+  </nav>
+  <div id="wizard-content">
     <wizard-textfield
       dialoginitialfocus=""
       helper="[scl.id]"
@@ -755,22 +800,6 @@ snapshots["DOType wizards defines a dOTypeWizard looks like the latest snapshot"
       pattern="([ -~]|[]|[ -퟿]|[-�])*"
     >
     </wizard-textfield>
-    <section>
-      <mwc-button
-        icon="playlist_add"
-        label="[scl.DO]"
-        slot="graphic"
-        trailingicon=""
-      >
-      </mwc-button>
-      <mwc-button
-        icon="playlist_add"
-        label="[scl.DA]"
-        slot="graphic"
-        trailingicon=""
-      >
-      </mwc-button>
-    </section>
     <mwc-list style="margin-top: 0px;">
       <mwc-list-item
         aria-disabled="false"

--- a/test/integration/editors/templates/dotype-wizarding.test.ts
+++ b/test/integration/editors/templates/dotype-wizarding.test.ts
@@ -220,7 +220,7 @@ describe('DOType wizards', () => {
         )
       );
       deleteButton = <HTMLElement>(
-        parent.wizardUI.dialog?.querySelector('mwc-button[icon="delete"]')
+        parent.wizardUI.dialog?.querySelector('mwc-menu > mwc-list-item')
       );
       typeSelect = <Select>(
         parent.wizardUI.dialog?.querySelector('mwc-select[label="type"]')

--- a/test/integration/editors/templates/dotype-wizarding.test.ts
+++ b/test/integration/editors/templates/dotype-wizarding.test.ts
@@ -9,6 +9,7 @@ import { Select } from '@material/mwc-select';
 import { FilteredList } from '../../../../src/filtered-list.js';
 import TemplatesPlugin from '../../../../src/editors/Templates.js';
 import { WizardTextField } from '../../../../src/wizard-textfield.js';
+import { ListItemBase } from '@material/mwc-list/mwc-list-item-base';
 
 describe('DOType wizards', () => {
   if (customElements.get('templates-editor') === undefined)
@@ -70,6 +71,7 @@ describe('DOType wizards', () => {
     it('looks like the latest snapshot', async () => {
       await expect(parent.wizardUI.dialog).to.equalSnapshot();
     });
+
     it('allows to add empty DOTypes to the project', async () => {
       expect(doc.querySelector('DOType[id="myGeneralDOType"]')).to.not.exist;
       idField.maybeValue = 'myGeneralDOType';
@@ -79,6 +81,7 @@ describe('DOType wizards', () => {
       await parent.updateComplete;
       expect(doc.querySelector('DOType[id="myGeneralDOType"]')).to.exist;
     });
+
     it('allows to define CDC only for empty DOType creation', async () => {
       await cdcField.updateComplete;
       expect(cdcField.disabled).to.not.be.true;
@@ -86,6 +89,7 @@ describe('DOType wizards', () => {
       await cdcField.requestUpdate();
       expect(cdcField.disabled).to.be.true;
     });
+
     it('requires CDC definition for empty DOTypes', async () => {
       expect(doc.querySelector('DOType[id="myGeneralDOType"]')).to.not.exist;
       idField.maybeValue = 'myGeneralDOType';
@@ -95,6 +99,7 @@ describe('DOType wizards', () => {
       await parent.updateComplete;
       expect(doc.querySelector('DOType[id="myGeneralDOType"]')).to.not.exist;
     });
+
     it('respects the sequence defined in the standard', async () => {
       idField.maybeValue = 'myGeneralDOType';
       cdcField.maybeValue = 'SPS';
@@ -105,6 +110,7 @@ describe('DOType wizards', () => {
       expect(element?.nextElementSibling?.tagName).to.equal('DOType');
       expect(element?.previousElementSibling?.tagName).to.equal('LNodeType');
     });
+
     it('recursively add missing! subsequent EnumType elements', async () => {
       expect(doc.querySelector('DOType[id="myENSHealth"]')).to.not.exist;
       expect(doc.querySelector('EnumType[id="HealthKind"]')).to.not.exist;
@@ -119,6 +125,7 @@ describe('DOType wizards', () => {
         1
       );
     });
+
     it('recursively add missing! subsequent DAType elements', async () => {
       expect(doc.querySelector('DAType[id="OpenSCD_AnalogueValue_INT32"]')).to
         .not.exist;
@@ -155,14 +162,19 @@ describe('DOType wizards', () => {
         )
       );
       deleteButton = <HTMLElement>(
-        parent.wizardUI.dialog?.querySelector('mwc-button[icon="delete"]')
+        Array.from(
+          parent.wizardUI.dialog!.querySelectorAll<ListItemBase>(
+            'mwc-menu > mwc-list-item'
+          )
+        ).find(item => item.innerHTML.includes(`[remove]`))
       );
     });
 
     it('looks like the latest snapshot', async () => {
       await expect(parent.wizardUI.dialog).to.equalSnapshot();
     });
-    it('edits DAType attributes id', async () => {
+
+    it('edits DOType attributes id', async () => {
       expect(doc.querySelector('DOType[id="Dummy.LLN0.Mod"]')).to.exist;
       idField.value = 'changedDOType';
       await parent.requestUpdate();
@@ -171,7 +183,8 @@ describe('DOType wizards', () => {
       expect(doc.querySelector('DOType[id="Dummy.LLN0.Mod"]')).to.not.exist;
       expect(doc.querySelector('DOType[id="changedDOType"]')).to.exist;
     });
-    it('deletes the DAType attribute on delete button click', async () => {
+
+    it('deletes the DOType attribute on delete button click', async () => {
       expect(doc.querySelector('DOType[id="Dummy.LLN0.Mod"]')).to.exist;
       expect(doc.querySelectorAll('DOType').length).to.equal(15);
       deleteButton.click();
@@ -179,7 +192,8 @@ describe('DOType wizards', () => {
       expect(doc.querySelector('DAType[id="Dummy.LLN0.Mod"]')).to.not.exist;
       expect(doc.querySelectorAll('DOType').length).to.equal(14);
     });
-    it('does not edit DAType element without changes', async () => {
+
+    it('does not edit DOType element without changes', async () => {
       const originData = (<Element>(
         doc.querySelector('DOType[id="Dummy.LLN0.Mod"]')
       )).cloneNode(true);
@@ -287,12 +301,16 @@ describe('DOType wizards', () => {
       )).click();
       await parent.requestUpdate();
       await new Promise(resolve => setTimeout(resolve, 100)); // await animation
+
       (<HTMLElement>(
-        parent.wizardUI.dialog?.querySelectorAll(
-          'mwc-button[icon="playlist_add"]'
-        )[0]
+        Array.from(
+          parent.wizardUI.dialog!.querySelectorAll<ListItemBase>(
+            'mwc-menu > mwc-list-item'
+          )
+        ).find(item => item.innerHTML.includes(`[scl.DO]`))
       )).click();
-      await parent.requestUpdate();
+      await parent.wizardUI.dialog?.requestUpdate();
+
       await new Promise(resolve => setTimeout(resolve, 100)); // await animation
 
       nameField = <WizardTextField>(

--- a/test/integration/wizards/da-wizarding-editing.test.ts
+++ b/test/integration/wizards/da-wizarding-editing.test.ts
@@ -3,6 +3,8 @@ import { html, fixture, expect } from '@open-wc/testing';
 import '../../mock-wizard-editor.js';
 import { MockWizardEditor } from '../../mock-wizard-editor.js';
 
+import { ListItemBase } from '@material/mwc-list/mwc-list-item-base';
+
 import { FilteredList } from '../../../src/filtered-list.js';
 import { ListItem } from '@material/mwc-list/mwc-list-item';
 import TemplatesPlugin from '../../../src/editors/Templates.js';
@@ -72,14 +74,17 @@ describe('DA wizarding editing integration', () => {
     it('looks like the latest snapshot', async () => {
       await expect(parent.wizardUI.dialog).to.equalSnapshot();
     });
+
     it('edits DA attributes name', async () => {
       expect(
         doc.querySelector('DOType[id="Dummy.LLN0.Mod"] > DA[name="stVal"]')
       ).to.exist;
       nameField.value = 'newCtlVal';
+
       await parent.requestUpdate();
       primayAction.click();
       await parent.requestUpdate();
+
       expect(
         doc.querySelector('DOType[id="Dummy.LLN0.Mod"] > DA[name="stVal"]')
       ).to.not.exist;
@@ -87,6 +92,7 @@ describe('DA wizarding editing integration', () => {
         doc.querySelector('DOType[id="Dummy.LLN0.Mod"] > DA[name="newCtlVal"]')
       ).to.exist;
     });
+
     it('deletes the DA element on delete button click', async () => {
       expect(
         doc.querySelector('DOType[id="Dummy.LLN0.Mod"] > DA[name="stVal"]')
@@ -94,8 +100,10 @@ describe('DA wizarding editing integration', () => {
       expect(
         doc.querySelectorAll('DOType[id="Dummy.LLN0.Mod"] > DA').length
       ).to.equal(14);
+
       deleteButton.click();
       await parent.requestUpdate();
+
       expect(
         doc.querySelector('DOType[id="Dummy.LLN0.Mod"] > DA[name="stVal"]')
       ).to.not.exist;
@@ -103,12 +111,15 @@ describe('DA wizarding editing integration', () => {
         doc.querySelectorAll('DOType[id="Dummy.LLN0.Mod"] > DA').length
       ).to.equal(13);
     });
+
     it('does not edit DA element without changes', async () => {
       const originData = (<Element>(
         doc.querySelector('DOType[id="Dummy.LLN0.Mod"] > DA[name="stVal"]')
       )).cloneNode(true);
+
       primayAction.click();
       await parent.requestUpdate();
+
       expect(
         originData.isEqualNode(
           doc.querySelector('DOType[id="Dummy.LLN0.Mod"] > DA[name="stVal"]')
@@ -134,11 +145,15 @@ describe('DA wizarding editing integration', () => {
       )).click();
       await parent.requestUpdate();
       await new Promise(resolve => setTimeout(resolve, 100)); // await animation
+
       (<HTMLElement>(
-        parent.wizardUI.dialog?.querySelectorAll(
-          'mwc-button[icon="playlist_add"]'
-        )[1]
+        Array.from(
+          parent.wizardUI.dialog!.querySelectorAll<ListItemBase>(
+            'mwc-menu > mwc-list-item'
+          )
+        ).find(item => item.innerHTML.includes('[scl.DA]'))
       )).click();
+
       await parent.requestUpdate();
       await new Promise(resolve => setTimeout(resolve, 100)); // await animation
 


### PR DESCRIPTION
Proceeding to remove `mwc-button` from `wizard-dialog`s content