### PR TITLE
feat(zeroline): add read-only subfuction-editor

### DIFF
--- a/src/zeroline/subfunction-editor.ts
+++ b/src/zeroline/subfunction-editor.ts
@@ -11,10 +11,10 @@ import '../action-pane.js';
 import './subfunction-editor.js';
 import { getChildElementsByTagName } from '../foundation.js';
 
-/** Pane rendering `Function` element with its children */
-@customElement('function-editor')
-export class FunctionEditor extends LitElement {
-  /** The edited `Function` element */
+/** Pane rendering `SubFunction` element with its children */
+@customElement('subfunction-editor')
+export class SubFunctionEditor extends LitElement {
+  /** The edited `SubFunction` element */
   @property({ attribute: false })
   element!: Element;
   @state()
@@ -35,11 +35,7 @@ export class FunctionEditor extends LitElement {
   }
 
   render(): TemplateResult {
-    return html`<action-pane
-      label="${this.header}"
-      icon="functions"
-      secondary
-      highlighted
+    return html`<action-pane label="${this.header}" icon="functions" secondary
       >${this.renderSubFunctions()}</action-pane
     >`;
   }

--- a/test/testfiles/zeroline/functions.scd
+++ b/test/testfiles/zeroline/functions.scd
@@ -7,12 +7,16 @@
 		</History>
 	</Header>
 	<Substation name="AA1" desc="Substation">
-        <Function name="myFunc" desc="myDesc" type="myFuncType"/>
+        <Function name="myFunc" desc="myDesc" type="myFuncType">
+			<SubFunction name="mySubFunc"/>
+		</Function>
 		<VoltageLevel name="E1" desc="Voltage Level" nomFreq="50.0" numPhases="3">
 			<Voltage unit="V" multiplier="k">110.0</Voltage>
             <Function name="voltLvName">
-                <SubFunction name="mySubFunc">
-					<SubFunction name="mySubSubFunction"/>
+                <SubFunction name="mySubFunc" desc="some string" type="some type">
+					<SubFunction name="mySubSubFunction">
+						<SubFunction name="mySubSubSubFunction"/>
+					</SubFunction>
 				</SubFunction> 
             </Function>
 			<Bay name="COUPLING_BAY" desc="Bay">

--- a/test/unit/zeroline/__snapshots__/function-editor.test.snap.js
+++ b/test/unit/zeroline/__snapshots__/function-editor.test.snap.js
@@ -1,0 +1,31 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["web component rendering Function element with complete attribute set and existing children looks like the latest snapshot"] = 
+`<action-pane
+  highlighted=""
+  icon="functions"
+  label="myFunc - myDesc (myFuncType)"
+  secondary=""
+  tabindex="0"
+>
+  <subfunction-editor>
+  </subfunction-editor>
+</action-pane>
+`;
+/* end snapshot web component rendering Function element with complete attribute set and existing children looks like the latest snapshot */
+
+snapshots["web component rendering Function element with missing desc and type attribute looks like the latest snapshot"] = 
+`<action-pane
+  highlighted=""
+  icon="functions"
+  label="voltLvName"
+  secondary=""
+  tabindex="0"
+>
+  <subfunction-editor>
+  </subfunction-editor>
+</action-pane>
+`;
+/* end snapshot web component rendering Function element with missing desc and type attribute looks like the latest snapshot */
+

--- a/test/unit/zeroline/__snapshots__/subfunction-editor.test.snap.js
+++ b/test/unit/zeroline/__snapshots__/subfunction-editor.test.snap.js
@@ -1,0 +1,27 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["web component rendering SubFunction element with complete attribute set and existing children looks like the latest snapshot"] = 
+`<action-pane
+  icon="functions"
+  label="mySubFunc - some string (some type)"
+  secondary=""
+  tabindex="0"
+>
+  <subfunction-editor>
+  </subfunction-editor>
+</action-pane>
+`;
+/* end snapshot web component rendering SubFunction element with complete attribute set and existing children looks like the latest snapshot */
+
+snapshots["web component rendering SubFunction element with missing desc and type attribute looks like the latest snapshot"] = 
+`<action-pane
+  icon="functions"
+  label="mySubFunc"
+  secondary=""
+  tabindex="0"
+>
+</action-pane>
+`;
+/* end snapshot web component rendering SubFunction element with missing desc and type attribute looks like the latest snapshot */
+

--- a/test/unit/zeroline/function-editor.test.ts
+++ b/test/unit/zeroline/function-editor.test.ts
@@ -1,0 +1,47 @@
+import { fixture, html, expect } from '@open-wc/testing';
+
+import '../../../src/zeroline/function-editor.js';
+import { FunctionEditor } from '../../../src/zeroline/function-editor.js';
+
+describe('web component rendering Function element', () => {
+  let element: FunctionEditor;
+  let doc: XMLDocument;
+
+  beforeEach(async () => {
+    doc = await fetch('/test/testfiles/zeroline/functions.scd')
+      .then(response => response.text())
+      .then(str => new DOMParser().parseFromString(str, 'application/xml'));
+  });
+
+  describe('with complete attribute set and existing children', () => {
+    beforeEach(async () => {
+      element = <FunctionEditor>(
+        await fixture(
+          html`<function-editor
+            .element=${doc.querySelector('Function')}
+          ></function-editor>`
+        )
+      );
+    });
+
+    it('looks like the latest snapshot', async () => {
+      await expect(element).shadowDom.to.equalSnapshot();
+    });
+  });
+
+  describe('with missing desc and type attribute', () => {
+    beforeEach(async () => {
+      element = <FunctionEditor>(
+        await fixture(
+          html`<function-editor
+            .element=${doc.querySelector('VoltageLevel Function')}
+          ></function-editor>`
+        )
+      );
+    });
+
+    it('looks like the latest snapshot', async () => {
+      await expect(element).shadowDom.to.equalSnapshot();
+    });
+  });
+});

--- a/test/unit/zeroline/subfunction-editor.test.ts
+++ b/test/unit/zeroline/subfunction-editor.test.ts
@@ -1,0 +1,47 @@
+import { fixture, html, expect } from '@open-wc/testing';
+
+import '../../../src/zeroline/subfunction-editor.js';
+import { SubFunctionEditor } from '../../../src/zeroline/subfunction-editor.js';
+
+describe('web component rendering SubFunction element', () => {
+  let element: SubFunctionEditor;
+  let doc: XMLDocument;
+
+  beforeEach(async () => {
+    doc = await fetch('/test/testfiles/zeroline/functions.scd')
+      .then(response => response.text())
+      .then(str => new DOMParser().parseFromString(str, 'application/xml'));
+  });
+
+  describe('with complete attribute set and existing children', () => {
+    beforeEach(async () => {
+      element = <SubFunctionEditor>(
+        await fixture(
+          html`<subfunction-editor
+            .element=${doc.querySelector('VoltageLevel SubFunction')}
+          ></subfunction-editor>`
+        )
+      );
+    });
+
+    it('looks like the latest snapshot', async () => {
+      await expect(element).shadowDom.to.equalSnapshot();
+    });
+  });
+
+  describe('with missing desc and type attribute', () => {
+    beforeEach(async () => {
+      element = <SubFunctionEditor>(
+        await fixture(
+          html`<subfunction-editor
+            .element=${doc.querySelector('SubFunction')}
+          ></subfunction-editor>`
+        )
+      );
+    });
+
+    it('looks like the latest snapshot', async () => {
+      await expect(element).shadowDom.to.equalSnapshot();
+    });
+  });
+});


### PR DESCRIPTION
The second of the two to render read-only `Function` and `SubFunction` editors within the Substation editor.