### PR TITLE
fix(editors/subscription): several style issues

### DIFF
--- a/src/editors/Subscription.ts
+++ b/src/editors/Subscription.ts
@@ -4,6 +4,7 @@ import '@material/mwc-fab';
 
 import './subscription/subscriber-ied-list-goose.js';
 import './subscription/publisher-goose-list.js';
+import { styles } from './subscription/foundation.js';
 
 /** An editor [[`plugin`]] for subscribing IEDs to GOOSE messages using the ABB subscription method. */
 export default class SubscriptionABBPlugin extends LitElement {
@@ -12,14 +13,12 @@ export default class SubscriptionABBPlugin extends LitElement {
   doc!: XMLDocument;
 
   render(): TemplateResult {
-    return html`
-    <div id="containerTemplates">
-      <section>
-        <publisher-goose-list .doc=${this.doc}></publisher-goose-list>
-      </section>
-      <section>
-        <subscriber-ied-list-goose .doc=${this.doc}></subscriber-ied-list-goose>
-      </section>
+    return html` <div class="container">
+      <publisher-goose-list class="row" .doc=${this.doc}></publisher-goose-list>
+      <subscriber-ied-list-goose
+        class="row"
+        .doc=${this.doc}
+      ></subscriber-ied-list-goose>
     </div>`;
   }
 
@@ -28,22 +27,18 @@ export default class SubscriptionABBPlugin extends LitElement {
       width: 100vw;
     }
 
-    section {
-      width: 49vw;
+    .container {
+      display: flex;
+      padding: 8px 6px 16px;
+      height: 86vh;
     }
 
-    #containerTemplates {
-      display: grid;
-      grid-gap: 12px;
-      padding: 8px 12px 16px;
-      box-sizing: border-box;
-      grid-template-columns: repeat(auto-fit, minmax(316px, auto));
-    }
-
-    @media (max-width: 387px) {
-      #containerTemplates {
-        grid-template-columns: repeat(auto-fit, minmax(196px, auto));
-      }
+    .row {
+      flex: 50%;
+      margin: 0px 6px 0px;
+      min-width: 300px;
+      height: 100%;
+      overflow-y: scroll;
     }
   `;
 }

--- a/src/editors/subscription/publisher-goose-list.ts
+++ b/src/editors/subscription/publisher-goose-list.ts
@@ -62,7 +62,7 @@ export class PublisherGOOSEList extends LitElement {
   }
 
   render(): TemplateResult {
-    return html` <section>
+    return html` <section tabindex="0">
       <h1>${translate('subscription.publisherGoose.title')}</h1>
       <filtered-list>
         ${this.ieds.map(
@@ -84,11 +84,6 @@ export class PublisherGOOSEList extends LitElement {
 
   static styles = css`
     ${styles}
-
-    filtered-list {
-      height: 100vh;
-      overflow-y: scroll;
-    }
 
     .iedListTitle {
       font-weight: bold;

--- a/src/editors/subscription/subscriber-ied-list-goose.ts
+++ b/src/editors/subscription/subscriber-ied-list-goose.ts
@@ -112,7 +112,7 @@ export class SubscriberIEDListGoose extends LitElement {
     this.onGOOSEDataSetEvent = this.onGOOSEDataSetEvent.bind(this);
     this.onIEDSubscriptionEvent = this.onIEDSubscriptionEvent.bind(this);
 
-    const parentDiv = this.closest('div[id="containerTemplates"]');
+    const parentDiv = this.closest('.container');
     if (parentDiv) {
       parentDiv.addEventListener('goose-dataset', this.onGOOSEDataSetEvent);
       parentDiv.addEventListener(
@@ -424,7 +424,7 @@ export class SubscriberIEDListGoose extends LitElement {
       localState.currentGseControl?.getAttribute('name') ?? undefined;
 
     return html`
-      <section>
+      <section tabindex="0">
         <h1>
           ${translate('subscription.subscriberIed.title', {
             selected: gseControlName
@@ -454,17 +454,6 @@ export class SubscriberIEDListGoose extends LitElement {
 
   static styles = css`
     ${styles}
-
-    h1 {
-      overflow: unset;
-      white-space: unset;
-      text-overflow: unset;
-    }
-
-    .subscriberWrapper {
-      height: 100vh;
-      overflow-y: scroll;
-    }
 
     .iedListTitle {
       font-weight: bold;

--- a/test/integration/editors/subscription/__snapshots__/Subscription.test.snap.js
+++ b/test/integration/editors/subscription/__snapshots__/Subscription.test.snap.js
@@ -2,7 +2,7 @@
 export const snapshots = {};
 
 snapshots["Subscription Plugin initially the GOOSE list looks like the latest snapshot"] = 
-`<section>
+`<section tabindex="0">
   <h1>
     [subscription.publisherGoose.title]
   </h1>
@@ -145,7 +145,7 @@ snapshots["Subscription Plugin initially the GOOSE list looks like the latest sn
 /* end snapshot Subscription Plugin initially the GOOSE list looks like the latest snapshot */
 
 snapshots["Subscription Plugin initially the IED list looks like the latest snapshot"] = 
-`<section>
+`<section tabindex="0">
   <h1>
     [subscription.subscriberIed.title]
   </h1>
@@ -165,252 +165,7 @@ snapshots["Subscription Plugin initially the IED list looks like the latest snap
 /* end snapshot Subscription Plugin initially the IED list looks like the latest snapshot */
 
 snapshots["Subscription Plugin when selecting a GOOSE message the list on the right will initially show the subscribed / partially subscribed / not subscribed IEDs"] = 
-`<section>
-  <h1>
-    [subscription.subscriberIed.title]
-  </h1>
-  <mwc-list>
-    <mwc-list-item
-      aria-disabled="false"
-      noninteractive=""
-      tabindex="-1"
-    >
-      <span class="iedListTitle">
-        [subscription.subscriberIed.noGooseMessageSelected]
-      </span>
-    </mwc-list-item>
-  </mwc-list>
-</section>
-`;
-/* end snapshot Subscription Plugin when selecting a GOOSE message the list on the right will initially show the subscribed / partially subscribed / not subscribed IEDs */
-
-snapshots["Subscription Plugin when selecting a GOOSE message and you subscribe a non-subscribed IED it looks like the latest snapshot"] = 
-`<section>
-  <h1>
-    [subscription.subscriberIed.title]
-  </h1>
-  <div class="subscriberWrapper">
-    <filtered-list id="subscribedIeds">
-      <mwc-list-item
-        aria-disabled="false"
-        noninteractive=""
-        tabindex="-1"
-      >
-        <span class="iedListTitle">
-          [subscription.subscriberIed.subscribed]
-        </span>
-      </mwc-list-item>
-      <li
-        divider=""
-        role="separator"
-      >
-      </li>
-      <mwc-list-item
-        aria-disabled="false"
-        graphic="avatar"
-        hasmeta=""
-        mwc-list-item=""
-        tabindex="-1"
-      >
-        <span>
-          IED3
-        </span>
-        <mwc-icon slot="graphic">
-          clear
-        </mwc-icon>
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        noninteractive=""
-        tabindex="-1"
-      >
-        <span class="iedListTitle">
-          [subscription.subscriberIed.partiallySubscribed]
-        </span>
-      </mwc-list-item>
-      <li
-        divider=""
-        role="separator"
-      >
-      </li>
-      <mwc-list-item
-        aria-disabled="false"
-        graphic="avatar"
-        noninteractive=""
-        tabindex="-1"
-      >
-        <span>
-          [subscription.none]
-        </span>
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        noninteractive=""
-        tabindex="-1"
-      >
-        <span class="iedListTitle">
-          [subscription.subscriberIed.availableToSubscribe]
-        </span>
-      </mwc-list-item>
-      <li
-        divider=""
-        role="separator"
-      >
-      </li>
-      <mwc-list-item
-        aria-disabled="false"
-        graphic="avatar"
-        hasmeta=""
-        mwc-list-item=""
-        tabindex="-1"
-      >
-        <span>
-          IED1
-        </span>
-        <mwc-icon slot="graphic">
-          add
-        </mwc-icon>
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        aria-selected="false"
-        graphic="avatar"
-        hasmeta=""
-        mwc-list-item=""
-        tabindex="-1"
-      >
-        <span>
-          IED2
-        </span>
-        <mwc-icon slot="graphic">
-          add
-        </mwc-icon>
-      </mwc-list-item>
-    </filtered-list>
-  </div>
-</section>
-`;
-/* end snapshot Subscription Plugin when selecting a GOOSE message and you subscribe a non-subscribed IED it looks like the latest snapshot */
-
-snapshots["Subscription Plugin when selecting a GOOSE message and you unsubscribe a subscribed IED it looks like the latest snapshot"] = 
-`<section>
-  <h1>
-    [subscription.subscriberIed.title]
-  </h1>
-  <div class="subscriberWrapper">
-    <filtered-list id="subscribedIeds">
-      <mwc-list-item
-        aria-disabled="false"
-        noninteractive=""
-        tabindex="-1"
-      >
-        <span class="iedListTitle">
-          [subscription.subscriberIed.subscribed]
-        </span>
-      </mwc-list-item>
-      <li
-        divider=""
-        role="separator"
-      >
-      </li>
-      <mwc-list-item
-        aria-disabled="false"
-        graphic="avatar"
-        noninteractive=""
-        tabindex="-1"
-      >
-        <span>
-          [subscription.none]
-        </span>
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        noninteractive=""
-        tabindex="-1"
-      >
-        <span class="iedListTitle">
-          [subscription.subscriberIed.partiallySubscribed]
-        </span>
-      </mwc-list-item>
-      <li
-        divider=""
-        role="separator"
-      >
-      </li>
-      <mwc-list-item
-        aria-disabled="false"
-        graphic="avatar"
-        noninteractive=""
-        tabindex="-1"
-      >
-        <span>
-          [subscription.none]
-        </span>
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        noninteractive=""
-        tabindex="-1"
-      >
-        <span class="iedListTitle">
-          [subscription.subscriberIed.availableToSubscribe]
-        </span>
-      </mwc-list-item>
-      <li
-        divider=""
-        role="separator"
-      >
-      </li>
-      <mwc-list-item
-        aria-disabled="false"
-        graphic="avatar"
-        hasmeta=""
-        mwc-list-item=""
-        tabindex="0"
-      >
-        <span>
-          IED1
-        </span>
-        <mwc-icon slot="graphic">
-          add
-        </mwc-icon>
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        graphic="avatar"
-        hasmeta=""
-        mwc-list-item=""
-        tabindex="-1"
-      >
-        <span>
-          IED2
-        </span>
-        <mwc-icon slot="graphic">
-          add
-        </mwc-icon>
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        graphic="avatar"
-        hasmeta=""
-        mwc-list-item=""
-        tabindex="-1"
-      >
-        <span>
-          IED3
-        </span>
-        <mwc-icon slot="graphic">
-          add
-        </mwc-icon>
-      </mwc-list-item>
-    </filtered-list>
-  </div>
-</section>
-`;
-/* end snapshot Subscription Plugin when selecting a GOOSE message and you unsubscribe a subscribed IED it looks like the latest snapshot */
-
-snapshots["Subscription Plugin when selecting a GOOSE message and you subscribe a partially subscribed IED it looks like the latest snapshot"] = 
-`<section>
+`<section tabindex="0">
   <h1>
     [subscription.subscriberIed.title]
   </h1>
@@ -471,6 +226,330 @@ snapshots["Subscription Plugin when selecting a GOOSE message and you subscribe 
         <mwc-icon slot="graphic">
           add
         </mwc-icon>
+      </mwc-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        noninteractive=""
+        tabindex="-1"
+      >
+        <span class="iedListTitle">
+          [subscription.subscriberIed.availableToSubscribe]
+        </span>
+      </mwc-list-item>
+      <li
+        divider=""
+        role="separator"
+      >
+      </li>
+      <mwc-list-item
+        aria-disabled="false"
+        graphic="avatar"
+        hasmeta=""
+        mwc-list-item=""
+        tabindex="-1"
+      >
+        <span>
+          IED3
+        </span>
+        <mwc-icon slot="graphic">
+          add
+        </mwc-icon>
+      </mwc-list-item>
+    </filtered-list>
+  </div>
+</section>
+`;
+/* end snapshot Subscription Plugin when selecting a GOOSE message the list on the right will initially show the subscribed / partially subscribed / not subscribed IEDs */
+
+snapshots["Subscription Plugin when selecting a GOOSE message and you subscribe a non-subscribed IED it looks like the latest snapshot"] = 
+`<section tabindex="0">
+  <h1>
+    [subscription.subscriberIed.title]
+  </h1>
+  <div class="subscriberWrapper">
+    <filtered-list id="subscribedIeds">
+      <mwc-list-item
+        aria-disabled="false"
+        noninteractive=""
+        tabindex="-1"
+      >
+        <span class="iedListTitle">
+          [subscription.subscriberIed.subscribed]
+        </span>
+      </mwc-list-item>
+      <li
+        divider=""
+        role="separator"
+      >
+      </li>
+      <mwc-list-item
+        aria-disabled="false"
+        graphic="avatar"
+        hasmeta=""
+        mwc-list-item=""
+        tabindex="-1"
+      >
+        <span>
+          IED1
+        </span>
+        <mwc-icon slot="graphic">
+          clear
+        </mwc-icon>
+      </mwc-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        graphic="avatar"
+        hasmeta=""
+        mwc-list-item=""
+        tabindex="-1"
+      >
+        <span>
+          IED3
+        </span>
+        <mwc-icon slot="graphic">
+          clear
+        </mwc-icon>
+      </mwc-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        noninteractive=""
+        tabindex="-1"
+      >
+        <span class="iedListTitle">
+          [subscription.subscriberIed.partiallySubscribed]
+        </span>
+      </mwc-list-item>
+      <li
+        divider=""
+        role="separator"
+      >
+      </li>
+      <mwc-list-item
+        aria-disabled="false"
+        aria-selected="false"
+        graphic="avatar"
+        hasmeta=""
+        mwc-list-item=""
+        tabindex="-1"
+      >
+        <span>
+          IED4
+        </span>
+        <mwc-icon slot="graphic">
+          add
+        </mwc-icon>
+      </mwc-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        noninteractive=""
+        tabindex="-1"
+      >
+        <span class="iedListTitle">
+          [subscription.subscriberIed.availableToSubscribe]
+        </span>
+      </mwc-list-item>
+      <li
+        divider=""
+        role="separator"
+      >
+      </li>
+      <mwc-list-item
+        aria-disabled="false"
+        graphic="avatar"
+        noninteractive=""
+        tabindex="-1"
+      >
+        <span>
+          [subscription.none]
+        </span>
+      </mwc-list-item>
+    </filtered-list>
+  </div>
+</section>
+`;
+/* end snapshot Subscription Plugin when selecting a GOOSE message and you subscribe a non-subscribed IED it looks like the latest snapshot */
+
+snapshots["Subscription Plugin when selecting a GOOSE message and you unsubscribe a subscribed IED it looks like the latest snapshot"] = 
+`<section tabindex="0">
+  <h1>
+    [subscription.subscriberIed.title]
+  </h1>
+  <div class="subscriberWrapper">
+    <filtered-list id="subscribedIeds">
+      <mwc-list-item
+        aria-disabled="false"
+        noninteractive=""
+        tabindex="-1"
+      >
+        <span class="iedListTitle">
+          [subscription.subscriberIed.subscribed]
+        </span>
+      </mwc-list-item>
+      <li
+        divider=""
+        role="separator"
+      >
+      </li>
+      <mwc-list-item
+        aria-disabled="false"
+        graphic="avatar"
+        hasmeta=""
+        mwc-list-item=""
+        tabindex="-1"
+      >
+        <span>
+          IED1
+        </span>
+        <mwc-icon slot="graphic">
+          clear
+        </mwc-icon>
+      </mwc-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        aria-selected="false"
+        graphic="avatar"
+        hasmeta=""
+        mwc-list-item=""
+        tabindex="-1"
+      >
+        <span>
+          IED4
+        </span>
+        <mwc-icon slot="graphic">
+          clear
+        </mwc-icon>
+      </mwc-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        noninteractive=""
+        tabindex="-1"
+      >
+        <span class="iedListTitle">
+          [subscription.subscriberIed.partiallySubscribed]
+        </span>
+      </mwc-list-item>
+      <li
+        divider=""
+        role="separator"
+      >
+      </li>
+      <mwc-list-item
+        aria-disabled="false"
+        graphic="avatar"
+        noninteractive=""
+        tabindex="-1"
+      >
+        <span>
+          [subscription.none]
+        </span>
+      </mwc-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        noninteractive=""
+        tabindex="-1"
+      >
+        <span class="iedListTitle">
+          [subscription.subscriberIed.availableToSubscribe]
+        </span>
+      </mwc-list-item>
+      <li
+        divider=""
+        role="separator"
+      >
+      </li>
+      <mwc-list-item
+        aria-disabled="false"
+        graphic="avatar"
+        hasmeta=""
+        mwc-list-item=""
+        tabindex="-1"
+      >
+        <span>
+          IED3
+        </span>
+        <mwc-icon slot="graphic">
+          add
+        </mwc-icon>
+      </mwc-list-item>
+    </filtered-list>
+  </div>
+</section>
+`;
+/* end snapshot Subscription Plugin when selecting a GOOSE message and you unsubscribe a subscribed IED it looks like the latest snapshot */
+
+snapshots["Subscription Plugin when selecting a GOOSE message and you subscribe a partially subscribed IED it looks like the latest snapshot"] = 
+`<section tabindex="0">
+  <h1>
+    [subscription.subscriberIed.title]
+  </h1>
+  <div class="subscriberWrapper">
+    <filtered-list id="subscribedIeds">
+      <mwc-list-item
+        aria-disabled="false"
+        noninteractive=""
+        tabindex="-1"
+      >
+        <span class="iedListTitle">
+          [subscription.subscriberIed.subscribed]
+        </span>
+      </mwc-list-item>
+      <li
+        divider=""
+        role="separator"
+      >
+      </li>
+      <mwc-list-item
+        aria-disabled="false"
+        graphic="avatar"
+        hasmeta=""
+        mwc-list-item=""
+        tabindex="-1"
+      >
+        <span>
+          IED1
+        </span>
+        <mwc-icon slot="graphic">
+          clear
+        </mwc-icon>
+      </mwc-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        aria-selected="false"
+        graphic="avatar"
+        hasmeta=""
+        mwc-list-item=""
+        tabindex="-1"
+      >
+        <span>
+          IED4
+        </span>
+        <mwc-icon slot="graphic">
+          clear
+        </mwc-icon>
+      </mwc-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        noninteractive=""
+        tabindex="-1"
+      >
+        <span class="iedListTitle">
+          [subscription.subscriberIed.partiallySubscribed]
+        </span>
+      </mwc-list-item>
+      <li
+        divider=""
+        role="separator"
+      >
+      </li>
+      <mwc-list-item
+        aria-disabled="false"
+        graphic="avatar"
+        noninteractive=""
+        tabindex="-1"
+      >
+        <span>
+          [subscription.none]
+        </span>
       </mwc-list-item>
       <mwc-list-item
         aria-disabled="false"

--- a/test/unit/editors/subscription/__snapshots__/publisher-goose-list.test.snap.js
+++ b/test/unit/editors/subscription/__snapshots__/publisher-goose-list.test.snap.js
@@ -2,7 +2,7 @@
 export const snapshots = {};
 
 snapshots["publisher-goose-list looks like the latest snapshot"] = 
-`<section>
+`<section tabindex="0">
   <h1>
     [subscription.publisherGoose.title]
   </h1>
@@ -103,7 +103,7 @@ snapshots["publisher-goose-list looks like the latest snapshot"] =
 /* end snapshot publisher-goose-list looks like the latest snapshot */
 
 snapshots["publisher-goose-list looks like the latest snapshot without a doc loaded"] = 
-`<section>
+`<section tabindex="0">
   <h1>
     [subscription.publisherGoose.title]
   </h1>

--- a/test/unit/editors/subscription/__snapshots__/subscriber-ied-list.test.snap.js
+++ b/test/unit/editors/subscription/__snapshots__/subscriber-ied-list.test.snap.js
@@ -2,7 +2,7 @@
 export const snapshots = {};
 
 snapshots["subscriber-ied-list initially looks like the latest snapshot"] = 
-`<section>
+`<section tabindex="0">
   <h1>
     [subscription.subscriberIed.title]
   </h1>


### PR DESCRIPTION
This is a suggestion to deal with some styling issues #658 reported by @ca-d. To be more precise

**Fixing**:
 - The gap between the list containers widens at higher resolutions.
 - At lower resolutions, the gap becomes negative, and the lists overlap (see below).
 - At an even lower resolution, the right list container is moved below the left one without the containers becoming wider, leading to an empty right half of the screen (see below).
 - The list containers have a fixed height that is larger than the available content space. This makes the entire window scroll unnecessarily, adding a scroll bar to the right.
 - The click targets for focusing the list containers (green border) are somewhat inconsistent, only clicking on elements inside the filtered-list will give focus to the container, not clicking the header or empty space below the filtered-list (which is there due to the fixed height)

**Maybe this**:
 - The list containers additionally have their own scroll bars, even if they're short enough that no scrolling is needed.

**Not this**(I did not have an idea how this could be solved the best)
- The "bold" font weight on the header list items looks slightly janky, since in other places we only use the three officially recommended material design font weights "Light", "Regular" and "Medium" (css values 300, 400, and 500, respectively) and therefore only include these three weights in https://openscd.github.io/public/google/fonts/roboto-v27.css . The "bold" typeface used here is therefore a version of one of these fonts artificially embiggened by the browser.
