### PR TITLE
refactor(setting/nsdoc): Loading NSDoc Files through Custom Event

### DIFF
--- a/src/Logging.ts
+++ b/src/Logging.ts
@@ -245,8 +245,8 @@ export function Logging<TBase extends LitElementConstructor>(Base: TBase) {
 
       this.undo = this.undo.bind(this);
       this.redo = this.redo.bind(this);
-
       this.onLog = this.onLog.bind(this);
+
       this.addEventListener('log', this.onLog);
       this.addEventListener('issue', this.onIssue);
       this.addEventListener('open-doc', this.onLoadHistoryFromDoc);

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -12,7 +12,7 @@ import { Dialog } from '@material/mwc-dialog';
 import { Select } from '@material/mwc-select';
 import { Switch } from '@material/mwc-switch';
 
-import {ifImplemented, LitElementConstructor, Mixin, newLogEvent, OpenDocEvent} from './foundation.js';
+import { ifImplemented, LitElementConstructor, Mixin, newLogEvent } from './foundation.js';
 import { Language, languages, loader } from './translations/loader.js';
 
 import './WizardDivider.js';

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -62,14 +62,12 @@ export interface LoadNsdocDetail {
 export type LoadNsdocEvent = CustomEvent<LoadNsdocDetail>;
 export function newLoadNsdocEvent(
   nsdoc: string,
-  filename: string,
-  eventInitDict?: CustomEventInit<Partial<LoadNsdocDetail>>
+  filename: string
 ): LoadNsdocEvent {
   return new CustomEvent<LoadNsdocDetail>('load-nsdoc', {
     bubbles: true,
     composed: true,
-    ...eventInitDict,
-    detail: { nsdoc, filename, ...eventInitDict?.detail },
+    detail: { nsdoc, filename },
   });
 }
 

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -70,10 +70,9 @@ export const de: Translations = {
     showieds: 'Zeige IEDs im Substation-Editor',
     selectFileButton: 'Datei auswählen',
     loadNsdTranslations: 'NSDoc-Dateien hochladen',
-    invalidFileNoIdFound:
-      "Ungültiges NSDoc; kein 'id'-Attribut in der Datei gefunden",
+    invalidFileNoIdFound: "Ungültiges NSDoc ({{ filename }}); kein 'id'-Attribut in der Datei gefunden",
     invalidNsdocVersion:
-      'Die Version {{ id }} NSD ({{ nsdVersion }}) passt nicht zu der geladenen NSDoc ({{ nsdocVersion }})',
+      'Die Version {{ id }} NSD ({{ nsdVersion }}) passt nicht zu der geladenen NSDoc ({{ filename }}, {{ nsdocVersion }})',
   },
   menu: {
     new: 'Neues projekt',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -67,10 +67,10 @@ export const en = {
     mode: 'Pro mode',
     showieds: 'Show IEDs in substation editor',
     selectFileButton: 'Select file',
-    loadNsdTranslations: 'Uploading NSDoc files',
-    invalidFileNoIdFound: "Invalid NSDoc; no 'id' attribute found in file",
+    loadNsdTranslations: 'Uploaded NSDoc files',
+    invalidFileNoIdFound: "Invalid NSDoc ({{ filename }}); no 'id' attribute found in file",
     invalidNsdocVersion:
-      'The version of {{ id }} NSD ({{ nsdVersion }}) does not correlate with the version of the corresponding NSDoc ({{ nsdocVersion }})',
+      'The version of {{ id }} NSD ({{ nsdVersion }}) does not correlate with the version of the corresponding NSDoc ({{ filename }}, {{ nsdocVersion }})',
   },
   menu: {
     new: 'New project',

--- a/test/integration/Setting.test.ts
+++ b/test/integration/Setting.test.ts
@@ -4,11 +4,14 @@ import '../../src/open-scd.js';
 
 import { OpenSCD } from '../../src/open-scd.js';
 import { newLoadNsdocEvent } from "../../src/Setting.js";
+import { cleanLocalStorageForNsdocFiles } from "../unit/foundation/nsdoc.test.js";
 
 describe('Setting', () => {
   let element: OpenSCD;
 
   beforeEach(async () => {
+    cleanLocalStorageForNsdocFiles();
+
     element = await fixture(html`
       <open-scd></open-scd>
 

--- a/test/integration/Setting.test.ts
+++ b/test/integration/Setting.test.ts
@@ -4,13 +4,12 @@ import '../../src/open-scd.js';
 
 import { OpenSCD } from '../../src/open-scd.js';
 import { newLoadNsdocEvent } from "../../src/Setting.js";
-import { cleanLocalStorageForNsdocFiles } from "../unit/foundation/nsdoc.test.js";
 
 describe('Setting', () => {
   let element: OpenSCD;
 
   beforeEach(async () => {
-    cleanLocalStorageForNsdocFiles();
+    localStorage.clear();
 
     element = await fixture(html`
       <open-scd></open-scd>

--- a/test/integration/Setting.test.ts
+++ b/test/integration/Setting.test.ts
@@ -1,6 +1,7 @@
 import { html, fixture, expect } from '@open-wc/testing';
 
 import '../../src/open-scd.js';
+
 import { OpenSCD } from '../../src/open-scd.js';
 import { newLoadNsdocEvent } from "../../src/Setting.js";
 

--- a/test/integration/Setting.test.ts
+++ b/test/integration/Setting.test.ts
@@ -1,0 +1,81 @@
+import { html, fixture, expect } from '@open-wc/testing';
+
+import '../../src/open-scd.js';
+import { OpenSCD } from '../../src/open-scd.js';
+import { newLoadNsdocEvent } from "../../src/Setting.js";
+
+describe('Setting', () => {
+  let element: OpenSCD;
+
+  beforeEach(async () => {
+    element = await fixture(html`
+      <open-scd></open-scd>
+
+      <link href="public/google/fonts/roboto-v27.css" rel="stylesheet" />
+      <link href="public/google/fonts/roboto-mono-v13.css" rel="stylesheet" />
+      <link href="public/google/icons/material-icons-outlined.css" rel="stylesheet" />
+    `);
+  });
+
+  it('opens the log on log menu entry click', async () => {
+    await (<HTMLElement>(
+      element.shadowRoot!.querySelector('mwc-list-item[iconid="history"]')!
+    )).click();
+    expect(element.logUI).to.have.property('open', true);
+  });
+
+  it('upload .nsdoc file using event and looks like latest snapshot', async () => {
+    element.settingsUI.show();
+    await element.settingsUI.updateComplete;
+
+    const nsdocFile = await fetch('/test/testfiles/nsdoc/IEC_61850-7-2.nsdoc')
+      .then(response => response.text())
+
+    element.dispatchEvent(
+      newLoadNsdocEvent(nsdocFile, 'IEC_61850-7-2.nsdoc')
+    );
+
+    await element.requestUpdate();
+    await element.updateComplete;
+
+    expect(localStorage.getItem('IEC 61850-7-2')).to.eql(nsdocFile);
+    expect(element).shadowDom.to.equalSnapshot();
+  });
+
+  it('upload invalid .nsdoc file using event and log event fired', async () => {
+    element.settingsUI.show();
+    await element.settingsUI.updateComplete;
+
+    const nsdocFile = await fetch('/test/testfiles/nsdoc/invalid.nsdoc')
+      .then(response => response.text())
+
+    element.dispatchEvent(
+      newLoadNsdocEvent(nsdocFile, 'invalid.nsdoc')
+    );
+
+    await element.requestUpdate();
+    await element.updateComplete;
+
+    expect(element.history.length).to.be.equal(1);
+    expect(element.history[0].title).to.be.equal('Invalid NSDoc (invalid.nsdoc); no \'id\' attribute found in file');
+  });
+
+  it('upload .nsdoc file with wrong version using event and log event fired', async () => {
+    element.settingsUI.show();
+    await element.settingsUI.updateComplete;
+
+    const nsdocFile = await fetch('/test/testfiles/nsdoc/wrong-version.nsdoc')
+      .then(response => response.text())
+
+    element.dispatchEvent(
+      newLoadNsdocEvent(nsdocFile, 'wrong-version.nsdoc')
+    );
+
+    await element.requestUpdate();
+    await element.updateComplete;
+
+    expect(element.history.length).to.be.equal(1);
+    expect(element.history[0].title).to.be.equal('The version of IEC 61850-7-3 NSD (2007B3) does not correlate ' +
+      'with the version of the corresponding NSDoc (wrong-version.nsdoc, 2007B4)');
+  });
+}).timeout(4000);

--- a/test/integration/__snapshots__/Setting.test.snap.js
+++ b/test/integration/__snapshots__/Setting.test.snap.js
@@ -1182,7 +1182,8 @@ snapshots["Setting upload .nsdoc file using event and looks like latest snapshot
       </mwc-icon>
     </mwc-list-item>
     <mwc-list-item
-      aria-disabled="false"
+      aria-disabled="true"
+      disabled=""
       graphic="avatar"
       hasmeta=""
       id="IEC 61850-7-3"
@@ -1193,24 +1194,16 @@ snapshots["Setting upload .nsdoc file using event and looks like latest snapshot
       <span>
         IEC 61850-7-3
       </span>
-      <span slot="secondary">
-        1010X1
-      </span>
       <mwc-icon
         slot="graphic"
-        style="color:green;"
+        style="color:red;"
       >
-        done
-      </mwc-icon>
-      <mwc-icon
-        id="deleteNsdocItem"
-        slot="meta"
-      >
-        delete
+        close
       </mwc-icon>
     </mwc-list-item>
     <mwc-list-item
-      aria-disabled="false"
+      aria-disabled="true"
+      disabled=""
       graphic="avatar"
       hasmeta=""
       id="IEC 61850-7-4"
@@ -1221,24 +1214,16 @@ snapshots["Setting upload .nsdoc file using event and looks like latest snapshot
       <span>
         IEC 61850-7-4
       </span>
-      <span slot="secondary">
-        2007B3
-      </span>
       <mwc-icon
         slot="graphic"
-        style="color:green;"
+        style="color:red;"
       >
-        done
-      </mwc-icon>
-      <mwc-icon
-        id="deleteNsdocItem"
-        slot="meta"
-      >
-        delete
+        close
       </mwc-icon>
     </mwc-list-item>
     <mwc-list-item
-      aria-disabled="false"
+      aria-disabled="true"
+      disabled=""
       graphic="avatar"
       hasmeta=""
       id="IEC 61850-8-1"
@@ -1249,20 +1234,11 @@ snapshots["Setting upload .nsdoc file using event and looks like latest snapshot
       <span>
         IEC 61850-8-1
       </span>
-      <span slot="secondary">
-        1010X1
-      </span>
       <mwc-icon
         slot="graphic"
-        style="color:green;"
+        style="color:red;"
       >
-        done
-      </mwc-icon>
-      <mwc-icon
-        id="deleteNsdocItem"
-        slot="meta"
-      >
-        delete
+        close
       </mwc-icon>
     </mwc-list-item>
   </mwc-list>

--- a/test/integration/__snapshots__/Setting.test.snap.js
+++ b/test/integration/__snapshots__/Setting.test.snap.js
@@ -1,7 +1,7 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["open-scd looks like its snapshot"] = 
+snapshots["Setting upload .nsdoc file using event and looks like latest snapshot"] = 
 `<mwc-drawer
   class="mdc-theme--surface"
   hasheader=""
@@ -1087,6 +1087,7 @@ snapshots["open-scd looks like its snapshot"] =
 <mwc-dialog
   heading="Settings"
   id="settings"
+  open=""
 >
   <form>
     <mwc-select
@@ -1153,8 +1154,7 @@ snapshots["open-scd looks like its snapshot"] =
   </section>
   <mwc-list id="nsdocList">
     <mwc-list-item
-      aria-disabled="true"
-      disabled=""
+      aria-disabled="false"
       graphic="avatar"
       hasmeta=""
       id="IEC 61850-7-2"
@@ -1165,11 +1165,20 @@ snapshots["open-scd looks like its snapshot"] =
       <span>
         IEC 61850-7-2
       </span>
+      <span slot="secondary">
+        2007B3
+      </span>
       <mwc-icon
         slot="graphic"
-        style="color:red;"
+        style="color:green;"
       >
-        close
+        done
+      </mwc-icon>
+      <mwc-icon
+        id="deleteNsdocItem"
+        slot="meta"
+      >
+        delete
       </mwc-icon>
     </mwc-list-item>
     <mwc-list-item
@@ -1213,7 +1222,7 @@ snapshots["open-scd looks like its snapshot"] =
         IEC 61850-7-4
       </span>
       <span slot="secondary">
-        1010X1
+        2007B3
       </span>
       <mwc-icon
         slot="graphic"
@@ -1280,5 +1289,5 @@ snapshots["open-scd looks like its snapshot"] =
   </mwc-button>
 </mwc-dialog>
 `;
-/* end snapshot open-scd looks like its snapshot */
+/* end snapshot Setting upload .nsdoc file using event and looks like latest snapshot */
 

--- a/test/integration/__snapshots__/open-scd.test.snap.js
+++ b/test/integration/__snapshots__/open-scd.test.snap.js
@@ -1173,7 +1173,8 @@ snapshots["open-scd looks like its snapshot"] =
       </mwc-icon>
     </mwc-list-item>
     <mwc-list-item
-      aria-disabled="false"
+      aria-disabled="true"
+      disabled=""
       graphic="avatar"
       hasmeta=""
       id="IEC 61850-7-3"
@@ -1184,24 +1185,16 @@ snapshots["open-scd looks like its snapshot"] =
       <span>
         IEC 61850-7-3
       </span>
-      <span slot="secondary">
-        1010X1
-      </span>
       <mwc-icon
         slot="graphic"
-        style="color:green;"
+        style="color:red;"
       >
-        done
-      </mwc-icon>
-      <mwc-icon
-        id="deleteNsdocItem"
-        slot="meta"
-      >
-        delete
+        close
       </mwc-icon>
     </mwc-list-item>
     <mwc-list-item
-      aria-disabled="false"
+      aria-disabled="true"
+      disabled=""
       graphic="avatar"
       hasmeta=""
       id="IEC 61850-7-4"
@@ -1212,24 +1205,16 @@ snapshots["open-scd looks like its snapshot"] =
       <span>
         IEC 61850-7-4
       </span>
-      <span slot="secondary">
-        1010X1
-      </span>
       <mwc-icon
         slot="graphic"
-        style="color:green;"
+        style="color:red;"
       >
-        done
-      </mwc-icon>
-      <mwc-icon
-        id="deleteNsdocItem"
-        slot="meta"
-      >
-        delete
+        close
       </mwc-icon>
     </mwc-list-item>
     <mwc-list-item
-      aria-disabled="false"
+      aria-disabled="true"
+      disabled=""
       graphic="avatar"
       hasmeta=""
       id="IEC 61850-8-1"
@@ -1240,20 +1225,11 @@ snapshots["open-scd looks like its snapshot"] =
       <span>
         IEC 61850-8-1
       </span>
-      <span slot="secondary">
-        1010X1
-      </span>
       <mwc-icon
         slot="graphic"
-        style="color:green;"
+        style="color:red;"
       >
-        done
-      </mwc-icon>
-      <mwc-icon
-        id="deleteNsdocItem"
-        slot="meta"
-      >
-        delete
+        close
       </mwc-icon>
     </mwc-list-item>
   </mwc-list>

--- a/test/integration/open-scd.test.ts
+++ b/test/integration/open-scd.test.ts
@@ -3,7 +3,6 @@ import { html, fixture, expect } from '@open-wc/testing';
 import '../../src/open-scd.js';
 import { newEmptySCD } from '../../src/schemas.js';
 import { OpenSCD } from '../../src/open-scd.js';
-import { cleanLocalStorageForNsdocFiles } from "../unit/foundation/nsdoc.test.js";
 
 describe('open-scd', () => {
   let element: OpenSCD;
@@ -11,7 +10,7 @@ describe('open-scd', () => {
   let validSCL: string;
 
   beforeEach(async () => {
-    cleanLocalStorageForNsdocFiles();
+    localStorage.clear();
 
     invalidSCL = await fetch('/test/testfiles/invalid2007B.scd').then(
       response => response.text()

--- a/test/integration/open-scd.test.ts
+++ b/test/integration/open-scd.test.ts
@@ -21,10 +21,7 @@ describe('open-scd', () => {
 
       <link href="public/google/fonts/roboto-v27.css" rel="stylesheet" />
       <link href="public/google/fonts/roboto-mono-v13.css" rel="stylesheet" />
-      <link
-        href="public/google/icons/material-icons-outlined.css"
-        rel="stylesheet"
-      />
+      <link href="public/google/icons/material-icons-outlined.css" rel="stylesheet" />
     `);
   });
 

--- a/test/integration/open-scd.test.ts
+++ b/test/integration/open-scd.test.ts
@@ -3,6 +3,7 @@ import { html, fixture, expect } from '@open-wc/testing';
 import '../../src/open-scd.js';
 import { newEmptySCD } from '../../src/schemas.js';
 import { OpenSCD } from '../../src/open-scd.js';
+import { cleanLocalStorageForNsdocFiles } from "../unit/foundation/nsdoc.test.js";
 
 describe('open-scd', () => {
   let element: OpenSCD;
@@ -10,6 +11,8 @@ describe('open-scd', () => {
   let validSCL: string;
 
   beforeEach(async () => {
+    cleanLocalStorageForNsdocFiles();
+
     invalidSCL = await fetch('/test/testfiles/invalid2007B.scd').then(
       response => response.text()
     );

--- a/test/testfiles/nsdoc/IEC_61850-7-2.nsdoc
+++ b/test/testfiles/nsdoc/IEC_61850-7-2.nsdoc
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<NSDoc id="IEC 61850-7-2"
+       version="2007"
+       revision="B"
+       release="3"
+       lang="en">
+</NSDoc>

--- a/test/testfiles/nsdoc/invalid.nsdoc
+++ b/test/testfiles/nsdoc/invalid.nsdoc
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- SPDX-FileCopyrightText: 2022 Alliander -->
+<!-- -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+<NSDoc>
+</NSDoc>

--- a/test/testfiles/nsdoc/wrong-version.nsdoc
+++ b/test/testfiles/nsdoc/wrong-version.nsdoc
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<NSDoc id="IEC 61850-7-3"
+       version="2007"
+       revision="B"
+       release="4"
+       lang="en">
+</NSDoc>

--- a/test/testfiles/settingTest.nsdoc
+++ b/test/testfiles/settingTest.nsdoc
@@ -1,3 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<NSDoc id="IEC 61850-7-2" lang="en">
-</NSDoc>

--- a/test/unit/Setting.test.ts
+++ b/test/unit/Setting.test.ts
@@ -52,12 +52,12 @@ describe('SettingElement', () => {
   it('saves chosen .nsdoc file and looks like latest snapshot', async () => {
     element.settingsUI.show();
     await element.settingsUI.updateComplete;
-  
-    const nsdocFile = await fetch('/test/testfiles/settingTest.nsdoc')
+
+    const nsdocFile = await fetch('/test/testfiles/nsdoc/IEC_61850-7-2.nsdoc')
       .then(response => response.text())
 
     element.setSetting('IEC 61850-7-2', nsdocFile);
-    
+
     await element.requestUpdate();
     await element.updateComplete;
 
@@ -68,19 +68,19 @@ describe('SettingElement', () => {
   it('deletes a chosen .nsdoc file and looks like latest snapshot', async () => {
     element.settingsUI.show();
     await element.settingsUI.updateComplete;
-  
-    const nsdocFile = await fetch('/test/testfiles/settingTest.nsdoc')
+
+    const nsdocFile = await fetch('/test/testfiles/nsdoc/IEC_61850-7-2.nsdoc')
       .then(response => response.text())
 
     element.setSetting('IEC 61850-7-2', nsdocFile);
-    
+
     await element.requestUpdate();
     await element.updateComplete;
 
     (<Button>(
       element.settingsUI.querySelector('mwc-icon[id="deleteNsdocItem"]')
     )).click();
-    
+
     await element.requestUpdate();
     await element.updateComplete;
 

--- a/test/unit/foundation/nsdoc.test.ts
+++ b/test/unit/foundation/nsdoc.test.ts
@@ -146,11 +146,3 @@ describe('nsdoc', () => {
     });
   });
 });
-
-export function cleanLocalStorageForNsdocFiles() {
-  // Cleanup NSDoc Files from LocalStorage
-  localStorage.removeItem('IEC 61850-7-2');
-  localStorage.removeItem('IEC 61850-7-3');
-  localStorage.removeItem('IEC 61850-7-4');
-  localStorage.removeItem('IEC 61850-8-1');
-}

--- a/test/unit/foundation/nsdoc.test.ts
+++ b/test/unit/foundation/nsdoc.test.ts
@@ -63,7 +63,7 @@ describe('nsdoc', () => {
         it('returns the lnClass in case no title can be found', async function () {
           const ln = validSCL.querySelector(
             'IED[name="IED1"] > AccessPoint[name="P1"] > Server > LDevice[inst="CircuitBreaker_CB1"] > LN[lnClass="XCBR"]');
-      
+
             expect(nsdocsObject.getDataDescription(ln!).label).to.eql('XCBR');
         });
       });
@@ -71,19 +71,19 @@ describe('nsdoc', () => {
       describe('which for DO elements', () => {
         it('returns the description', async function () {
           const dataObject = validSCL.querySelector('LNodeType[id="Dummy.LLN0"] > DO[name="Beh"]');
-  
+
           expect(nsdocsObject.getDataDescription(dataObject!).label).to.eql('Some DO description');
         });
-  
+
         it('returns the description where the DO is part of a parent class', async function () {
           const dataObject = validSCL.querySelector('LNodeType[id="Dummy.XCBR1"] > DO[name="Beh"]');
-  
+
           expect(nsdocsObject.getDataDescription(dataObject!).label).to.eql('Some DomainLN Description');
         });
-  
+
         it('returns the name in case no description can be found', async function () {
           const dataObject = validSCL.querySelector('LNodeType[id="Dummy.LLN0"] > DO[name="Health"]');
-  
+
           expect(nsdocsObject.getDataDescription(dataObject!).label).to.eql('Health');
         });
       });
@@ -91,25 +91,25 @@ describe('nsdoc', () => {
       describe('which for DA elements', () => {
         it('returns the description defined in IEC 61850-7-3', async function () {
           const dataObject = validSCL.querySelector('DOType[id="Dummy.LLN0.Mod"] > DA[name="q"]');
-  
+
           expect(nsdocsObject.getDataDescription(dataObject!).label).to.eql('Some DA description');
         });
-  
+
         it('returns the name in case no description can be found in IEC 61850-7-3', async function () {
           const dataObject = validSCL.querySelector('DOType[id="Dummy.LLN0.Mod"] > DA[name="t"]');
-  
+
           expect(nsdocsObject.getDataDescription(dataObject!).label).to.eql('t');
         });
-  
+
         it('returns the description defined in IEC 61850-8-1', async function () {
           const dataObject = validSCL.querySelector('DOType[id="Dummy.LLN0.Mod"] > DA[name="SBOw"]');
-  
+
           expect(nsdocsObject.getDataDescription(dataObject!).label).to.eql('Some SBOw title');
         });
-  
+
         it('which returns the name in case no description can be found in IEC 61850-8-1', async function () {
           const dataObject = validSCL.querySelector('DOType[id="Dummy.LLN0.Mod"] > DA[name="SBO"]');
-  
+
           expect(nsdocsObject.getDataDescription(dataObject!).label).to.eql('SBO');
         });
       });
@@ -118,31 +118,39 @@ describe('nsdoc', () => {
         it('returns the description defined in IEC 61850-7-3', async function () {
           const bdaElement = validSCL.querySelector('DAType[id="AnalogueValue_i"] > BDA[name="i"]');
           const bdaElementParent = validSCL.querySelector('DOType[id="DummySAV"] > DA[name="instMag"]');
-  
+
           expect(nsdocsObject.getDataDescription(bdaElement!, [bdaElementParent!]).label).to.eql('Some i description');
         });
-  
+
         it('returns the name in case no description can be found in IEC 61850-7-3', async function () {
           const bdaElement = validSCL.querySelector('DAType[id="AnalogueValue_i"] > BDA[name="x"]');
           const bdaElementParent = validSCL.querySelector('DOType[id="DummySAV"] > DA[name="instMag"]');
-  
+
           expect(nsdocsObject.getDataDescription(bdaElement!, [bdaElementParent!]).label).to.eql('x');
         });
-  
+
         it('returns the description defined in IEC 61850-8-1', async function () {
           const bdaElement = validSCL.querySelector('DAType[id="Dummy.LLN0.Mod.SBOw"] > BDA[name="ctlNum"]');
           const bdaElementParent = validSCL.querySelector('DOType[id="Dummy.LLN0.Mod"] > DA[name="SBOw"]');
-  
+
           expect(nsdocsObject.getDataDescription(bdaElement!, [bdaElementParent!]).label).to.eql('Some ctlNum description');
         });
-  
+
         it('returns the name in case no description can be found in IEC 61850-8-1', async function () {
           const bdaElement = validSCL.querySelector('DAType[id="Dummy.LLN0.Mod.SBOw"] > BDA[name="T"]');
           const bdaElementParent = validSCL.querySelector('DOType[id="Dummy.LLN0.Mod"] > DA[name="SBOw"]');
-  
+
           expect(nsdocsObject.getDataDescription(bdaElement!, [bdaElementParent!]).label).to.eql('T');
         });
       });
     });
   });
 });
+
+export function cleanLocalStorageForNsdocFiles() {
+  // Cleanup NSDoc Files from LocalStorage
+  localStorage.removeItem('IEC 61850-7-2');
+  localStorage.removeItem('IEC 61850-7-3');
+  localStorage.removeItem('IEC 61850-7-4');
+  localStorage.removeItem('IEC 61850-8-1');
+}


### PR DESCRIPTION
For CoMPAS we needed the loading to be done through a Custom Event, as it was original agreed. 
This way the logic for loading doesn't need to be duplicated.