### PR TITLE
feat(expandable-list-item): container adding expand/collapse to list item

### DIFF
--- a/src/expandable-list-item.ts
+++ b/src/expandable-list-item.ts
@@ -1,0 +1,108 @@
+import {
+  css,
+  customElement,
+  html,
+  LitElement,
+  property,
+  query,
+  TemplateResult,
+} from 'lit-element';
+
+import '@material/mwc-icon-button-toggle';
+import '@material/mwc-list';
+import '@material/mwc-list/mwc-list-item';
+import { IconButtonToggle } from '@material/mwc-icon-button-toggle';
+
+/** CSS constainer adding expand/collapse capability to list item */
+@customElement('expandable-list-item')
+export class ExpandableListItem extends LitElement {
+  /** Wether parent list item are expanded per default */
+  @property({ type: Boolean })
+  defaultExtended = false;
+
+  /** Toggle button expanding/collapsing the parent item */
+  @query('mwc-icon-button-toggle') expandButton!: IconButtonToggle;
+  /** Child list items slot */
+  @query('slot[name="child"]') childrenSlot?: HTMLSlotElement;
+
+  protected firstUpdated(): void {
+    const existSlottedChildren =
+      this.childrenSlot?.assignedElements().length !== 0;
+
+    if (!existSlottedChildren) this.expandButton?.classList.add('hidden');
+
+    if (this.defaultExtended && existSlottedChildren) {
+      this.expandButton.on = true;
+      this.shadowRoot?.querySelector('.parent')?.setAttribute('on', '');
+    }
+
+    this.requestUpdate();
+  }
+
+  private onExtendToggle(e: Event): void {
+    const isOn = (e.target as Element).getAttribute('on');
+    if (isOn !== null)
+      this.shadowRoot?.querySelector('.parent')?.setAttribute('on', '');
+    else this.shadowRoot?.querySelector('.parent')?.removeAttribute('on');
+    this.requestUpdate();
+  }
+
+  renderList(): TemplateResult {
+    return html`<mwc-list><slot name="child"></slot></mwc-list>`;
+  }
+
+  renderExtendToggle(): TemplateResult {
+    return html`<div class="extendContainer">
+      <mwc-icon-button-toggle
+        onIcon="keyboard_arrow_up"
+        offIcon="keyboard_arrow_down"
+        @click=${this.onExtendToggle}
+        }}
+      ></mwc-icon-button-toggle>
+    </div>`;
+  }
+
+  render(): TemplateResult {
+    return html`<div class="container">
+      <div class="parent">
+        ${this.renderExtendToggle()} <slot name="parent"></slot>
+      </div>
+      <div class="content">${this.renderList()}</div>
+    </div>`;
+  }
+
+  static styles = css`
+    .container {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .parent {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+    }
+
+    .content {
+      padding-left: 28px;
+    }
+
+    .extendContainer {
+      flex-basis: 28px;
+    }
+
+    mwc-icon-button-toggle {
+      padding: 2px;
+      --mdc-icon-size: 24px;
+      --mdc-icon-button-size: 24px;
+    }
+
+    mwc-icon-button-toggle.hidden {
+      display: none;
+    }
+
+    .parent:not([on]) ~ .content mwc-list {
+      display: none;
+    }
+  `;
+}

--- a/src/expandable-list-item.ts
+++ b/src/expandable-list-item.ts
@@ -39,7 +39,7 @@ export class ExpandableListItem extends LitElement {
     this.requestUpdate();
   }
 
-  private onExtendToggle(e: Event): void {
+  private onExpandToggle(e: Event): void {
     const isOn = (e.target as Element).getAttribute('on');
     if (isOn !== null)
       this.shadowRoot?.querySelector('.parent')?.setAttribute('on', '');
@@ -52,11 +52,11 @@ export class ExpandableListItem extends LitElement {
   }
 
   renderExtendToggle(): TemplateResult {
-    return html`<div class="extendContainer">
+    return html`<div class="expandIconContainer">
       <mwc-icon-button-toggle
         onIcon="keyboard_arrow_up"
         offIcon="keyboard_arrow_down"
-        @click=${this.onExtendToggle}
+        @click=${this.onExpandToggle}
         }}
       ></mwc-icon-button-toggle>
     </div>`;
@@ -83,12 +83,12 @@ export class ExpandableListItem extends LitElement {
       align-items: center;
     }
 
-    .content {
-      padding-left: 28px;
+    .expandIconContainer {
+      flex-basis: 28px;
     }
 
-    .extendContainer {
-      flex-basis: 28px;
+    .content {
+      padding-left: 28px;
     }
 
     mwc-icon-button-toggle {

--- a/test/unit/__snapshots__/expandable-list-item.test.snap.js
+++ b/test/unit/__snapshots__/expandable-list-item.test.snap.js
@@ -4,7 +4,7 @@ export const snapshots = {};
 snapshots["expandable/collapsable list item container with missing parent and children slotted looks like the latest snapshot"] = 
 `<div class="container">
   <div class="parent">
-    <div class="extendContainer">
+    <div class="expandIconContainer">
       <mwc-icon-button-toggle
         }}=""
         class="hidden"
