### PR TITLE
fix(filtered-list): allow filter nested mwc-...-list-item s

### DIFF
--- a/src/filtered-list.ts
+++ b/src/filtered-list.ts
@@ -16,7 +16,28 @@ import '@material/mwc-textfield';
 import { CheckListItem } from '@material/mwc-list/mwc-check-list-item';
 import { List } from '@material/mwc-list';
 import { ListBase } from '@material/mwc-list/mwc-list-base';
+import { ListItemBase } from '@material/mwc-list/mwc-list-item-base';
 import { TextField } from '@material/mwc-textfield';
+
+function slotItem(item: Element): Element {
+  if (!item.closest('filtered-list') || !item.parentElement) return item;
+  if (item.parentElement instanceof FilteredList) return item;
+  return slotItem(item.parentElement);
+}
+
+function hideFiltered(item: ListItemBase, searchText: string): void {
+  const itemInnerText = item.innerText + '\n';
+  const childInnerText = Array.from(item.children)
+    .map(child => (<HTMLElement>child).innerText)
+    .join('\n');
+  const filterTarget: string = (itemInnerText + childInnerText).toUpperCase();
+
+  const terms: string[] = searchText.toUpperCase().split(' ');
+
+  terms.some(term => !filterTarget.includes(term))
+    ? slotItem(item).classList.add('hidden')
+    : slotItem(item).classList.remove('hidden');
+}
 
 /**
  * A mwc-list with mwc-textfield that filters the list items for given or separated terms
@@ -61,20 +82,13 @@ export class FilteredList extends ListBase {
   }
 
   onFilterInput(): void {
-    this.items.forEach(item => {
-      const text: string = (
-        item.innerText +
-        '\n' +
-        Array.from(item.children)
-          .map(child => (<HTMLElement>child).innerText)
-          .join('\n')
-      ).toUpperCase();
-      const terms: string[] = this.searchField.value.toUpperCase().split(' ');
-
-      terms.some(term => !text.includes(term))
-        ? item.classList.add('hidden')
-        : item.classList.remove('hidden');
-    });
+    Array.from(
+      this.querySelectorAll(
+        'mwc-list-item, mwc-check-list-item, mwc-radio-list-item'
+      )
+    ).forEach(item =>
+      hideFiltered(item as ListItemBase, this.searchField.value)
+    );
   }
 
   protected onListItemConnected(e: CustomEvent): void {

--- a/src/filtered-list.ts
+++ b/src/filtered-list.ts
@@ -86,9 +86,11 @@ export class FilteredList extends ListBase {
       this.querySelectorAll(
         'mwc-list-item, mwc-check-list-item, mwc-radio-list-item'
       )
-    ).forEach(item =>
-      hideFiltered(item as ListItemBase, this.searchField.value)
-    );
+    )
+      .filter(item => !(item as ListItemBase).noninteractive)
+      .forEach(item =>
+        hideFiltered(item as ListItemBase, this.searchField.value)
+      );
   }
 
   protected onListItemConnected(e: CustomEvent): void {

--- a/test/unit/filtered-list.test.ts
+++ b/test/unit/filtered-list.test.ts
@@ -1,6 +1,8 @@
 import { expect, fixture, html } from '@open-wc/testing';
 
 import '@material/mwc-list/mwc-check-list-item';
+import '@material/mwc-list/mwc-list-item';
+import '@material/mwc-list/mwc-radio-list-item';
 
 import '../../src/filtered-list.js';
 import { FilteredList } from '../../src/filtered-list.js';
@@ -13,6 +15,7 @@ describe('filtered-list', () => {
     { prim: 'item3', sec: 'item3sec', disabled: false },
     { prim: 'item4', sec: 'item4sec', disabled: true },
   ];
+
   beforeEach(async () => {
     element = await fixture(
       html`<filtered-list multi
@@ -22,7 +25,13 @@ describe('filtered-list', () => {
               ><span>${item.prim}</span
               ><span slot="secondary">${item.sec}</span></mwc-check-list-item
             >`
-        )}</filtered-list
+        )}<abbr
+          ><mwc-list-item><span>nestedItem5</span></mwc-list-item></abbr
+        ><abbr
+          ><div>
+            <mwc-radio-list-item><span>nestedItem6</span></mwc-radio-list-item>
+          </div></abbr
+        ></filtered-list
       >`
     );
   });
@@ -44,6 +53,7 @@ describe('filtered-list', () => {
         element.shadowRoot!.querySelector('mwc-formfield>mwc-checkbox')
       ).to.have.attribute('indeterminate');
     });
+
     it('is selected if all check-list-items are selected', async () => {
       expect(
         element.shadowRoot!.querySelector('mwc-formfield>mwc-checkbox')
@@ -59,6 +69,7 @@ describe('filtered-list', () => {
         element.shadowRoot!.querySelector('mwc-formfield>mwc-checkbox')
       ).to.have.attribute('checked');
     });
+
     it('is none of the above if no check-list-item is selected', () => {
       expect(
         element.shadowRoot!.querySelector('mwc-formfield>mwc-checkbox')
@@ -67,6 +78,7 @@ describe('filtered-list', () => {
         element.shadowRoot!.querySelector('mwc-formfield>mwc-checkbox')
       ).to.not.have.attribute('indeterminate');
     });
+
     it('can be disabled with disableCheckAll property', async () => {
       expect(element.shadowRoot!.querySelector('mwc-formfield>mwc-checkbox')).to
         .not.be.null;
@@ -75,6 +87,7 @@ describe('filtered-list', () => {
       expect(element.shadowRoot!.querySelector('mwc-formfield>mwc-checkbox')).to
         .be.null;
     });
+
     it('selects all enabled and visable check-list-items on checkAll click', async () => {
       (<HTMLElement>(
         element.shadowRoot!.querySelector('mwc-formfield>mwc-checkbox')
@@ -86,6 +99,7 @@ describe('filtered-list', () => {
           expect(item).to.have.attribute('selected');
         });
     });
+
     it('does not select disabled check-list-items on checkAll click', async () => {
       (<HTMLElement>(
         element.shadowRoot!.querySelector('mwc-formfield>mwc-checkbox')
@@ -93,6 +107,7 @@ describe('filtered-list', () => {
       await element.updateComplete;
       expect(element.items[3]).to.not.have.attribute('selected');
     });
+
     it('unselects all check-list-items on checkAll click', async () => {
       (<HTMLElement>(
         element.shadowRoot!.querySelector('mwc-formfield>mwc-checkbox')
@@ -109,27 +124,31 @@ describe('filtered-list', () => {
     });
   });
 
-  describe('onFilterInput', () => {
-    it('filteres its items', async () => {
+  describe('allows to filter on', () => {
+    it('directly slotted mwc-check-list-item', async () => {
       element.searchField.value = 'item1';
       element.onFilterInput();
       element.requestUpdate();
       await element.updateComplete;
-      expect(element.items[0].classList.contains('hidden')).to.be.false;
-      expect(element.items[1].classList.contains('hidden')).to.be.true;
-      expect(element.items[2].classList.contains('hidden')).to.be.true;
-      expect(element.items[3].classList.contains('hidden')).to.be.true;
+      expect(element.children[0].classList.contains('hidden')).to.be.false;
+      expect(element.children[1].classList.contains('hidden')).to.be.true;
+      expect(element.children[2].classList.contains('hidden')).to.be.true;
+      expect(element.children[3].classList.contains('hidden')).to.be.true;
+      expect(element.children[4].classList.contains('hidden')).to.be.true;
+      expect(element.children[5].classList.contains('hidden')).to.be.true;
     });
 
-    it('filteres within twoline mwc-list-item', async () => {
+    it('directly slotted twoline mwc-check-list-item', async () => {
       element.searchField.value = 'item2sec';
       element.onFilterInput();
       element.requestUpdate();
       await element.updateComplete;
-      expect(element.items[0].classList.contains('hidden')).to.be.true;
-      expect(element.items[1].classList.contains('hidden')).to.be.false;
-      expect(element.items[2].classList.contains('hidden')).to.be.true;
-      expect(element.items[3].classList.contains('hidden')).to.be.true;
+      expect(element.children[0].classList.contains('hidden')).to.be.true;
+      expect(element.children[1].classList.contains('hidden')).to.be.false;
+      expect(element.children[2].classList.contains('hidden')).to.be.true;
+      expect(element.children[3].classList.contains('hidden')).to.be.true;
+      expect(element.children[4].classList.contains('hidden')).to.be.true;
+      expect(element.children[5].classList.contains('hidden')).to.be.true;
     });
 
     it('uses space as logic AND ', async () => {
@@ -137,10 +156,38 @@ describe('filtered-list', () => {
       element.onFilterInput();
       element.requestUpdate();
       await element.updateComplete;
-      expect(element.items[0].classList.contains('hidden')).to.be.true;
-      expect(element.items[1].classList.contains('hidden')).to.be.true;
-      expect(element.items[2].classList.contains('hidden')).to.be.false;
-      expect(element.items[3].classList.contains('hidden')).to.be.true;
+      expect(element.children[0].classList.contains('hidden')).to.be.true;
+      expect(element.children[1].classList.contains('hidden')).to.be.true;
+      expect(element.children[2].classList.contains('hidden')).to.be.false;
+      expect(element.children[3].classList.contains('hidden')).to.be.true;
+      expect(element.children[4].classList.contains('hidden')).to.be.true;
+      expect(element.children[5].classList.contains('hidden')).to.be.true;
+    });
+
+    it('nested mwc-list-item elements', async () => {
+      element.searchField.value = 'nesteditem5';
+      element.onFilterInput();
+      element.requestUpdate();
+      await element.updateComplete;
+      expect(element.children[0].classList.contains('hidden')).to.be.true;
+      expect(element.children[1].classList.contains('hidden')).to.be.true;
+      expect(element.children[2].classList.contains('hidden')).to.be.true;
+      expect(element.children[3].classList.contains('hidden')).to.be.true;
+      expect(element.children[4].classList.contains('hidden')).to.be.false;
+      expect(element.children[5].classList.contains('hidden')).to.be.true;
+    });
+
+    it('nested mwc-radio-list-item elements', async () => {
+      element.searchField.value = 'nesteditem6';
+      element.onFilterInput();
+      element.requestUpdate();
+      await element.updateComplete;
+      expect(element.children[0].classList.contains('hidden')).to.be.true;
+      expect(element.children[1].classList.contains('hidden')).to.be.true;
+      expect(element.children[2].classList.contains('hidden')).to.be.true;
+      expect(element.children[3].classList.contains('hidden')).to.be.true;
+      expect(element.children[4].classList.contains('hidden')).to.be.true;
+      expect(element.children[5].classList.contains('hidden')).to.be.false;
     });
   });
 });

--- a/test/unit/filtered-list.test.ts
+++ b/test/unit/filtered-list.test.ts
@@ -31,8 +31,8 @@ describe('filtered-list', () => {
           ><div>
             <mwc-radio-list-item><span>nestedItem6</span></mwc-radio-list-item>
           </div></abbr
-        ></filtered-list
-      >`
+        ><mwc-list-item noninteractive><span>item7</span></mwc-list-item>
+      </filtered-list>`
     );
   });
 
@@ -149,6 +149,7 @@ describe('filtered-list', () => {
       expect(element.children[3].classList.contains('hidden')).to.be.true;
       expect(element.children[4].classList.contains('hidden')).to.be.true;
       expect(element.children[5].classList.contains('hidden')).to.be.true;
+      expect(element.children[6].classList.contains('hidden')).to.be.false;
     });
 
     it('uses space as logic AND ', async () => {
@@ -162,6 +163,7 @@ describe('filtered-list', () => {
       expect(element.children[3].classList.contains('hidden')).to.be.true;
       expect(element.children[4].classList.contains('hidden')).to.be.true;
       expect(element.children[5].classList.contains('hidden')).to.be.true;
+      expect(element.children[6].classList.contains('hidden')).to.be.false;
     });
 
     it('nested mwc-list-item elements', async () => {
@@ -175,6 +177,7 @@ describe('filtered-list', () => {
       expect(element.children[3].classList.contains('hidden')).to.be.true;
       expect(element.children[4].classList.contains('hidden')).to.be.false;
       expect(element.children[5].classList.contains('hidden')).to.be.true;
+      expect(element.children[6].classList.contains('hidden')).to.be.false;
     });
 
     it('nested mwc-radio-list-item elements', async () => {
@@ -188,6 +191,21 @@ describe('filtered-list', () => {
       expect(element.children[3].classList.contains('hidden')).to.be.true;
       expect(element.children[4].classList.contains('hidden')).to.be.true;
       expect(element.children[5].classList.contains('hidden')).to.be.false;
+      expect(element.children[6].classList.contains('hidden')).to.be.false;
+    });
+
+    it('onyl on noninteractive list itmes', async () => {
+      element.searchField.value = 'item7';
+      element.onFilterInput();
+      element.requestUpdate();
+      await element.updateComplete;
+      expect(element.children[0].classList.contains('hidden')).to.be.true;
+      expect(element.children[1].classList.contains('hidden')).to.be.true;
+      expect(element.children[2].classList.contains('hidden')).to.be.true;
+      expect(element.children[3].classList.contains('hidden')).to.be.true;
+      expect(element.children[4].classList.contains('hidden')).to.be.true;
+      expect(element.children[5].classList.contains('hidden')).to.be.true;
+      expect(element.children[6].classList.contains('hidden')).to.be.false;
     });
   });
 });


### PR DESCRIPTION
Close #646 

This PR is in between fix and feat. The `filtered-list` was not designed to filter nested list items. However, in dialogs the space is so limited that we do use `abbr` like in the diagnosis dialog. 

With this PR I propose to change the filter strategy of the `filtered-list` a bit an allow to filter for any nested `mwc-...-list-item`.  