### PR TITLE
feat(wizards/gsecontrol): add create wizards

### DIFF
--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -468,6 +468,8 @@ export const de: Translations = {
     action: {
       addaddress: 'GSE bearbeitet ({{identity}})',
     },
+    missingaccp:
+      'AccessPoint is nicht verbunden. GSE kann nicht hinzugefügt werden.',
   },
   smv: {
     action: {

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -70,7 +70,8 @@ export const de: Translations = {
     showieds: 'Zeige IEDs im Substation-Editor',
     selectFileButton: 'Datei auswählen',
     loadNsdTranslations: 'NSDoc-Dateien hochladen',
-    invalidFileNoIdFound: "Ungültiges NSDoc ({{ filename }}); kein 'id'-Attribut in der Datei gefunden",
+    invalidFileNoIdFound:
+      "Ungültiges NSDoc ({{ filename }}); kein 'id'-Attribut in der Datei gefunden",
     invalidNsdocVersion:
       'Die Version {{ id }} NSD ({{ nsdVersion }}) passt nicht zu der geladenen NSDoc ({{ filename }}, {{ nsdocVersion }})',
   },
@@ -523,8 +524,10 @@ export const de: Translations = {
     unreferencedControls: {
       title: 'Steuerblöcke mit einem fehlenden oder ungültigen Kontrollblock',
       deleteButton: 'Ausgewählte Kontrollblöcke entfernen',
-      tooltip: 'Steuerblöcke ohne Verweis auf ein vorhandenes Datensatz. Das ist kein Fehler und eher üblich for allem für Reports',
-      addressDefinitionTooltip: 'Für diesen Kontrollblock existiert eine Adressdefinition im Abschnitt Kommunikation',
+      tooltip:
+        'Steuerblöcke ohne Verweis auf ein vorhandenes Datensatz. Das ist kein Fehler und eher üblich for allem für Reports',
+      addressDefinitionTooltip:
+        'Für diesen Kontrollblock existiert eine Adressdefinition im Abschnitt Kommunikation',
       alsoRemoveFromCommunication: 'Kommunikation SMV/GSE mit entfernen',
     },
   },
@@ -545,6 +548,9 @@ export const de: Translations = {
     label: {
       copy: 'Kopie in anderen IEDs ertellen',
     },
+  },
+  gsecontrol: {
+    wizard: { location: 'Ablageort der GOOSE wählen' },
   },
   add: 'Hinzufügen',
   new: 'Neu',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -68,7 +68,8 @@ export const en = {
     showieds: 'Show IEDs in substation editor',
     selectFileButton: 'Select file',
     loadNsdTranslations: 'Uploaded NSDoc files',
-    invalidFileNoIdFound: "Invalid NSDoc ({{ filename }}); no 'id' attribute found in file",
+    invalidFileNoIdFound:
+      "Invalid NSDoc ({{ filename }}); no 'id' attribute found in file",
     invalidNsdocVersion:
       'The version of {{ id }} NSD ({{ nsdVersion }}) does not correlate with the version of the corresponding NSDoc ({{ filename }}, {{ nsdocVersion }})',
   },
@@ -465,6 +466,7 @@ export const en = {
     action: {
       addaddress: 'Edit GSE ({{identity}})',
     },
+    missingaccp: 'Accesspoint is not connected. GSE cannot be created.',
   },
   smv: {
     action: {
@@ -518,8 +520,10 @@ export const en = {
     unreferencedControls: {
       title: 'Control Blocks with a Missing or Invalid Dataset',
       deleteButton: 'Remove Selected Control Blocks',
-      tooltip: 'Control Blocks without a reference to an existing DataSet. Note that this is normal in an ICD file or for an MMS ReportControl with a dynamically allocated DataSet',
-      addressDefinitionTooltip: 'An address definition exists for this control block in the Communication section',
+      tooltip:
+        'Control Blocks without a reference to an existing DataSet. Note that this is normal in an ICD file or for an MMS ReportControl with a dynamically allocated DataSet',
+      addressDefinitionTooltip:
+        'An address definition exists for this control block in the Communication section',
       alsoRemoveFromCommunication: 'Also remove SMV/GSE Address',
     },
   },

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -543,6 +543,9 @@ export const en = {
     },
     label: { copy: 'Copy to other IEDs' },
   },
+  gsecontrol: {
+    wizard: { location: 'Select GOOSE Control Block Location' },
+  },
   add: 'Add',
   new: 'New',
   remove: 'Remove',

--- a/src/wizards/address.ts
+++ b/src/wizards/address.ts
@@ -13,32 +13,30 @@ import {
   getValue,
   WizardInputElement,
 } from '../foundation.js';
-import {
-  pTypesGSESMV,
-  typeNullable,
-  typePattern,
-} from './foundation/p-types.js';
+import { typeNullable, typePattern } from './foundation/p-types.js';
 
-export function renderGseSmvAddress(parent: Element): TemplateResult[] {
-  const hasInstType = Array.from(parent.querySelectorAll('Address > P')).some(
-    pType => pType.getAttribute('xsi:type')
-  );
+interface ContentOptions {
+  hasInstType: boolean;
+  attributes: Record<string, string | null>;
+}
 
+export function contentGseWizard(content: ContentOptions): TemplateResult[] {
   return [
     html`<mwc-formfield
       label="${translate('connectedap.wizard.addschemainsttype')}"
     >
-      <mwc-checkbox id="instType" ?checked="${hasInstType}"></mwc-checkbox>
+      <mwc-checkbox
+        id="instType"
+        ?checked="${content.hasInstType}"
+      ></mwc-checkbox>
     </mwc-formfield>`,
-    html`${pTypesGSESMV.map(
-      ptype =>
+    html`${Object.entries(content.attributes).map(
+      ([key, value]) =>
         html`<wizard-textfield
-          label="${ptype}"
-          .maybeValue=${parent
-            .querySelector(`Address > P[type="${ptype}"]`)
-            ?.innerHTML.trim() ?? null}
-          ?nullable=${typeNullable[ptype]}
-          pattern="${ifDefined(typePattern[ptype])}"
+          label="${key}"
+          .maybeValue=${value}
+          ?nullable=${typeNullable[key]}
+          pattern="${ifDefined(typePattern[key])}"
           required
         ></wizard-textfield>`
     )}`,

--- a/src/wizards/address.ts
+++ b/src/wizards/address.ts
@@ -6,13 +6,7 @@ import '@material/mwc-checkbox';
 import '@material/mwc-formfield';
 
 import '../wizard-textfield.js';
-import {
-  Create,
-  createElement,
-  Delete,
-  getValue,
-  WizardInputElement,
-} from '../foundation.js';
+import { Create, createElement, Delete } from '../foundation.js';
 import { typeNullable, typePattern } from './foundation/p-types.js';
 
 interface ContentOptions {
@@ -54,25 +48,25 @@ function isEqualAddress(oldAddr: Element, newAdddr: Element): boolean {
   );
 }
 
-function createAddressElement(
-  inputs: WizardInputElement[],
+export function createAddressElement(
+  inputs: Record<string, string | null>,
   parent: Element,
   instType: boolean
 ): Element {
   const element = createElement(parent.ownerDocument, 'Address', {});
 
-  inputs
-    .filter(input => getValue(input) !== null)
-    .forEach(validInput => {
-      const type = validInput.label;
+  Object.entries(inputs)
+    .filter(([key, value]) => value !== null)
+    .forEach(([key, value]) => {
+      const type = key;
       const child = createElement(parent.ownerDocument, 'P', { type });
       if (instType)
         child.setAttributeNS(
           'http://www.w3.org/2001/XMLSchema-instance',
           'xsi:type',
-          'tP_' + type
+          'tP_' + key
         );
-      child.textContent = getValue(validInput);
+      child.textContent = value;
       element.appendChild(child);
     });
 
@@ -81,7 +75,7 @@ function createAddressElement(
 
 export function updateAddress(
   parent: Element,
-  inputs: WizardInputElement[],
+  inputs: Record<string, string | null>,
   instType: boolean
 ): (Create | Delete)[] {
   const actions: (Create | Delete)[] = [];

--- a/src/wizards/address.ts
+++ b/src/wizards/address.ts
@@ -28,8 +28,8 @@ export function contentGseWizard(content: ContentOptions): TemplateResult[] {
       ([key, value]) =>
         html`<wizard-textfield
           label="${key}"
-          .maybeValue=${value}
           ?nullable=${typeNullable[key]}
+          .maybeValue=${value}
           pattern="${ifDefined(typePattern[key])}"
           required
         ></wizard-textfield>`

--- a/src/wizards/foundation/scl.ts
+++ b/src/wizards/foundation/scl.ts
@@ -1,0 +1,54 @@
+function incrementMac(oldMac: string): string {
+  const mac = oldMac.split('-').join('');
+  //destination MAC in IEC61850 always starts with 01:0C:CD:...
+  const newMac = '0' + (parseInt(mac, 16) + 1).toString(16).toUpperCase();
+  return newMac.match(/.{1,2}/g)!.join('-');
+}
+
+export function uniqueMacAddress(
+  doc: XMLDocument,
+  serviceType: 'SMV' | 'GOOSE'
+): string | null {
+  const maxMac =
+    serviceType === 'GOOSE' ? '01-0C-CD-01-01-FF' : '01-0C-CD-04-01-FF';
+  const startMac =
+    serviceType === 'GOOSE' ? '01-0C-CD-01-00-00' : '01-0C-CD-04-00-00';
+
+  const givenMacs = Array.from(doc.querySelectorAll('Address > P'))
+    .filter(pElement => pElement.getAttribute('type') === 'MAC-Address')
+    .map(mac => mac.innerHTML.trim());
+
+  let mac = startMac;
+  while (mac !== maxMac) {
+    if (!givenMacs.includes(mac)) return mac;
+    mac = incrementMac(mac);
+  }
+
+  return givenMacs.includes(mac) ? null : mac;
+}
+
+function incrementAppId(oldAppId: string): string {
+  return (parseInt(oldAppId, 16) + 1)
+    .toString(16)
+    .toUpperCase()
+    .padStart(4, '0');
+}
+
+export function uniqueAppId(doc: XMLDocument): string | null {
+  const maxAppId = 'FFFF';
+  const startAppId = '0001';
+
+  const givenAppIds = Array.from(doc.querySelectorAll('Address > P'))
+    .filter(pElement => pElement.getAttribute('type') === 'APPID')
+    .map(mac => mac.innerHTML.trim());
+
+  if (givenAppIds.length === 0) return null;
+
+  let appId = startAppId;
+  while (appId !== maxAppId) {
+    if (!givenAppIds.includes(appId)) return appId;
+    appId = incrementAppId(appId);
+  }
+
+  return givenAppIds.includes(appId) ? null : appId;
+}

--- a/src/wizards/foundation/scl.ts
+++ b/src/wizards/foundation/scl.ts
@@ -1,3 +1,17 @@
+export function getConnectedAP(element: Element): Element | null {
+  return element.ownerDocument.querySelector(
+    `:root > Communication > SubNetwork > ConnectedAP[iedName="${element
+      .closest('IED')
+      ?.getAttribute('name')}"][apName="${element
+      .closest('AccessPoint')
+      ?.getAttribute('name')}"]`
+  );
+}
+
+export function isAccessPointConnected(element: Element): boolean {
+  return getConnectedAP(element) ? true : false;
+}
+
 function incrementMac(oldMac: string): string {
   const mac = oldMac.split('-').join('');
   //destination MAC in IEC61850 always starts with 01:0C:CD:...

--- a/src/wizards/gse.ts
+++ b/src/wizards/gse.ts
@@ -67,7 +67,20 @@ export function updateGSEAction(element: Element): WizardActor {
     const instType: boolean =
       (<Checkbox>wizard.shadowRoot?.querySelector('#instType'))?.checked ??
       false;
-    const addressActions = updateAddress(element, inputs, instType);
+
+    const addressContent: Record<string, string | null> = {};
+    addressContent['MAC-Address'] = getValue(
+      inputs.find(i => i.label === 'MAC-Address')!
+    );
+    addressContent['APPID'] = getValue(inputs.find(i => i.label === 'APPID')!);
+    addressContent['VLAN-ID'] = getValue(
+      inputs.find(i => i.label === 'VLAN-ID')!
+    );
+    addressContent['VLAN-PRIORITY'] = getValue(
+      inputs.find(i => i.label === 'VLAN-PRIORITY')!
+    );
+
+    const addressActions = updateAddress(element, addressContent, instType);
 
     addressActions.forEach(action => {
       complexAction.actions.push(action);

--- a/src/wizards/gse.ts
+++ b/src/wizards/gse.ts
@@ -15,7 +15,7 @@ import {
   WizardActor,
   WizardInputElement,
 } from '../foundation.js';
-import { renderGseSmvAddress, updateAddress } from './address.js';
+import { contentGseWizard, updateAddress } from './address.js';
 
 export function getMTimeAction(
   type: 'MinTime' | 'MaxTime',
@@ -110,6 +110,19 @@ export function editGseWizard(element: Element): Wizard {
   const minTime = element.querySelector('MinTime')?.innerHTML.trim() ?? null;
   const maxTime = element.querySelector('MaxTime')?.innerHTML.trim() ?? null;
 
+  const hasInstType = Array.from(element.querySelectorAll('Address > P')).some(
+    pType => pType.getAttribute('xsi:type')
+  );
+
+  const attributes: Record<string, string | null> = {};
+
+  ['MAC-Address', 'APPID', 'VLAN-ID', 'VLAN-PRIORITY'].forEach(key => {
+    if (!attributes[key])
+      attributes[key] =
+        element.querySelector(`Address > P[type="${key}"]`)?.innerHTML.trim() ??
+        null;
+  });
+
   return [
     {
       title: get('wizard.title.edit', { tagName: element.tagName }),
@@ -120,7 +133,7 @@ export function editGseWizard(element: Element): Wizard {
         action: updateGSEAction(element),
       },
       content: [
-        ...renderGseSmvAddress(element),
+        ...contentGseWizard({ hasInstType, attributes }),
         html`<wizard-textfield
           label="MinTime"
           .maybeValue=${minTime}

--- a/src/wizards/gsecontrol.ts
+++ b/src/wizards/gsecontrol.ts
@@ -55,7 +55,7 @@ export function getGSE(element: Element): Element | null | undefined {
     );
 }
 
-export function renderGseControlAttributes(
+export function contentGseControlWizard(
   content: ContentOptions
 ): TemplateResult[] {
   return [
@@ -270,7 +270,7 @@ export function editGseControlWizard(element: Element): Wizard {
       },
       menuActions,
       content: [
-        ...renderGseControlAttributes({
+        ...contentGseControlWizard({
           name,
           desc,
           type,

--- a/src/wizards/gsecontrol.ts
+++ b/src/wizards/gsecontrol.ts
@@ -244,8 +244,8 @@ export function createGseControlWizard(ln0OrLn: Element): Wizard {
   const attributes: Record<string, string | null> = {
     'MAC-Address': uniqueMacAddress(ln0OrLn.ownerDocument, 'GOOSE'),
     APPID: uniqueAppId(ln0OrLn.ownerDocument),
-    'VLAN-ID': '000',
-    'VLAN-PRIORITY': '7',
+    'VLAN-ID': null,
+    'VLAN-PRIORITY': null,
   };
   const minTime = '10';
   const maxTime = '1000';
@@ -352,7 +352,7 @@ function openGseControlCreateWizard(doc: XMLDocument): WizardActor {
 export function gseControlParentSelector(doc: XMLDocument): Wizard {
   return [
     {
-      title: get('report.wizard.location'),
+      title: get('gsecontrol.wizard.location'),
       primary: {
         icon: '',
         label: get('next'),

--- a/src/wizards/gsecontrol.ts
+++ b/src/wizards/gsecontrol.ts
@@ -32,6 +32,14 @@ import { maxLength, patterns } from './foundation/limits.js';
 import { editDataSetWizard } from './dataset.js';
 import { editGseWizard } from './gse.js';
 import { securityEnableEnum } from './foundation/enums.js';
+interface ContentOptions {
+  name: string | null;
+  desc: string | null;
+  type: string | null;
+  appID: string | null;
+  fixedOffs: string | null;
+  securityEnabled: string | null;
+}
 
 export function getGSE(element: Element): Element | null | undefined {
   const cbName = element.getAttribute('name');
@@ -47,18 +55,13 @@ export function getGSE(element: Element): Element | null | undefined {
     );
 }
 
-export function renderGseAttributes(
-  name: string | null,
-  desc: string | null,
-  type: string | null,
-  appID: string | null,
-  fixedOffs: string | null,
-  securityEnabled: string | null
+export function renderGseControlAttributes(
+  content: ContentOptions
 ): TemplateResult[] {
   return [
     html`<wizard-textfield
       label="name"
-      .maybeValue=${name}
+      .maybeValue=${content.name}
       helper="${translate('scl.name')}"
       required
       validationMessage="${translate('textfield.required')}"
@@ -68,13 +71,13 @@ export function renderGseAttributes(
     ></wizard-textfield>`,
     html`<wizard-textfield
       label="desc"
-      .maybeValue=${desc}
+      .maybeValue=${content.desc}
       nullable
       helper="${translate('scl.desc')}"
     ></wizard-textfield>`,
     html`<wizard-select
       label="type"
-      .maybeValue=${type}
+      .maybeValue=${content.type}
       helper="${translate('scl.type')}"
       nullable
       required
@@ -84,20 +87,20 @@ export function renderGseAttributes(
     >`,
     html`<wizard-textfield
       label="appID"
-      .maybeValue=${appID}
+      .maybeValue=${content.appID}
       helper="${translate('scl.id')}"
       required
       validationMessage="${translate('textfield.nonempty')}"
     ></wizard-textfield>`,
     html`<wizard-checkbox
       label="fixedOffs"
-      .maybeValue=${fixedOffs}
+      .maybeValue=${content.fixedOffs}
       nullable
       helper="${translate('scl.fixedOffs')}"
     ></wizard-checkbox>`,
     html`<wizard-select
       label="securityEnabled"
-      .maybeValue=${securityEnabled}
+      .maybeValue=${content.securityEnabled}
       nullable
       required
       helper="${translate('scl.securityEnable')}"
@@ -267,14 +270,14 @@ export function editGseControlWizard(element: Element): Wizard {
       },
       menuActions,
       content: [
-        ...renderGseAttributes(
+        ...renderGseControlAttributes({
           name,
           desc,
           type,
           appID,
           fixedOffs,
-          securityEnabled
-        ),
+          securityEnabled,
+        }),
       ],
     },
   ];

--- a/src/wizards/gsecontrol.ts
+++ b/src/wizards/gsecontrol.ts
@@ -306,6 +306,18 @@ export function createGseControlWizard(ln0OrLn: Element): Wizard {
           }),
         },
         {
+          title: get('wizard.title.add', { tagName: 'GSE' }),
+          content: [
+            html`<h3
+              style="color: var(--mdc-theme-on-surface);
+                      font-family: 'Roboto', sans-serif;
+                      font-weight: 300;"
+            >
+              ${translate('gse.missingaccp')}
+            </h3>`,
+          ],
+        },
+        {
           title: get('dataset.fcda.add'),
           primary: {
             icon: 'save',

--- a/src/wizards/smv.ts
+++ b/src/wizards/smv.ts
@@ -10,7 +10,7 @@ import {
   WizardActor,
   WizardInputElement,
 } from '../foundation.js';
-import { renderGseSmvAddress, updateAddress } from './address.js';
+import { contentGseWizard, updateAddress } from './address.js';
 
 export function updateSmvAction(element: Element): WizardActor {
   return (inputs: WizardInputElement[], wizard: Element): WizardAction[] => {
@@ -36,6 +36,18 @@ export function updateSmvAction(element: Element): WizardActor {
 }
 
 export function editSMvWizard(element: Element): Wizard {
+  const hasInstType = Array.from(element.querySelectorAll('Address > P')).some(
+    pType => pType.getAttribute('xsi:type')
+  );
+
+  const attributes: Record<string, string | null> = {};
+
+  ['MAC-Address', 'APPID', 'VLAN-ID', 'VLAN-PRIORITY'].forEach(key => {
+    if (!attributes[key])
+      attributes[key] =
+        element.querySelector(`Address > P[type="${key}"]`)?.innerHTML.trim() ??
+        null;
+  });
   return [
     {
       title: get('wizard.title.edit', { tagName: element.tagName }),
@@ -45,7 +57,7 @@ export function editSMvWizard(element: Element): Wizard {
         icon: 'edit',
         action: updateSmvAction(element),
       },
-      content: [...renderGseSmvAddress(element)],
+      content: [...contentGseWizard({ hasInstType, attributes })],
     },
   ];
 }

--- a/src/wizards/smv.ts
+++ b/src/wizards/smv.ts
@@ -4,6 +4,7 @@ import { Checkbox } from '@material/mwc-checkbox';
 
 import {
   ComplexAction,
+  getValue,
   identity,
   Wizard,
   WizardAction,
@@ -24,7 +25,20 @@ export function updateSmvAction(element: Element): WizardActor {
     const instType: boolean = (<Checkbox>(
       wizard.shadowRoot?.querySelector('#instType')
     ))?.checked;
-    const addressActions = updateAddress(element, inputs, instType);
+
+    const addressContent: Record<string, string | null> = {};
+    addressContent['MAC-Address'] = getValue(
+      inputs.find(i => i.label === 'MAC-Address')!
+    );
+    addressContent['APPID'] = getValue(inputs.find(i => i.label === 'APPID')!);
+    addressContent['VLAN-ID'] = getValue(
+      inputs.find(i => i.label === 'VLAN-ID')!
+    );
+    addressContent['VLAN-PRIORITY'] = getValue(
+      inputs.find(i => i.label === 'VLAN-PRIORITY')!
+    );
+
+    const addressActions = updateAddress(element, addressContent, instType);
     if (!addressActions.length) return [];
 
     addressActions.forEach(action => {

--- a/test/testfiles/wizards/gsecontrol.scd
+++ b/test/testfiles/wizards/gsecontrol.scd
@@ -372,4 +372,319 @@
 		<AccessPoint name="P2">
 		</AccessPoint>
 	</IED>
+	<IED name="IED4" type="DummyIED" manufacturer="DummyManufactorer" configVersion="1" originalSclVersion="2007" originalSclRevision="B" owner="DummyOwner">
+		<Services>
+			<DynAssociation />
+			<GetDirectory />
+			<GetDataObjectDefinition />
+			<DataObjectDirectory />
+			<GetDataSetValue />
+			<SetDataSetValue />
+			<DataSetDirectory />
+			<ConfDataSet modify="false" max="3" />
+			<DynDataSet max="42" />
+			<ReadWrite />
+			<ConfReportControl bufConf="false" max="10"/>
+			<GetCBValues />
+			<ReportSettings rptID="Dyn" optFields="Dyn" bufTime="Dyn" trgOps="Dyn" intgPd="Dyn" resvTms="true" owner="true" />
+			<GOOSE max="1" />
+			<GSSE max="0" />
+			<ConfLNs fixPrefix="true" fixLnInst="true" />
+		</Services>
+		<AccessPoint name="P1">
+			<Server>
+				<Authentication none="true" />
+				<LDevice inst="MU01">
+					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0.two">
+					<DataSet name="PhsMeas1">
+                            <FCDA ldInst="MU01" prefix="I01A" lnClass="TCTR" lnInst="1" doName="Amp" daName="instMag.i" fc="MX"/>
+                            <FCDA ldInst="MU01" prefix="I01A" lnClass="TCTR" lnInst="1" doName="Amp" daName="q" fc="MX"/>
+                            <FCDA ldInst="MU01" prefix="I01B" lnClass="TCTR" lnInst="2" doName="Amp" daName="instMag.i" fc="MX"/>
+                            <FCDA ldInst="MU01" prefix="I01B" lnClass="TCTR" lnInst="2" doName="Amp" daName="q" fc="MX"/>
+                            <FCDA ldInst="MU01" prefix="I01C" lnClass="TCTR" lnInst="3" doName="Amp" daName="instMag.i" fc="MX"/>
+                            <FCDA ldInst="MU01" prefix="I01C" lnClass="TCTR" lnInst="3" doName="Amp" daName="q" fc="MX"/>
+                            <FCDA ldInst="MU01" prefix="I01N" lnClass="TCTR" lnInst="4" doName="Amp" daName="instMag.i" fc="MX"/>
+                            <FCDA ldInst="MU01" prefix="I01N" lnClass="TCTR" lnInst="4" doName="Amp" daName="q" fc="MX"/>
+                            <FCDA ldInst="MU01" prefix="U01A" lnClass="TVTR" lnInst="1" doName="Vol" daName="instMag.i" fc="MX"/>
+                            <FCDA ldInst="MU01" prefix="U01A" lnClass="TVTR" lnInst="1" doName="Vol" daName="q" fc="MX"/>
+                            <FCDA ldInst="MU01" prefix="U01B" lnClass="TVTR" lnInst="2" doName="Vol" daName="instMag.i" fc="MX"/>
+                            <FCDA ldInst="MU01" prefix="U01B" lnClass="TVTR" lnInst="2" doName="Vol" daName="q" fc="MX"/>
+                            <FCDA ldInst="MU01" prefix="U01C" lnClass="TVTR" lnInst="3" doName="Vol" daName="instMag.i" fc="MX"/>
+                            <FCDA ldInst="MU01" prefix="U01C" lnClass="TVTR" lnInst="3" doName="Vol" daName="q" fc="MX"/>
+                            <FCDA ldInst="MU01" prefix="U01N" lnClass="TVTR" lnInst="4" doName="Vol" daName="instMag.i" fc="MX"/>
+                            <FCDA ldInst="MU01" prefix="U01N" lnClass="TVTR" lnInst="4" doName="Vol" daName="q" fc="MX"/>
+                        </DataSet>
+					<SampledValueControl smvID="IED3_SMVID" multicast="true" smpRate="80" nofASDU="1" confRev="1" name="MSVCB01" datSet="PhsMeas1">
+						<SmvOpts/>
+					</SampledValueControl>
+					</LN0>
+                    <LN prefix="I01A" lnClass="TCTR" inst="1" lnType="DummyTCTR" />
+                    <LN prefix="I01B" lnClass="TCTR" inst="2" lnType="DummyTCTR" />
+                    <LN prefix="I01C" lnClass="TCTR" inst="3" lnType="DummyTCTR" />
+                    <LN prefix="I01N" lnClass="TCTR" inst="4" lnType="DummyTCTR" />
+                    <LN prefix="U01A" lnClass="TVTR" inst="1" lnType="DummyTVTR" />
+                    <LN prefix="U01B" lnClass="TVTR" inst="2" lnType="DummyTVTR" />
+                    <LN prefix="U01C" lnClass="TVTR" inst="3" lnType="DummyTVTR" />
+                    <LN prefix="U01N" lnClass="TVTR" inst="4" lnType="DummyTVTR" />
+				</LDevice>
+			</Server>
+		</AccessPoint>
+		<AccessPoint name="P2">
+		</AccessPoint>
+	</IED>
+	<DataTypeTemplates>
+		<LNodeType lnClass="LLN0" id="Dummy.LLN0">
+    		<DO name="Mod" type="Dummy.LLN0.Mod" />
+    		<DO name="Beh" type="Dummy.LLN0.Beh" />
+    		<DO name="Health" type="Dummy.LLN0.Health" />
+    		<DO name="NamPlt" type="Dummy.LLN0.NamPlt" />
+    	</LNodeType>
+    	<LNodeType lnClass="LLN0" id="Dummy.LLN0.two">
+    		<DO name="Mod" type="Dummy.LLN0.Mod" />
+    		<DO name="Beh" type="Dummy.LLN0.Beh" />
+    		<DO name="Health" type="Dummy.LLN0.Health" />
+    		<DO name="NamPlt" type="Dummy.LLN0.NamPlt" />
+    	</LNodeType>
+    	<LNodeType lnClass="LPHD" id="Dummy.LPHD1">
+    		<DO name="PhyNam" type="Dummy.LPHD1.PhyNam" />
+    		<DO name="PhyHealth" type="Dummy.LLN0.Health" />
+    		<DO name="Proxy" type="Dummy.SPS" />
+    		<DO name="Sim" type="Dummy.LPHD1.Sim" />
+    	</LNodeType>
+    	<LNodeType lnClass="XCBR" id="Dummy.XCBR1">
+    		<DO name="Beh" type="Dummy.LLN0.Beh" />
+    		<DO name="NamPlt" type="Dummy.XCBR1.NamPlt" />
+    		<DO name="Loc" type="Dummy.SPS" />
+    		<DO name="OpCnt" type="Dummy.XCBR1.OpCnt" />
+    		<DO name="Pos" type="Dummy.XCBR1.Pos" />
+    		<DO name="BlkOpn" type="Dummy.XCBR1.BlkOpn" />
+    		<DO name="BlkCls" type="Dummy.XCBR1.BlkOpn" />
+    	</LNodeType>
+    	<LNodeType lnClass="CSWI" id="Dummy.CSWI">
+    		<DO name="Beh" type="Dummy.LLN0.Beh" />
+    		<DO name="NamPlt" type="Dummy.XCBR1.NamPlt" />
+    		<DO name="Loc" type="Dummy.SPS" />
+    		<DO name="OpCnt" type="Dummy.XCBR1.OpCnt" />
+    		<DO name="Pos" type="Dummy.CSWI.Pos1" />
+    	</LNodeType>
+    	<LNodeType lnClass="CILO" id="Dummy.CILO">
+    		<DO name="Beh" type="Dummy.LLN0.Beh" />
+    		<DO name="NamPlt" type="Dummy.XCBR1.NamPlt" />
+    		<DO name="EnaOpn" type="Dummy.SPS"/>
+            <DO name="EnaCls" type="Dummy.SPS"/>
+    	</LNodeType>
+    	<LNodeType lnClass="CSWI" id="Dummy.CSWIwithoutCtlModel">
+    		<DO name="Beh" type="Dummy.LLN0.Beh" />
+    		<DO name="NamPlt" type="Dummy.XCBR1.NamPlt" />
+    		<DO name="Loc" type="Dummy.SPS" />
+    		<DO name="OpCnt" type="Dummy.XCBR1.OpCnt" />
+    		<DO name="Pos" type="Dummy.CSWI.Pos2" />
+    	</LNodeType>
+    	<LNodeType lnClass="XSWI" id="Dummy.XSWI1">
+    		<DO name="Beh" type="Dummy.LLN0.Beh" />
+    		<DO name="NamPlt" type="Dummy.XCBR1.NamPlt" />
+    		<DO name="Loc" type="Dummy.SPS" />
+    		<DO name="OpCnt" type="Dummy.XCBR1.OpCnt" />
+    		<DO name="Pos" type="Dummy.XCBR1.Pos" />
+    		<DO name="BlkOpn" type="Dummy.XCBR1.BlkOpn" />
+    		<DO name="BlkCls" type="Dummy.XCBR1.BlkOpn" />
+    	</LNodeType>
+    	<LNodeType lnClass="GGIO" id="Dummy.GGIO1">
+    		<DO name="Beh" type="Dummy.LLN0.Beh" />
+    		<DO name="NamPlt" type="Dummy.XCBR1.NamPlt" />
+    		<DO name="Ind1" type="Dummy.SPS" />
+    		<DO name="SPCSO1" type="Dummy.LPHD1.Sim" />
+    	</LNodeType>
+    	<LNodeType lnClass="TCTR" id="DummyTCTR">
+            <DO name="Mod" type="Dummy.LLN0.Mod"/>
+            <DO name="Beh" type="Dummy.LLN0.Beh"/>
+            <DO name="NamPlt" type="Dummy.XCBR1.NamPlt"/>
+            <DO name="Amp" type="DummySAV"/>
+        </LNodeType>
+    	<LNodeType lnClass="TVTR" id="DummyTVTR">
+            <DO name="Mod" type="Dummy.LLN0.Mod"/>
+            <DO name="Beh" type="Dummy.LLN0.Beh"/>
+            <DO name="NamPlt" type="Dummy.XCBR1.NamPlt"/>
+            <DO name="Vol" type="DummySAV"/>
+        </LNodeType>
+    	<DOType cdc="SAV" id="DummySAV">
+            <DA fc="MX" name="instMag" bType="Struct" type="AnalogueValue_i"/>
+            <DA fc="MX" qchg="true" name="q" bType="Quality"/>
+            <DA fc="CF" name="sVC" bType="Struct" type="ScaledValueConfig"/>
+        </DOType>
+    	<DOType cdc="ENC" id="Dummy.LLN0.Mod">
+    		<DA fc="ST" name="stVal" bType="Enum" type="Dummy_Beh" />
+    		<DA fc="ST" name="q" bType="Quality" />
+    		<DA fc="ST" name="t" bType="Timestamp" />
+    		<DA fc="ST" name="stSeld" bType="BOOLEAN" />
+    		<DA fc="OR" name="opRcvd" bType="BOOLEAN" />
+    		<DA fc="OR" name="opOk" bType="BOOLEAN" />
+    		<DA fc="OR" name="tOpOk" bType="Timestamp" />
+    		<DA fc="CF" name="ctlModel" bType="Enum" type="Dummy_ctlModel" />
+    		<DA fc="CF" name="sboTimeout" bType="INT32U" />
+    		<DA fc="CF" name="operTimeout" bType="INT32U" />
+    		<DA fc="CO" name="SBO" bType="ObjRef" />
+    		<DA fc="CO" name="SBOw" bType="Struct" type="Dummy.LLN0.Mod.SBOw" />
+    		<DA fc="CO" name="Oper" bType="Struct" type="Dummy.LLN0.Mod.SBOw" />
+    		<DA fc="CO" name="Cancel" bType="Struct" type="Dummy.LLN0.Mod.Cancel" />
+    	</DOType>
+    	<DOType cdc="ENS" id="Dummy.LLN0.Beh">
+    		<DA fc="ST" name="stVal" bType="Enum" type="Dummy_Beh" />
+    		<DA fc="ST" name="q" bType="Quality" />
+    		<DA fc="ST" name="t" bType="Timestamp" />
+    	</DOType>
+    	<DOType cdc="ENS" id="Dummy.LLN0.Health">
+    		<DA fc="ST" name="stVal" bType="Enum" type="Dummy_Health" />
+    		<DA fc="ST" name="q" bType="Quality" />
+    		<DA fc="ST" name="t" bType="Timestamp" />
+    	</DOType>
+    	<DOType cdc="LPL" id="Dummy.LLN0.NamPlt">
+    		<DA fc="DC" name="vendor" bType="VisString255" />
+    		<DA fc="DC" name="swRev" bType="VisString255" />
+    		<DA fc="DC" name="d" bType="VisString255" />
+    		<DA fc="DC" name="configRev" bType="VisString255" />
+    		<DA fc="EX" name="ldNs" bType="VisString255" />
+    	</DOType>
+    	<DOType cdc="DPL" id="Dummy.LPHD1.PhyNam">
+    		<DA fc="DC" name="vendor" bType="VisString255" />
+    		<DA fc="DC" name="hwRev" bType="VisString255" />
+    		<DA fc="DC" name="swRev" bType="VisString255" />
+    		<DA fc="DC" name="serNum" bType="VisString255" />
+    		<DA fc="DC" name="model" bType="VisString255" />
+    	</DOType>
+    	<DOType cdc="SPC" id="Dummy.LPHD1.Sim">
+    		<DA fc="ST" name="stVal" bType="BOOLEAN" />
+    		<DA fc="ST" name="q" bType="Quality" />
+    		<DA fc="ST" name="t" bType="Timestamp" />
+    		<DA fc="ST" name="stSeld" bType="BOOLEAN" />
+    		<DA fc="OR" name="opRcvd" bType="BOOLEAN" />
+    		<DA fc="OR" name="opOk" bType="BOOLEAN" />
+    		<DA fc="OR" name="tOpOk" bType="Timestamp" />
+    		<DA fc="CF" name="ctlModel" bType="Enum" type="Dummy_ctlModel" />
+    		<DA fc="CF" name="sboTimeout" bType="INT32U" />
+    		<DA fc="CF" name="operTimeout" bType="INT32U" />
+    		<DA fc="DC" name="d" bType="VisString255" />
+    		<DA fc="CO" name="SBO" bType="ObjRef" />
+    		<DA fc="CO" name="SBOw" bType="Struct" type="Dummy.LPHD1.Sim.SBOw" />
+    		<DA fc="CO" name="Oper" bType="Struct" type="Dummy.LPHD1.Sim.SBOw" />
+    		<DA fc="CO" name="Cancel" bType="Struct" type="Dummy.LPHD1.Sim.Cancel" />
+    	</DOType>
+    	<DOType cdc="DPC" id="Dummy.XCBR1.Pos">
+    		<DA fc="ST" name="stVal" bType="Dbpos" />
+    		<DA fc="ST" name="q" bType="Quality" />
+    		<DA fc="ST" name="t" bType="Timestamp" />
+    		<DA fc="CF" name="ctlModel" bType="Enum" type="Dummy_ctlModel" />
+    		<DA fc="DC" name="d" bType="VisString255" />
+    	</DOType>
+    	<DOType cdc="DPC" id="Dummy.CSWI.Pos1">
+    		<DA fc="ST" name="stVal" bType="Dbpos" />
+    		<DA fc="ST" name="q" bType="Quality" />
+    		<DA fc="ST" name="t" bType="Timestamp" />
+    		<DA fc="CF" name="ctlModel" bType="Enum" type="Dummy_ctlModel">
+    			<Val>sbo-with-enhanced-security</Val>
+    		</DA>
+    		<DA fc="DC" name="d" bType="VisString255" />
+    	</DOType>
+    	<DOType cdc="DPC" id="Dummy.CSWI.Pos2">
+    		<DA fc="ST" name="stVal" bType="Dbpos" />
+    		<DA fc="ST" name="q" bType="Quality" />
+    		<DA fc="ST" name="t" bType="Timestamp" />
+    		<DA fc="CF" name="ctlModel" bType="Enum" type="Dummy_ctlModel"/>
+    		<DA fc="DC" name="d" bType="VisString255" />
+    	</DOType>
+    	<DOType cdc="INS" id="Dummy.XCBR1.OpCnt">
+    		<DA fc="ST" name="stVal" bType="INT32" />
+    		<DA fc="ST" name="q" bType="Quality" />
+    		<DA fc="ST" name="t" bType="Timestamp" />
+    	</DOType>
+    	<DOType cdc="LPL" id="Dummy.XCBR1.NamPlt">
+    		<DA fc="DC" name="vendor" bType="VisString255" />
+    		<DA fc="DC" name="swRev" bType="VisString255" />
+    		<DA fc="DC" name="d" bType="VisString255" />
+    	</DOType>
+    	<DOType cdc="SPC" id="Dummy.XCBR1.BlkOpn">
+    		<DA fc="ST" name="stVal" bType="BOOLEAN" />
+    		<DA fc="ST" name="q" bType="Quality" />
+    		<DA fc="ST" name="t" bType="Timestamp" />
+    		<DA fc="CF" name="ctlModel" bType="Enum" type="Dummy_ctlModel" />
+    		<DA fc="DC" name="d" bType="VisString255" />
+    	</DOType>
+    	<DOType cdc="SPS" id="Dummy.SPS">
+            <DA fc="ST" dchg="true" name="stVal" bType="BOOLEAN"/>
+            <DA fc="ST" qchg="true" name="q" bType="Quality"/>
+            <DA fc="ST" name="t" bType="Timestamp"/>
+        </DOType>
+    	<DAType id="AnalogueValue_i">
+            <BDA name="i" bType="INT32"/>
+        </DAType>
+    	<DAType id="ScaledValueConfig">
+            <BDA name="scaleFactor" bType="FLOAT32"/>
+            <BDA name="offset" bType="FLOAT32"/>
+        </DAType>
+    	<DAType id="Dummy_origin">
+    		<BDA name="orCat" bType="Enum" type="Dummy_orCategory" />
+    		<BDA name="orIdent" bType="Octet64" />
+    	</DAType>
+    	<DAType id="Dummy.LLN0.Mod.SBOw">
+    		<BDA name="ctlVal" bType="Enum" type="Dummy_Beh" />
+    		<BDA name="origin" bType="Struct" type="Dummy_origin" />
+    		<BDA name="ctlNum" bType="INT8U" />
+    		<BDA name="T" bType="Timestamp" />
+    		<BDA name="Test" bType="BOOLEAN" />
+    		<BDA name="Check" bType="Check" />
+    		<ProtNs>IEC 61850-8-1:2003</ProtNs>
+    	</DAType>
+    	<DAType id="Dummy.LLN0.Mod.Cancel">
+    		<BDA name="ctlVal" bType="Enum" type="Dummy_Beh" />
+    		<BDA name="origin" bType="Struct" type="Dummy_origin" />
+    		<BDA name="ctlNum" bType="INT8U" />
+    		<BDA name="T" bType="Timestamp" />
+    		<BDA name="Test" bType="BOOLEAN" />
+    	</DAType>
+    	<DAType id="Dummy.LPHD1.Sim.SBOw">
+    		<BDA name="ctlVal" bType="BOOLEAN" />
+    		<BDA name="origin" bType="Struct" type="Dummy_origin" />
+    		<BDA name="ctlNum" bType="INT8U" />
+    		<BDA name="T" bType="Timestamp" />
+    		<BDA name="Test" bType="BOOLEAN" />
+    		<BDA name="Check" bType="Check" />
+    	</DAType>
+    	<DAType id="Dummy.LPHD1.Sim.Cancel">
+    		<BDA name="ctlVal" bType="BOOLEAN" />
+    		<BDA name="origin" bType="Struct" type="Dummy_origin" />
+    		<BDA name="ctlNum" bType="INT8U" />
+    		<BDA name="T" bType="Timestamp" />
+    		<BDA name="Test" bType="BOOLEAN" />
+    	</DAType>
+    	<EnumType id="Dummy_ctlModel">
+    		<EnumVal ord="0">status-only</EnumVal>
+    		<EnumVal ord="1">direct-with-normal-security</EnumVal>
+    		<EnumVal ord="2">sbo-with-normal-security</EnumVal>
+    		<EnumVal ord="3">direct-with-enhanced-security</EnumVal>
+    		<EnumVal ord="4">sbo-with-enhanced-security</EnumVal>
+    	</EnumType>
+    	<EnumType id="Dummy_Beh">
+            <EnumVal ord="1">on</EnumVal>
+            <EnumVal ord="2">blocked</EnumVal>
+            <EnumVal ord="3">test</EnumVal>
+            <EnumVal ord="4">test/blocked</EnumVal>
+            <EnumVal ord="5">off</EnumVal>
+        </EnumType>
+    	<EnumType id="Dummy_Health">
+    		<EnumVal ord="1">Ok</EnumVal>
+    		<EnumVal ord="2">Warning</EnumVal>
+    		<EnumVal ord="3">Alarm</EnumVal>
+    	</EnumType>
+    	<EnumType id="Dummy_orCategory">
+    		<EnumVal ord="0">not-supported</EnumVal>
+    		<EnumVal ord="1">bay-control</EnumVal>
+    		<EnumVal ord="2">station-control</EnumVal>
+    		<EnumVal ord="3">remote-control</EnumVal>
+    		<EnumVal ord="4">automatic-bay</EnumVal>
+    		<EnumVal ord="5">automatic-station</EnumVal>
+    		<EnumVal ord="6">automatic-remote</EnumVal>
+    		<EnumVal ord="7">maintenance</EnumVal>
+    		<EnumVal ord="8">process</EnumVal>
+    	</EnumType>
+    </DataTypeTemplates>
 </SCL>

--- a/test/unit/wizards/__snapshots__/gsecontrol.test.snap.js
+++ b/test/unit/wizards/__snapshots__/gsecontrol.test.snap.js
@@ -329,3 +329,264 @@ snapshots["gsecontrol wizards editGseControlWizard looks like the latest snapsho
 `;
 /* end snapshot gsecontrol wizards editGseControlWizard looks like the latest snapshot */
 
+snapshots["gsecontrol wizards define an create wizard that with existing ConnectedAP element in the Communication section the first page looks like the latest snapshot"] = 
+`<mwc-dialog
+  defaultaction="close"
+  heading="[wizard.title.add]"
+  open=""
+>
+  <div id="wizard-content">
+    <wizard-textfield
+      dialoginitialfocus=""
+      helper="[scl.name]"
+      label="name"
+      maxlength="32"
+      pattern="[A-Za-z][0-9,A-Z,a-z_]*"
+      required=""
+      validationmessage="[textfield.required]"
+    >
+    </wizard-textfield>
+    <wizard-textfield
+      disabled=""
+      helper="[scl.desc]"
+      label="desc"
+      nullable=""
+    >
+    </wizard-textfield>
+    <wizard-select
+      helper="[scl.type]"
+      label="type"
+      nullable=""
+      required=""
+    >
+      <mwc-list-item
+        aria-disabled="false"
+        mwc-list-item=""
+        role="option"
+        tabindex="-1"
+        value="GOOSE"
+      >
+        GOOSE
+      </mwc-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        mwc-list-item=""
+        role="option"
+        tabindex="-1"
+        value="GSSE"
+      >
+        GSSE
+      </mwc-list-item>
+    </wizard-select>
+    <wizard-textfield
+      helper="[scl.id]"
+      label="appID"
+      required=""
+      validationmessage="[textfield.nonempty]"
+    >
+    </wizard-textfield>
+    <wizard-checkbox
+      helper="[scl.fixedOffs]"
+      label="fixedOffs"
+      nullable=""
+    >
+    </wizard-checkbox>
+    <wizard-select
+      disabled=""
+      helper="[scl.securityEnable]"
+      label="securityEnabled"
+      nullable=""
+      required=""
+    >
+      <mwc-list-item
+        aria-disabled="false"
+        mwc-list-item=""
+        role="option"
+        tabindex="-1"
+        value="None"
+      >
+        None
+      </mwc-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        mwc-list-item=""
+        role="option"
+        tabindex="-1"
+        value="Signature"
+      >
+        Signature
+      </mwc-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        mwc-list-item=""
+        role="option"
+        tabindex="-1"
+        value="SignatureAndEncryption"
+      >
+        SignatureAndEncryption
+      </mwc-list-item>
+    </wizard-select>
+  </div>
+  <mwc-button
+    dialogaction="close"
+    label="[cancel]"
+    slot="secondaryAction"
+    style="--mdc-theme-primary: var(--mdc-theme-error)"
+  >
+  </mwc-button>
+  <mwc-button
+    dialogaction="next"
+    icon="navigate_next"
+    label="[wizard.title.add]"
+    slot="primaryAction"
+    trailingicon=""
+  >
+  </mwc-button>
+</mwc-dialog>
+`;
+/* end snapshot gsecontrol wizards define an create wizard that with existing ConnectedAP element in the Communication section the first page looks like the latest snapshot */
+
+snapshots["gsecontrol wizards define an create wizard that with existing ConnectedAP element in the Communication section the second page looks like the latest snapshot"] = 
+`<mwc-dialog
+  defaultaction="close"
+  heading="[wizard.title.add]"
+>
+  <div id="wizard-content">
+    <mwc-formfield label="[connectedap.wizard.addschemainsttype]">
+      <mwc-checkbox
+        checked=""
+        id="instType"
+      >
+      </mwc-checkbox>
+    </mwc-formfield>
+    <wizard-textfield
+      label="MAC-Address"
+      pattern="([0-9A-F]{2}-){5}[0-9A-F]{2}"
+      required=""
+    >
+    </wizard-textfield>
+    <wizard-textfield
+      label="APPID"
+      pattern="[0-9A-F]{4}"
+      required=""
+    >
+    </wizard-textfield>
+    <wizard-textfield
+      label="VLAN-ID"
+      nullable=""
+      pattern="[0-9A-F]{3}"
+      required=""
+    >
+    </wizard-textfield>
+    <wizard-textfield
+      label="VLAN-PRIORITY"
+      nullable=""
+      pattern="[0-7]"
+      required=""
+    >
+    </wizard-textfield>
+    <wizard-textfield
+      label="MinTime"
+      nullable=""
+      suffix="ms"
+      type="number"
+    >
+    </wizard-textfield>
+    <wizard-textfield
+      label="MaxTime"
+      nullable=""
+      suffix="ms"
+      type="number"
+    >
+    </wizard-textfield>
+  </div>
+  <mwc-button
+    dialogaction="prev"
+    icon="navigate_before"
+    label="[wizard.title.add]"
+    slot="secondaryAction"
+  >
+  </mwc-button>
+  <mwc-button
+    dialogaction="close"
+    label="[cancel]"
+    slot="secondaryAction"
+    style="--mdc-theme-primary: var(--mdc-theme-error)"
+  >
+  </mwc-button>
+  <mwc-button
+    dialogaction="next"
+    icon="navigate_next"
+    label="[dataset.fcda.add]"
+    slot="primaryAction"
+    trailingicon=""
+  >
+  </mwc-button>
+</mwc-dialog>
+`;
+/* end snapshot gsecontrol wizards define an create wizard that with existing ConnectedAP element in the Communication section the second page looks like the latest snapshot */
+
+snapshots["gsecontrol wizards define an create wizard that with existing ConnectedAP element in the Communication section the third page looks like the latest snapshot"] = 
+`<mwc-dialog
+  defaultaction="close"
+  heading="[dataset.fcda.add]"
+>
+  <div id="wizard-content">
+    <finder-list multi="">
+    </finder-list>
+  </div>
+  <mwc-button
+    dialogaction="prev"
+    icon="navigate_before"
+    label="[wizard.title.add]"
+    slot="secondaryAction"
+  >
+  </mwc-button>
+  <mwc-button
+    dialogaction="close"
+    label="[cancel]"
+    slot="secondaryAction"
+    style="--mdc-theme-primary: var(--mdc-theme-error)"
+  >
+  </mwc-button>
+  <mwc-button
+    dialoginitialfocus=""
+    icon="save"
+    label="[save]"
+    slot="primaryAction"
+    trailingicon=""
+  >
+  </mwc-button>
+</mwc-dialog>
+`;
+/* end snapshot gsecontrol wizards define an create wizard that with existing ConnectedAP element in the Communication section the third page looks like the latest snapshot */
+
+snapshots["gsecontrol wizards define a wizard to select the control block reference looks like the latest snapshot"] = 
+`<mwc-dialog
+  defaultaction="close"
+  heading="[report.wizard.location]"
+  open=""
+>
+  <div id="wizard-content">
+    <finder-list path="[&quot;SCL: &quot;]">
+    </finder-list>
+  </div>
+  <mwc-button
+    dialogaction="close"
+    label="[cancel]"
+    slot="secondaryAction"
+    style="--mdc-theme-primary: var(--mdc-theme-error)"
+  >
+  </mwc-button>
+  <mwc-button
+    dialoginitialfocus=""
+    icon=""
+    label="[next]"
+    slot="primaryAction"
+    trailingicon=""
+  >
+  </mwc-button>
+</mwc-dialog>
+`;
+/* end snapshot gsecontrol wizards define a wizard to select the control block reference looks like the latest snapshot */
+

--- a/test/unit/wizards/__snapshots__/gsecontrol.test.snap.js
+++ b/test/unit/wizards/__snapshots__/gsecontrol.test.snap.js
@@ -60,6 +60,14 @@ snapshots["gsecontrol wizards selectGseControlWizard looks like the latest snaps
     style="--mdc-theme-primary: var(--mdc-theme-error)"
   >
   </mwc-button>
+  <mwc-button
+    dialoginitialfocus=""
+    icon="add"
+    label="[GOOSE]"
+    slot="primaryAction"
+    trailingicon=""
+  >
+  </mwc-button>
 </mwc-dialog>
 `;
 /* end snapshot gsecontrol wizards selectGseControlWizard looks like the latest snapshot */

--- a/test/unit/wizards/__snapshots__/gsecontrol.test.snap.js
+++ b/test/unit/wizards/__snapshots__/gsecontrol.test.snap.js
@@ -569,6 +569,44 @@ snapshots["gsecontrol wizards define an create wizard that with existing Connect
 `;
 /* end snapshot gsecontrol wizards define an create wizard that with existing ConnectedAP element in the Communication section the third page looks like the latest snapshot */
 
+snapshots["gsecontrol wizards define an create wizard that with missing ConnectedAP element in the Communication section the second page having a warning message "] = 
+`<mwc-dialog
+  defaultaction="close"
+  heading="[wizard.title.add]"
+>
+  <div id="wizard-content">
+    <h3 style="color: var(--mdc-theme-on-surface);
+                      font-family: 'Roboto', sans-serif;
+                      font-weight: 300;">
+      [gse.missingaccp]
+    </h3>
+  </div>
+  <mwc-button
+    dialogaction="prev"
+    icon="navigate_before"
+    label="[wizard.title.add]"
+    slot="secondaryAction"
+  >
+  </mwc-button>
+  <mwc-button
+    dialogaction="close"
+    label="[cancel]"
+    slot="secondaryAction"
+    style="--mdc-theme-primary: var(--mdc-theme-error)"
+  >
+  </mwc-button>
+  <mwc-button
+    dialogaction="next"
+    icon="navigate_next"
+    label="[dataset.fcda.add]"
+    slot="primaryAction"
+    trailingicon=""
+  >
+  </mwc-button>
+</mwc-dialog>
+`;
+/* end snapshot gsecontrol wizards define an create wizard that with missing ConnectedAP element in the Communication section the second page having a warning message  */
+
 snapshots["gsecontrol wizards define a wizard to select the control block reference looks like the latest snapshot"] = 
 `<mwc-dialog
   defaultaction="close"

--- a/test/unit/wizards/__snapshots__/gsecontrol.test.snap.js
+++ b/test/unit/wizards/__snapshots__/gsecontrol.test.snap.js
@@ -480,6 +480,7 @@ snapshots["gsecontrol wizards define an create wizard that with existing Connect
     >
     </wizard-textfield>
     <wizard-textfield
+      disabled=""
       label="VLAN-ID"
       nullable=""
       pattern="[0-9A-F]{3}"
@@ -487,6 +488,7 @@ snapshots["gsecontrol wizards define an create wizard that with existing Connect
     >
     </wizard-textfield>
     <wizard-textfield
+      disabled=""
       label="VLAN-PRIORITY"
       nullable=""
       pattern="[0-7]"
@@ -610,7 +612,7 @@ snapshots["gsecontrol wizards define an create wizard that with missing Connecte
 snapshots["gsecontrol wizards define a wizard to select the control block reference looks like the latest snapshot"] = 
 `<mwc-dialog
   defaultaction="close"
-  heading="[report.wizard.location]"
+  heading="[gsecontrol.wizard.location]"
   open=""
 >
   <div id="wizard-content">

--- a/test/unit/wizards/address.test.ts
+++ b/test/unit/wizards/address.test.ts
@@ -14,7 +14,7 @@ import {
   WizardInputElement,
 } from '../../../src/foundation.js';
 import {
-  renderGseSmvAddress,
+  contentGseWizard,
   updateAddress,
 } from '../../../src/wizards/address.js';
 
@@ -34,7 +34,25 @@ describe('address', () => {
       const gse = doc.querySelector(
         'GSE[ldInst="CircuitBreaker_CB1"][cbName="GCB"]'
       )!;
-      const wizard = [{ title: 'title', content: renderGseSmvAddress(gse) }];
+
+      const hasInstType = Array.from(gse.querySelectorAll('Address > P')).some(
+        pType => pType.getAttribute('xsi:type')
+      );
+
+      const attributes: Record<string, string | null> = {};
+      ['MAC-Address', 'APPID', 'VLAN-ID', 'VLAN-PRIORITY'].forEach(key => {
+        if (!attributes[key])
+          attributes[key] =
+            gse.querySelector(`Address > P[type="${key}"]`)?.innerHTML.trim() ??
+            null;
+      });
+
+      const wizard = [
+        {
+          title: 'title',
+          content: contentGseWizard({ hasInstType, attributes }),
+        },
+      ];
 
       element.workflow.push(() => wizard);
       await element.requestUpdate();
@@ -55,10 +73,23 @@ describe('address', () => {
           'GSE[ldInst="CircuitBreaker_CB1"][cbName="GCB"]'
         )!;
 
+        const hasInstType = Array.from(
+          gse.querySelectorAll('Address > P')
+        ).some(pType => pType.getAttribute('xsi:type'));
+
+        const attributes: Record<string, string | null> = {};
+        ['MAC-Address', 'APPID', 'VLAN-ID', 'VLAN-PRIORITY'].forEach(key => {
+          if (!attributes[key])
+            attributes[key] =
+              gse
+                .querySelector(`Address > P[type="${key}"]`)
+                ?.innerHTML.trim() ?? null;
+        });
+
         wizard = [
           {
             title: 'asdas',
-            content: renderGseSmvAddress(gse),
+            content: contentGseWizard({ hasInstType, attributes }),
           },
         ];
         element.workflow.push(() => wizard);
@@ -138,10 +169,23 @@ describe('address', () => {
           'GSE[ldInst="CircuitBreaker_CB1"][cbName="GCB2"]'
         )!;
 
+        const hasInstType = Array.from(
+          gse.querySelectorAll('Address > P')
+        ).some(pType => pType.getAttribute('xsi:type'));
+
+        const attributes: Record<string, string | null> = {};
+        ['MAC-Address', 'APPID', 'VLAN-ID', 'VLAN-PRIORITY'].forEach(key => {
+          if (!attributes[key])
+            attributes[key] =
+              gse
+                .querySelector(`Address > P[type="${key}"]`)
+                ?.innerHTML.trim() ?? null;
+        });
+
         wizard = [
           {
             title: 'asdas',
-            content: renderGseSmvAddress(gse),
+            content: contentGseWizard({ hasInstType, attributes }),
           },
         ];
         element.workflow.push(() => wizard);

--- a/test/unit/wizards/address.test.ts
+++ b/test/unit/wizards/address.test.ts
@@ -8,6 +8,7 @@ import { WizardTextField } from '../../../src/wizard-textfield.js';
 import {
   Create,
   Delete,
+  getValue,
   isCreate,
   isDelete,
   Wizard,
@@ -17,6 +18,25 @@ import {
   contentGseWizard,
   updateAddress,
 } from '../../../src/wizards/address.js';
+
+function addressContent(
+  inputs: WizardInputElement[]
+): Record<string, string | null> {
+  const addressContent: Record<string, string | null> = {};
+
+  addressContent['MAC-Address'] = getValue(
+    inputs.find(i => i.label === 'MAC-Address')!
+  );
+  addressContent['APPID'] = getValue(inputs.find(i => i.label === 'APPID')!);
+  addressContent['VLAN-ID'] = getValue(
+    inputs.find(i => i.label === 'VLAN-ID')!
+  );
+  addressContent['VLAN-PRIORITY'] = getValue(
+    inputs.find(i => i.label === 'VLAN-PRIORITY')!
+  );
+
+  return addressContent;
+}
 
 describe('address', () => {
   let doc: XMLDocument;
@@ -99,9 +119,10 @@ describe('address', () => {
       });
 
       it('does not update a Address element when no attribute has changed', () => {
-        const actions = updateAddress(gse, inputs, false);
+        const actions = updateAddress(gse, addressContent(inputs), false);
         expect(actions).to.be.empty;
       });
+
       it('update a Address element when at least one attribute changes', async () => {
         for (const rawInput of inputs) {
           const input =
@@ -115,7 +136,8 @@ describe('address', () => {
 
           input.value = newValue;
           await input.requestUpdate();
-          const actions = updateAddress(gse, inputs, false);
+
+          const actions = updateAddress(gse, addressContent(inputs), false);
           expect(actions.length).to.equal(2);
           expect(actions[0]).to.satisfy(isDelete);
           expect(actions[1]).to.satisfy(isCreate);
@@ -132,6 +154,7 @@ describe('address', () => {
           ).to.not.have.attribute('xsi:type', `tP_${type}`);
         }
       });
+
       it('update a Address element when status of instType has changed', async () => {
         for (const rawInput of inputs) {
           const input =
@@ -145,7 +168,8 @@ describe('address', () => {
 
           input.value = newValue;
           await input.requestUpdate();
-          const actions = updateAddress(gse, inputs, true);
+
+          const actions = updateAddress(gse, addressContent(inputs), true);
           expect(actions.length).to.equal(2);
           expect(actions[0]).to.satisfy(isDelete);
           expect(actions[1]).to.satisfy(isCreate);
@@ -163,6 +187,7 @@ describe('address', () => {
         }
       });
     });
+
     describe('with missing address element', () => {
       beforeEach(async () => {
         gse = doc.querySelector(
@@ -206,7 +231,8 @@ describe('address', () => {
 
           input.value = newValue;
           await input.requestUpdate();
-          const actions = updateAddress(gse, inputs, false);
+
+          const actions = updateAddress(gse, addressContent(inputs), false);
           expect(actions.length).to.equal(1);
           expect(actions[0]).to.satisfy(isCreate);
           const newElement = <Element>(<Create>actions[0]).new.element;
@@ -218,6 +244,7 @@ describe('address', () => {
           ).to.not.have.attribute('xsi:type', `tP_${type}`);
         }
       });
+
       it('update a Address element when status of instType has changed', async () => {
         for (const rawInput of inputs) {
           const input =
@@ -230,7 +257,7 @@ describe('address', () => {
 
           input.value = newValue;
           await input.requestUpdate();
-          const actions = updateAddress(gse, inputs, true);
+          const actions = updateAddress(gse, addressContent(inputs), true);
           expect(actions.length).to.equal(1);
           expect(actions[0]).to.satisfy(isCreate);
           const newElement = <Element>(<Create>actions[0]).new.element;

--- a/test/unit/wizards/address.test.ts
+++ b/test/unit/wizards/address.test.ts
@@ -226,9 +226,13 @@ describe('address', () => {
               ? <WizardTextField>rawInput
               : <WizardSelect>rawInput;
 
+          if (input.maybeValue === null) {
+            input.nullSwitch?.click();
+            await input.requestUpdate();
+          }
+
           const type = input.label;
           const newValue = 'newValue';
-
           input.value = newValue;
           await input.requestUpdate();
 
@@ -251,6 +255,11 @@ describe('address', () => {
             rawInput instanceof WizardTextField
               ? <WizardTextField>rawInput
               : <WizardSelect>rawInput;
+
+          if (input.maybeValue === null) {
+            input.nullSwitch?.click();
+            await input.requestUpdate();
+          }
 
           const type = input.label;
           const newValue = input.value;

--- a/test/unit/wizards/foundation/scl.test.ts
+++ b/test/unit/wizards/foundation/scl.test.ts
@@ -1,0 +1,204 @@
+import { expect } from '@open-wc/testing';
+import {
+  uniqueAppId,
+  uniqueMacAddress,
+} from '../../../../src/wizards/foundation/scl.js';
+
+function incrementMac(oldMac: string): string {
+  const mac = oldMac.split('-').join('');
+  //destination MAC in IEC61850 always starts with 01:0C:CD:...
+  const newMac = '0' + (parseInt(mac, 16) + 1).toString(16).toUpperCase();
+  return newMac.match(/.{1,2}/g)!.join('-');
+}
+
+export function createMacs(serviceType: 'SMV' | 'GOOSE'): string[] {
+  const maxMac =
+    serviceType === 'GOOSE' ? '01-0C-CD-01-01-FF' : '01-0C-CD-04-01-FF';
+  const startMac =
+    serviceType === 'GOOSE' ? '01-0C-CD-01-00-00' : '01-0C-CD-04-00-00';
+
+  const macs: string[] = [];
+
+  let mac = startMac;
+  while (mac !== maxMac) {
+    macs.push(mac);
+    mac = incrementMac(mac);
+  }
+
+  macs.push(maxMac);
+
+  return macs;
+}
+
+function incrementAppId(oldAppId: string): string {
+  return (parseInt(oldAppId, 16) + 1)
+    .toString(16)
+    .toUpperCase()
+    .padStart(4, '0');
+}
+
+export function createAppIds(): string[] {
+  const maxAppId = 'FFFF';
+  const startAppId = '0001';
+
+  const appIds: string[] = [];
+
+  let appId = startAppId;
+  while (appId !== maxAppId) {
+    appIds.push(appId);
+    appId = incrementAppId(appId);
+  }
+
+  appIds.push(maxAppId);
+
+  return appIds;
+}
+
+describe('SCL specific functions', () => {
+  describe('define a function to get unique GSE MAC addres', () => {
+    describe('with all MAC address in use', () => {
+      const gseElementString = `<SubNetwork>${createMacs('GOOSE').map(
+        mac =>
+          `<ConnectedAP><Address><P type="MAC-Address">${mac}</P></Address></ConnectedAP>`
+      )}</SubNEtwork>`;
+      const doc = new DOMParser().parseFromString(
+        gseElementString,
+        'application/xml'
+      );
+
+      it('return null with no unique MAC', () =>
+        expect(uniqueMacAddress(doc, 'GOOSE')).to.be.null);
+    });
+
+    describe('with available MAC address', () => {
+      const macs = createMacs('GOOSE');
+      macs.splice(4, 5);
+      const gseElementString = `<SubNetwork>${macs.map(
+        mac =>
+          `<ConnectedAP><Address><P type="MAC-Address">${mac}</P></Address></ConnectedAP>`
+      )}</SubNEtwork>`;
+      const doc = new DOMParser().parseFromString(
+        gseElementString,
+        'application/xml'
+      );
+
+      it('return the first availablefirst unique MAC', () =>
+        expect(uniqueMacAddress(doc, 'GOOSE')).to.equal('01-0C-CD-01-00-04'));
+    });
+
+    describe('with one available MAC address', () => {
+      const macs = createMacs('GOOSE');
+      macs.pop();
+      const gseElementString = `<SubNetwork>${macs.map(
+        mac =>
+          `<ConnectedAP><Address><P type="MAC-Address">${mac}</P></Address></ConnectedAP>`
+      )}</SubNetwork>`;
+      const doc = new DOMParser().parseFromString(
+        gseElementString,
+        'application/xml'
+      );
+
+      it('return the first availablefirst unique MAC', () =>
+        expect(uniqueMacAddress(doc, 'GOOSE')).to.equal('01-0C-CD-01-01-FF'));
+    });
+  });
+
+  describe('define a function to get unique SMV MAC addres', () => {
+    describe('with all MAC address in use', () => {
+      const smvElementString = `<SubNetwork>${createMacs('SMV').map(
+        mac =>
+          `<ConnectedAP><Address><P type="MAC-Address">${mac}</P></Address></ConnectedAP>`
+      )}</SubNetwork>`;
+      const doc = new DOMParser().parseFromString(
+        smvElementString,
+        'application/xml'
+      );
+
+      it('return null with no unique MAC', () =>
+        expect(uniqueMacAddress(doc, 'SMV')).to.be.null);
+    });
+
+    describe('with available MAC address', () => {
+      const macs = createMacs('SMV');
+      macs.splice(10, 5);
+      const gseElementString = `<SubNetwork>${macs.map(
+        mac =>
+          `<ConnectedAP><Address><P type="MAC-Address">${mac}</P></Address></ConnectedAP>`
+      )}</SubNetwork>`;
+      const doc = new DOMParser().parseFromString(
+        gseElementString,
+        'application/xml'
+      );
+
+      it('return the first availablefirst unique MAC', () =>
+        expect(uniqueMacAddress(doc, 'SMV')).to.equal('01-0C-CD-04-00-0A'));
+    });
+
+    describe('with one available MAC address', () => {
+      const macs = createMacs('SMV');
+      macs.pop();
+      const gseElementString = `<SubNetwork>${macs.map(
+        mac =>
+          `<ConnectedAP><Address><P type="MAC-Address">${mac}</P></Address></ConnectedAP>`
+      )}</SubNetwork>`;
+      const doc = new DOMParser().parseFromString(
+        gseElementString,
+        'application/xml'
+      );
+
+      it('return the first availablefirst unique MAC', () =>
+        expect(uniqueMacAddress(doc, 'SMV')).to.equal('01-0C-CD-04-01-FF'));
+    });
+  });
+
+  describe('define a function to get unique APPID', () => {
+    describe('with all APPIDs in use', () => {
+      const appIdElementString = `<SubNetwork>${createAppIds().map(
+        appId =>
+          `<ConnectedAP><Address><P type="APPID">${appId}</P></Address></ConnectedAP>`
+      )}</SubNetwork>`;
+      const doc = new DOMParser().parseFromString(
+        appIdElementString,
+        'application/xml'
+      );
+
+      it('return null with no unique APPID', () => {
+        expect(uniqueAppId(doc)).to.be.null;
+      }).timeout(5000);
+    });
+
+    describe('with available APPID', () => {
+      const appIds = createAppIds();
+      appIds.splice(10, 5);
+      const gseElementString = `<SubNetwork>${appIds.map(
+        appId =>
+          `<ConnectedAP><Address><P type="APPID">${appId}</P></Address></ConnectedAP>`
+      )}</SubNetwork>`;
+      const doc = new DOMParser().parseFromString(
+        gseElementString,
+        'application/xml'
+      );
+
+      it('return the first availablefirst unique APPID', () => {
+        expect(uniqueAppId(doc)).to.equal('000B');
+      });
+    });
+
+    describe('with one available APPID', () => {
+      const appIds = createAppIds();
+      appIds.pop();
+      const appIdElementString = `<SubNetwork>${appIds.map(
+        appId =>
+          `<ConnectedAP><Address><P type="APPID">${appId}</P></Address></ConnectedAP>`
+      )}</SubNetwork>`;
+      const doc = new DOMParser().parseFromString(
+        appIdElementString,
+        'application/xml'
+      );
+
+      it('return the first availablefirst unique APPID', () => {
+        expect(uniqueAppId(doc)).to.equal('FFFF');
+      }).timeout(5000);
+    });
+  });
+});

--- a/test/unit/wizards/foundation/scl.test.ts
+++ b/test/unit/wizards/foundation/scl.test.ts
@@ -164,7 +164,7 @@ describe('SCL specific functions', () => {
 
       it('return null with no unique APPID', () => {
         expect(uniqueAppId(doc)).to.be.null;
-      }).timeout(5000);
+      }).timeout(10000);
     });
 
     describe('with available APPID', () => {
@@ -198,7 +198,7 @@ describe('SCL specific functions', () => {
 
       it('return the first availablefirst unique APPID', () => {
         expect(uniqueAppId(doc)).to.equal('FFFF');
-      }).timeout(5000);
+      }).timeout(10000);
     });
   });
 });

--- a/test/unit/wizards/foundation/scl.test.ts
+++ b/test/unit/wizards/foundation/scl.test.ts
@@ -152,21 +152,6 @@ describe('SCL specific functions', () => {
   });
 
   describe('define a function to get unique APPID', () => {
-    describe('with all APPIDs in use', () => {
-      const appIdElementString = `<SubNetwork>${createAppIds().map(
-        appId =>
-          `<ConnectedAP><Address><P type="APPID">${appId}</P></Address></ConnectedAP>`
-      )}</SubNetwork>`;
-      const doc = new DOMParser().parseFromString(
-        appIdElementString,
-        'application/xml'
-      );
-
-      it('return null with no unique APPID', () => {
-        expect(uniqueAppId(doc)).to.be.null;
-      }).timeout(10000);
-    });
-
     describe('with available APPID', () => {
       const appIds = createAppIds();
       appIds.splice(10, 5);
@@ -182,23 +167,6 @@ describe('SCL specific functions', () => {
       it('return the first availablefirst unique APPID', () => {
         expect(uniqueAppId(doc)).to.equal('000B');
       });
-    });
-
-    describe('with one available APPID', () => {
-      const appIds = createAppIds();
-      appIds.pop();
-      const appIdElementString = `<SubNetwork>${appIds.map(
-        appId =>
-          `<ConnectedAP><Address><P type="APPID">${appId}</P></Address></ConnectedAP>`
-      )}</SubNetwork>`;
-      const doc = new DOMParser().parseFromString(
-        appIdElementString,
-        'application/xml'
-      );
-
-      it('return the first availablefirst unique APPID', () => {
-        expect(uniqueAppId(doc)).to.equal('FFFF');
-      }).timeout(10000);
     });
   });
 });

--- a/test/unit/wizards/foundation/scl.test.ts
+++ b/test/unit/wizards/foundation/scl.test.ts
@@ -11,7 +11,7 @@ function incrementMac(oldMac: string): string {
   return newMac.match(/.{1,2}/g)!.join('-');
 }
 
-export function createMacs(serviceType: 'SMV' | 'GOOSE'): string[] {
+function createMacs(serviceType: 'SMV' | 'GOOSE'): string[] {
   const maxMac =
     serviceType === 'GOOSE' ? '01-0C-CD-01-01-FF' : '01-0C-CD-04-01-FF';
   const startMac =
@@ -37,7 +37,7 @@ function incrementAppId(oldAppId: string): string {
     .padStart(4, '0');
 }
 
-export function createAppIds(): string[] {
+function createAppIds(): string[] {
   const maxAppId = 'FFFF';
   const startAppId = '0001';
 

--- a/test/unit/wizards/gsecontrol.test.ts
+++ b/test/unit/wizards/gsecontrol.test.ts
@@ -16,7 +16,7 @@ import {
 import {
   editGseControlWizard,
   removeGseControlAction,
-  renderGseControlAttributes,
+  contentGseControlWizard,
   selectGseControlWizard,
   updateGseControlAction,
 } from '../../../src/wizards/gsecontrol.js';
@@ -51,7 +51,7 @@ describe('gsecontrol wizards', () => {
       const wizard = [
         {
           title: 'title',
-          content: renderGseControlAttributes({
+          content: contentGseControlWizard({
             name: 'GSEcontrol',
             desc: null,
             type: 'GOOSE',
@@ -226,7 +226,7 @@ describe('gsecontrol wizards', () => {
       wizard = [
         {
           title: 'title',
-          content: renderGseControlAttributes({
+          content: contentGseControlWizard({
             name: 'myCbName',
             desc: null,
             type: 'GOOSE',

--- a/test/unit/wizards/gsecontrol.test.ts
+++ b/test/unit/wizards/gsecontrol.test.ts
@@ -16,7 +16,7 @@ import {
 import {
   editGseControlWizard,
   removeGseControlAction,
-  renderGseAttributes,
+  renderGseControlAttributes,
   selectGseControlWizard,
   updateGseControlAction,
 } from '../../../src/wizards/gsecontrol.js';
@@ -51,14 +51,14 @@ describe('gsecontrol wizards', () => {
       const wizard = [
         {
           title: 'title',
-          content: renderGseAttributes(
-            'GSEcontrol',
-            null,
-            'GOOSE',
-            'myIED/myAP/myLD/myLN0/myGSE',
-            null,
-            null
-          ),
+          content: renderGseControlAttributes({
+            name: 'GSEcontrol',
+            desc: null,
+            type: 'GOOSE',
+            appID: 'myIED/myAP/myLD/myLN0/myGSE',
+            fixedOffs: null,
+            securityEnabled: null,
+          }),
         },
       ];
       element.workflow.push(() => wizard);
@@ -226,14 +226,14 @@ describe('gsecontrol wizards', () => {
       wizard = [
         {
           title: 'title',
-          content: renderGseAttributes(
-            'myCbName',
-            null,
-            'GOOSE',
-            'myAPP/ID',
-            null,
-            null
-          ),
+          content: renderGseControlAttributes({
+            name: 'myCbName',
+            desc: null,
+            type: 'GOOSE',
+            appID: 'myAPP/ID',
+            fixedOffs: null,
+            securityEnabled: null,
+          }),
         },
       ];
       element.workflow.push(() => wizard);

--- a/test/unit/wizards/gsecontrol.test.ts
+++ b/test/unit/wizards/gsecontrol.test.ts
@@ -506,7 +506,7 @@ describe('gsecontrol wizards', () => {
         )).maybeValue = 'wer';
 
         primaryAction = <HTMLElement>(
-          element.wizardUI.dialogs[1]?.querySelector(
+          element.wizardUI.dialogs[2]?.querySelector(
             'mwc-button[slot="primaryAction"]'
           )
         );
@@ -518,8 +518,12 @@ describe('gsecontrol wizards', () => {
         await element.wizardUI.requestUpdate(); // make sure wizard is rendered
       });
 
-      it('has two pages', () =>
-        expect(element.wizardUI.dialogs.length).to.equal(2));
+      it('has three pages', () =>
+        expect(element.wizardUI.dialogs.length).to.equal(3));
+
+      it('the second page having a warning message ', async () => {
+        await expect(element.wizardUI.dialogs[1]).dom.to.equalSnapshot();
+      }).timeout(5000);
 
       it('triggers complex action on primary action click', async () => {
         await primaryAction.click();


### PR DESCRIPTION
Create wizards for the `GSEControl` elements. Some implementation details:

When adding a `GSEControl` a `GSE` element must be added to the `Communication` section as well. This is true only if there is a `ConnectedAP` for the `AccessPoint` where the `Server` resides in. If there is no `ConnectedAP` no `GSE` element must be added. The way it is implemented now: when `ConnectedAP` is present the second page of the create wizard allows to specify the `GSE` element. Otherwise this page is not rendered and the create wizard consists of only two wizard pages. To test delete all `SubNetwork` elements in the Communication plugin.