@@ -29,7 +29,7 @@ snapshots["expandable/collapsable list item container with missing parent and ch
 snapshots["expandable/collapsable list item container with only parent item slotted looks like the latest snapshot"] = 
 `<div class="container">
   <div class="parent">
-    <div class="extendContainer">
+    <div class="expandIconContainer">
       <mwc-icon-button-toggle
         }}=""
         class="hidden"
@@ -54,7 +54,7 @@ snapshots["expandable/collapsable list item container with only parent item slot
 snapshots["expandable/collapsable list item container with both parent and childen slotted and defaultExpanded not set looks like the latest snapshot"] = 
 `<div class="container">
   <div class="parent">
-    <div class="extendContainer">
+    <div class="expandIconContainer">
       <mwc-icon-button-toggle
         }}=""
         officon="keyboard_arrow_down"
@@ -81,7 +81,7 @@ snapshots["expandable/collapsable list item container with both parent and child
     class="parent"
     on=""
   >
-    <div class="extendContainer">
+    <div class="expandIconContainer">
       <mwc-icon-button-toggle
         }}=""
         officon="keyboard_arrow_down"

--- a/test/unit/__snapshots__/expandable-list-item.test.snap.js
+++ b/test/unit/__snapshots__/expandable-list-item.test.snap.js
@@ -1,0 +1,105 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["expandable/collapsable list item container with missing parent and children slotted looks like the latest snapshot"] = 
+`<div class="container">
+  <div class="parent">
+    <div class="extendContainer">
+      <mwc-icon-button-toggle
+        }}=""
+        class="hidden"
+        officon="keyboard_arrow_down"
+        onicon="keyboard_arrow_up"
+      >
+      </mwc-icon-button-toggle>
+    </div>
+    <slot name="parent">
+    </slot>
+  </div>
+  <div class="content">
+    <mwc-list>
+      <slot name="child">
+      </slot>
+    </mwc-list>
+  </div>
+</div>
+`;
+/* end snapshot expandable/collapsable list item container with missing parent and children slotted looks like the latest snapshot */
+
+snapshots["expandable/collapsable list item container with only parent item slotted looks like the latest snapshot"] = 
+`<div class="container">
+  <div class="parent">
+    <div class="extendContainer">
+      <mwc-icon-button-toggle
+        }}=""
+        class="hidden"
+        officon="keyboard_arrow_down"
+        onicon="keyboard_arrow_up"
+      >
+      </mwc-icon-button-toggle>
+    </div>
+    <slot name="parent">
+    </slot>
+  </div>
+  <div class="content">
+    <mwc-list>
+      <slot name="child">
+      </slot>
+    </mwc-list>
+  </div>
+</div>
+`;
+/* end snapshot expandable/collapsable list item container with only parent item slotted looks like the latest snapshot */
+
+snapshots["expandable/collapsable list item container with both parent and childen slotted and defaultExpanded not set looks like the latest snapshot"] = 
+`<div class="container">
+  <div class="parent">
+    <div class="extendContainer">
+      <mwc-icon-button-toggle
+        }}=""
+        officon="keyboard_arrow_down"
+        onicon="keyboard_arrow_up"
+      >
+      </mwc-icon-button-toggle>
+    </div>
+    <slot name="parent">
+    </slot>
+  </div>
+  <div class="content">
+    <mwc-list>
+      <slot name="child">
+      </slot>
+    </mwc-list>
+  </div>
+</div>
+`;
+/* end snapshot expandable/collapsable list item container with both parent and childen slotted and defaultExpanded not set looks like the latest snapshot */
+
+snapshots["expandable/collapsable list item container with both parent and childen slotted and defaultExpanded set to true looks like the latest snapshot"] = 
+`<div class="container">
+  <div
+    class="parent"
+    on=""
+  >
+    <div class="extendContainer">
+      <mwc-icon-button-toggle
+        }}=""
+        officon="keyboard_arrow_down"
+        on=""
+        onicon="keyboard_arrow_up"
+      >
+      </mwc-icon-button-toggle>
+    </div>
+    <slot name="parent">
+    </slot>
+  </div>
+  <div class="content">
+    <mwc-list>
+      <slot name="child">
+      </slot>
+    </mwc-list>
+  </div>
+</div>
+`;
+/* end snapshot expandable/collapsable list item container with both parent and childen slotted and defaultExpanded set to true looks like the latest snapshot */
+

--- a/test/unit/expandable-list-item.test.ts
+++ b/test/unit/expandable-list-item.test.ts
@@ -1,0 +1,105 @@
+import { expect, fixture, html } from '@open-wc/testing';
+
+import '@material/mwc-list/mwc-list-item';
+
+import '../../src/expandable-list-item.js';
+import { ExpandableListItem } from '../../src/expandable-list-item.js';
+
+describe('expandable/collapsable list item container', () => {
+  let element: ExpandableListItem;
+
+  describe('with missing parent and children slotted', () => {
+    beforeEach(async () => {
+      element = await fixture(
+        html`<expandable-list-item></expandable-list-item>`
+      );
+    });
+
+    it('looks like the latest snapshot', async () =>
+      await expect(element).shadowDom.to.equalSnapshot());
+  });
+
+  describe('with only parent item slotted', () => {
+    beforeEach(async () => {
+      element = await fixture(
+        html`<expandable-list-item
+          ><mwc-list-item slot="parent"
+            >parent</mwc-list-item
+          ></expandable-list-item
+        >`
+      );
+    });
+
+    it('looks like the latest snapshot', async () =>
+      await expect(element).shadowDom.to.equalSnapshot());
+
+    it('does not render the expand toggle button', () =>
+      expect(element.expandButton.classList.contains('hidden')).to.be.true);
+  });
+
+  describe('with both parent and childen slotted', () => {
+    describe('and defaultExpanded not set', () => {
+      beforeEach(async () => {
+        element = await fixture(
+          html`<expandable-list-item
+            ><mwc-list-item slot="parent">parent</mwc-list-item
+            ><mwc-list-item slot="child"
+              >child1</mwc-list-item
+            ></expandable-list-item
+          >`
+        );
+      });
+
+      it('looks like the latest snapshot', async () =>
+        await expect(element).shadowDom.to.equalSnapshot());
+
+      it('does render the expand toggle button', () =>
+        expect(element.expandButton.classList.contains('hidden')).to.be.false);
+
+      it('is folded', () => {
+        expect(element.expandButton.on).to.be.false;
+        expect(
+          element.shadowRoot?.querySelector('.parent')
+        ).to.not.have.attribute('on');
+      });
+
+      it('un-foldes on expand button click', async () => {
+        await element.expandButton.click();
+        expect(element.expandButton.on).to.be.true;
+      });
+    });
+
+    describe('and defaultExpanded set to true', () => {
+      beforeEach(async () => {
+        element = await fixture(
+          html`<expandable-list-item ?defaultExtended=${true}
+            ><mwc-list-item slot="parent">parent</mwc-list-item
+            ><mwc-list-item slot="child">child1</mwc-list-item
+            ><mwc-list-item slot="child"
+              >child2</mwc-list-item
+            ></expandable-list-item
+          >`
+        );
+      });
+
+      it('looks like the latest snapshot', async () =>
+        await expect(element).shadowDom.to.equalSnapshot());
+
+      it('does render the expand toggle button', () =>
+        expect(element.expandButton.classList.contains('hidden')).to.be.false);
+
+      it('is un-folded', () => {
+        expect(element.expandButton.on).to.be.true;
+        expect(element.shadowRoot?.querySelector('.parent')).to.have.attribute(
+          'on',
+          ''
+        );
+      });
+
+      it('foldes on expand button click', async () => {
+        await element.expandButton.click();
+        expect(element.expandButton.on).to.be.false;
+      });
+    });
+  });
+});


### PR DESCRIPTION
The web-component proposed here is a CSS container with expanding/collapsing function. It is working with slots and therefore allows adding all kind of list items. Theoretically, It can be used to build a tree. 

If you want to test exchange the `renderGoose` and `render` methods in `editors/subscriber/publisher-goose-list` with:

```
renderGoose(element: Element): TemplateResult {
    return html`<mwc-list-item
        twoline
        slot="child"
        @click=${() => this.onGooseSelect(element)}
        graphic="large"
      >
        <span>${element.getAttribute('name')}</span>
        <span slot="secondary">${identity(element)}</span>
        <mwc-icon slot="graphic">${gooseIcon}</mwc-icon>
      </mwc-list-item></extendable-list-item
    >`;
  }

  render(): TemplateResult {
    return html` <section tabindex="0">
      <h1>${translate('subscription.publisherGoose.title')}</h1>
      <filtered-list>
        ${this.ieds.map(
          ied =>
            html`
              <expandable-list-item ?defaultExtended=${true}>
                <mwc-list-item slot="parent" graphic="icon">
                  <span>${getNameAttribute(ied)}</span>
                  <mwc-icon slot="graphic">developer_board</mwc-icon>
                </mwc-list-item>
                ${this.getGSEControls(ied).map(control =>
                  this.renderGoose(control)
                )}
              </expandable-list-item>
            `
        )}
      </filtered-list>
    </section>`;
  }
```

There is only one thing I do not like about the implementation as is: For proper styling, I needed a `.parent` div that align the parent list item with the toggle button. This however requires reflecting the toggle buttons `on` attribute to the `.parent` div that then does this 

```
.parent:not([on]) ~ .content mwc-list {
   display: none;
}
```

The method `onExpandToggle`  that does the reflection, is ugly although it does what it has to do. 

I am curious about your take on it :)