### PR TITLE
feat(editors/substation): show read-only `EqFunction` and `SubEqFunction`

### DIFF
--- a/src/editors/substation/bay-editor.ts
+++ b/src/editors/substation/bay-editor.ts
@@ -45,7 +45,7 @@ export class BayEditor extends LitElement {
   element!: Element;
   @property({ type: Boolean })
   readonly = false;
-  /** Wheter `Function` and `SubFunction` are rendered */
+  /** Whether `Function` and `SubFunction` are rendered */
   @property({ type: Boolean })
   showfunctions = false;
 

--- a/src/editors/substation/bay-editor.ts
+++ b/src/editors/substation/bay-editor.ts
@@ -7,6 +7,7 @@ import {
   query,
   TemplateResult,
 } from 'lit-element';
+import { classMap } from 'lit-html/directives/class-map';
 import { translate } from 'lit-translate';
 
 import '@material/mwc-icon-button';
@@ -177,13 +178,19 @@ export class BayEditor extends LitElement {
         >
       </abbr>
       ${this.renderIedContainer()} ${this.renderFunctions()}
-      <div id="ceContainer">
+      <div
+        class="${classMap({
+          content: true,
+          actionicon: !this.showfunctions,
+        })}"
+      >
         ${Array.from(
           getChildElementsByTagName(this.element, 'PowerTransformer')
         ).map(
           pwt =>
             html`<powertransformer-editor
               .element=${pwt}
+              ?showfunctions=${this.showfunctions}
             ></powertransformer-editor>`
         )}
         ${Array.from(
@@ -193,6 +200,7 @@ export class BayEditor extends LitElement {
             html`<conducting-equipment-editor
               .element=${voltageLevel}
               ?readonly=${this.readonly}
+              ?showfunctions=${this.showfunctions}
             ></conducting-equipment-editor>`
         )}
       </div>
@@ -202,12 +210,16 @@ export class BayEditor extends LitElement {
   static styles = css`
     ${styles}
 
-    #ceContainer {
+    .content.actionicon {
       display: grid;
       grid-gap: 12px;
       padding: 12px;
       box-sizing: border-box;
       grid-template-columns: repeat(auto-fit, minmax(64px, auto));
+    }
+
+    conducting-equipment-editor[showfunctions] {
+      margin: 4px 8px 16px;
     }
   `;
 }

--- a/src/editors/substation/conducting-equipment-editor.ts
+++ b/src/editors/substation/conducting-equipment-editor.ts
@@ -9,6 +9,8 @@ import {
 import { translate } from 'lit-translate';
 
 import '@material/mwc-fab';
+import '@material/mwc-icon';
+import '@material/mwc-icon-button';
 
 import '../../action-icon.js';
 import '../../action-pane.js';

--- a/src/editors/substation/conducting-equipment-editor.ts
+++ b/src/editors/substation/conducting-equipment-editor.ts
@@ -6,10 +6,12 @@ import {
   property,
   TemplateResult,
 } from 'lit-element';
+import { translate } from 'lit-translate';
 
 import '@material/mwc-fab';
 
 import '../../action-icon.js';
+import '../../action-pane.js';
 import { startMove, getIcon } from './foundation.js';
 import { newActionEvent, newWizardEvent } from '../../foundation.js';
 import { BayEditor } from './bay-editor.js';
@@ -26,6 +28,9 @@ export class ConductingEquipmentEditor extends LitElement {
   get name(): string {
     return this.element.getAttribute('name') ?? '';
   }
+  /** Wheter `Function` and `SubFunction` are rendered */
+  @property({ type: Boolean })
+  showfunctions = false;
 
   private openEditWizard(): void {
     const wizard = wizards['ConductingEquipment'].edit(this.element);
@@ -50,9 +55,47 @@ export class ConductingEquipmentEditor extends LitElement {
       );
   }
 
-  render(): TemplateResult {
-    return html`<action-icon label="${this.name}">
-      <span slot="icon">${getIcon(this.element)}</span>
+  renderContentPane(): TemplateResult {
+    return html`<mwc-icon slot="icon" style="width:24px;height:24px"
+        >${getIcon(this.element)}</mwc-icon
+      >
+      <abbr slot="action" title="${translate('lnode.tooltip')}">
+        <mwc-icon-button
+          slot="action"
+          mini
+          @click="${() => this.openLNodeWizard()}"
+          icon="account_tree"
+        ></mwc-icon-button>
+      </abbr>
+      <abbr slot="action" title="${translate('edit')}">
+        <mwc-icon-button
+          slot="action"
+          mini
+          icon="edit"
+          @click="${() => this.openEditWizard()}}"
+        ></mwc-icon-button>
+      </abbr>
+      <abbr slot="action" title="${translate('move')}">
+        <mwc-icon-button
+          slot="action"
+          mini
+          @click="${() =>
+            startMove(this, ConductingEquipmentEditor, [BayEditor])}"
+          icon="forward"
+        ></mwc-icon-button>
+      </abbr>
+      <abbr slot="action" title="${translate('remove')}">
+        <mwc-icon-button
+          slot="action"
+          mini
+          icon="delete"
+          @click="${() => this.remove()}}"
+        ></mwc-icon-button>
+      </abbr> `;
+  }
+
+  renderContentIcon(): TemplateResult {
+    return html`<mwc-icon slot="icon">${getIcon(this.element)}</mwc-icon>
       <mwc-fab
         slot="action"
         mini
@@ -77,13 +120,28 @@ export class ConductingEquipmentEditor extends LitElement {
         mini
         icon="delete"
         @click="${() => this.remove()}}"
-      ></mwc-fab>
-    </action-icon>`;
+      ></mwc-fab>`;
+  }
+
+  render(): TemplateResult {
+    if (this.showfunctions)
+      return html`<action-pane label="${this.name}"
+        >${this.renderContentPane()}</action-pane
+      >`;
+
+    return html`<action-icon label="${this.name}"
+      >${this.renderContentIcon()}</action-icon
+    >`;
   }
 
   static styles = css`
     :host(.moving) {
       opacity: 0.3;
+    }
+
+    abbr {
+      text-decoration: none;
+      border-bottom: none;
     }
   `;
 }

--- a/src/editors/substation/conducting-equipment-editor.ts
+++ b/src/editors/substation/conducting-equipment-editor.ts
@@ -30,7 +30,7 @@ export class ConductingEquipmentEditor extends LitElement {
   get name(): string {
     return this.element.getAttribute('name') ?? '';
   }
-  /** Wheter `Function` and `SubFunction` are rendered */
+  /** Whether `EqFunction` and `SubEqFunction` are rendered */
   @property({ type: Boolean })
   showfunctions = false;
 

--- a/src/editors/substation/conducting-equipment-editor.ts
+++ b/src/editors/substation/conducting-equipment-editor.ts
@@ -14,8 +14,13 @@ import '@material/mwc-icon-button';
 
 import '../../action-icon.js';
 import '../../action-pane.js';
+import './eq-function-editor.js';
 import { startMove, getIcon } from './foundation.js';
-import { newActionEvent, newWizardEvent } from '../../foundation.js';
+import {
+  getChildElementsByTagName,
+  newActionEvent,
+  newWizardEvent,
+} from '../../foundation.js';
 import { BayEditor } from './bay-editor.js';
 import { wizards } from '../../wizards/wizard-library.js';
 
@@ -55,6 +60,16 @@ export class ConductingEquipmentEditor extends LitElement {
           },
         })
       );
+  }
+
+  renderEqFunctions(): TemplateResult {
+    if (!this.showfunctions) return html``;
+
+    const eqFunctions = getChildElementsByTagName(this.element, 'EqFunction');
+    return html` ${eqFunctions.map(
+      eqFunction =>
+        html`<eq-function-editor .element=${eqFunction}></eq-function-editor>`
+    )}`;
   }
 
   renderContentPane(): TemplateResult {
@@ -128,7 +143,7 @@ export class ConductingEquipmentEditor extends LitElement {
   render(): TemplateResult {
     if (this.showfunctions)
       return html`<action-pane label="${this.name}"
-        >${this.renderContentPane()}</action-pane
+        >${this.renderContentPane()}${this.renderEqFunctions()}</action-pane
       >`;
 
     return html`<action-icon label="${this.name}"

--- a/src/editors/substation/eq-function-editor.ts
+++ b/src/editors/substation/eq-function-editor.ts
@@ -1,0 +1,35 @@
+import {
+  html,
+  LitElement,
+  TemplateResult,
+  property,
+  customElement,
+  state,
+} from 'lit-element';
+
+import '../../action-pane.js';
+
+/** Pane rendering `Function` element with its children */
+@customElement('eq-function-editor')
+export class EqFunctionEditor extends LitElement {
+  /** The edited `EqFunction` element */
+  @property({ attribute: false })
+  element!: Element;
+  @state()
+  get header(): string {
+    const name = this.element.getAttribute('name');
+    const desc = this.element.getAttribute('desc');
+    const type = this.element.getAttribute('type');
+
+    return `${name}${desc ? ` - ${desc}` : ''}${type ? ` (${type})` : ''}`;
+  }
+
+  render(): TemplateResult {
+    return html`<action-pane
+      label="${this.header}"
+      icon="functions"
+      secondary
+      highlighted
+    ></action-pane>`;
+  }
+}

--- a/src/editors/substation/eq-function-editor.ts
+++ b/src/editors/substation/eq-function-editor.ts
@@ -18,7 +18,7 @@ export class EqFunctionEditor extends LitElement {
   @property({ attribute: false })
   element!: Element;
   @state()
-  get header(): string {
+  private get header(): string {
     const name = this.element.getAttribute('name');
     const desc = this.element.getAttribute('desc');
     const type = this.element.getAttribute('type');
@@ -26,7 +26,7 @@ export class EqFunctionEditor extends LitElement {
     return `${name}${desc ? ` - ${desc}` : ''}${type ? ` (${type})` : ''}`;
   }
 
-  renderEqSubFunctions(): TemplateResult {
+  private renderEqSubFunctions(): TemplateResult {
     const eqSubFunctions = getChildElementsByTagName(
       this.element,
       'EqSubFunction'

--- a/src/editors/substation/eq-sub-function-editor.ts
+++ b/src/editors/substation/eq-sub-function-editor.ts
@@ -17,7 +17,7 @@ export class EqSubFunctionEditor extends LitElement {
   @property({ attribute: false })
   element!: Element;
   @state()
-  get header(): string {
+  private get header(): string {
     const name = this.element.getAttribute('name');
     const desc = this.element.getAttribute('desc');
     const type = this.element.getAttribute('type');
@@ -25,7 +25,7 @@ export class EqSubFunctionEditor extends LitElement {
     return `${name}${desc ? ` - ${desc}` : ''}${type ? ` (${type})` : ''}`;
   }
 
-  renderEqSubFunctions(): TemplateResult {
+  private renderEqSubFunctions(): TemplateResult {
     const eqSubFunctions = getChildElementsByTagName(
       this.element,
       'EqSubFunction'

--- a/src/editors/substation/eq-sub-function-editor.ts
+++ b/src/editors/substation/eq-sub-function-editor.ts
@@ -8,13 +8,12 @@ import {
 } from 'lit-element';
 
 import '../../action-pane.js';
-import './eq-sub-function-editor.js';
 import { getChildElementsByTagName } from '../../foundation.js';
 
-/** Pane rendering `EqFunction` element with its children */
-@customElement('eq-function-editor')
-export class EqFunctionEditor extends LitElement {
-  /** The edited `EqFunction` element */
+/** Pane rendering `EqSubFunction` element with its children */
+@customElement('eq-sub-function-editor')
+export class EqSubFunctionEditor extends LitElement {
+  /** The edited `EqSubFunction` element */
   @property({ attribute: false })
   element!: Element;
   @state()
@@ -40,11 +39,7 @@ export class EqFunctionEditor extends LitElement {
   }
 
   render(): TemplateResult {
-    return html`<action-pane
-      label="${this.header}"
-      icon="functions"
-      secondary
-      highlighted
+    return html`<action-pane label="${this.header}" icon="functions" secondary
       >${this.renderEqSubFunctions()}</action-pane
     >`;
   }

--- a/src/editors/substation/foundation.ts
+++ b/src/editors/substation/foundation.ts
@@ -281,7 +281,7 @@ export const styles = css`
     border-bottom: none;
   }
 
-  #powertransformercontainer {
+  .ptrContent.actionicon {
     display: grid;
     grid-gap: 12px;
     padding: 8px 12px 16px;
@@ -295,5 +295,9 @@ export const styles = css`
     padding: 8px 12px 16px;
     box-sizing: border-box;
     grid-template-columns: repeat(auto-fit, minmax(64px, auto));
+  }
+
+  powertransformer-editor[showfunctions] {
+    margin: 4px 8px 16px;
   }
 `;

--- a/src/editors/substation/function-editor.ts
+++ b/src/editors/substation/function-editor.ts
@@ -8,7 +8,7 @@ import {
 } from 'lit-element';
 
 import '../../action-pane.js';
-import './subfunction-editor.js';
+import './sub-function-editor.js';
 import { getChildElementsByTagName } from '../../foundation.js';
 
 /** Pane rendering `Function` element with its children */
@@ -30,7 +30,9 @@ export class FunctionEditor extends LitElement {
     const subfunctions = getChildElementsByTagName(this.element, 'SubFunction');
     return html` ${subfunctions.map(
       subFunction =>
-        html`<subfunction-editor .element=${subFunction}></subfunction-editor>`
+        html`<sub-function-editor
+          .element=${subFunction}
+        ></sub-function-editor>`
     )}`;
   }
 

--- a/src/editors/substation/function-editor.ts
+++ b/src/editors/substation/function-editor.ts
@@ -18,7 +18,7 @@ export class FunctionEditor extends LitElement {
   @property({ attribute: false })
   element!: Element;
   @state()
-  get header(): string {
+  private get header(): string {
     const name = this.element.getAttribute('name');
     const desc = this.element.getAttribute('desc');
     const type = this.element.getAttribute('type');
@@ -26,7 +26,7 @@ export class FunctionEditor extends LitElement {
     return `${name}${desc ? ` - ${desc}` : ''}${type ? ` (${type})` : ''}`;
   }
 
-  renderSubFunctions(): TemplateResult {
+  private renderSubFunctions(): TemplateResult {
     const subfunctions = getChildElementsByTagName(this.element, 'SubFunction');
     return html` ${subfunctions.map(
       subFunction =>

--- a/src/editors/substation/powertransformer-editor.ts
+++ b/src/editors/substation/powertransformer-editor.ts
@@ -16,7 +16,11 @@ import '../../action-icon.js';
 import '../../action-pane.js';
 import { powerTransformerTwoWindingIcon } from '../../icons/icons.js';
 import { wizards } from '../../wizards/wizard-library.js';
-import { newActionEvent, newWizardEvent } from '../../foundation.js';
+import {
+  getChildElementsByTagName,
+  newActionEvent,
+  newWizardEvent,
+} from '../../foundation.js';
 import { startMove } from './foundation.js';
 import { SubstationEditor } from './substation-editor.js';
 import { BayEditor } from './bay-editor.js';
@@ -59,6 +63,16 @@ export class PowerTransformerEditor extends LitElement {
           },
         })
       );
+  }
+
+  renderEqFunctions(): TemplateResult {
+    if (!this.showfunctions) return html``;
+
+    const eqFunctions = getChildElementsByTagName(this.element, 'EqFunction');
+    return html` ${eqFunctions.map(
+      eqFunction =>
+        html`<eq-function-editor .element=${eqFunction}></eq-function-editor>`
+    )}`;
   }
 
   renderContentPane(): TemplateResult {
@@ -145,7 +159,7 @@ export class PowerTransformerEditor extends LitElement {
   render(): TemplateResult {
     if (this.showfunctions)
       return html`<action-pane label="${this.name}"
-        >${this.renderContentPane()}</action-pane
+        >${this.renderContentPane()}${this.renderEqFunctions()}</action-pane
       > `;
 
     return html`<action-icon label="${this.name}"

--- a/src/editors/substation/powertransformer-editor.ts
+++ b/src/editors/substation/powertransformer-editor.ts
@@ -10,6 +10,7 @@ import { translate } from 'lit-translate';
 
 import '@material/mwc-fab';
 import '@material/mwc-icon';
+import '@material/mwc-icon-button';
 
 import '../../action-icon.js';
 import '../../action-pane.js';

--- a/src/editors/substation/powertransformer-editor.ts
+++ b/src/editors/substation/powertransformer-editor.ts
@@ -34,7 +34,7 @@ export class PowerTransformerEditor extends LitElement {
   get name(): string {
     return this.element.getAttribute('name') ?? 'UNDEFINED';
   }
-  /** Wheter `EqFunction` and `SubEqFunction` are rendered */
+  /** Whether `EqFunction` and `SubEqFunction` are rendered */
   @property({ type: Boolean })
   showfunctions = false;
 

--- a/src/editors/substation/powertransformer-editor.ts
+++ b/src/editors/substation/powertransformer-editor.ts
@@ -6,11 +6,13 @@ import {
   property,
   TemplateResult,
 } from 'lit-element';
+import { translate } from 'lit-translate';
 
 import '@material/mwc-fab';
 import '@material/mwc-icon';
 
 import '../../action-icon.js';
+import '../../action-pane.js';
 import { powerTransformerTwoWindingIcon } from '../../icons/icons.js';
 import { wizards } from '../../wizards/wizard-library.js';
 import { newActionEvent, newWizardEvent } from '../../foundation.js';
@@ -31,6 +33,9 @@ export class PowerTransformerEditor extends LitElement {
   get name(): string {
     return this.element.getAttribute('name') ?? 'UNDEFINED';
   }
+  /** Wheter `EqFunction` and `SubEqFunction` are rendered */
+  @property({ type: Boolean })
+  showfunctions = false;
 
   private openEditWizard(): void {
     const wizard = wizards['PowerTransformer'].edit(this.element);
@@ -55,11 +60,54 @@ export class PowerTransformerEditor extends LitElement {
       );
   }
 
-  render(): TemplateResult {
-    return html`<action-icon
-      label="${this.name}"
-      .icon="${powerTransformerTwoWindingIcon}"
-    >
+  renderContentPane(): TemplateResult {
+    return html`<mwc-icon slot="icon" style="width:24px;height:24px"
+        >${powerTransformerTwoWindingIcon}</mwc-icon
+      >
+      <abbr slot="action" title="${translate('lnode.tooltip')}">
+        <mwc-icon-button
+          slot="action"
+          mini
+          @click="${() => this.openLNodeWizard()}"
+          icon="account_tree"
+        ></mwc-icon-button>
+      </abbr>
+      <abbr slot="action" title="${translate('edit')}">
+        <mwc-icon-button
+          slot="action"
+          mini
+          icon="edit"
+          @click="${() => this.openEditWizard()}}"
+        ></mwc-icon-button>
+      </abbr>
+      <abbr slot="action" title="${translate('move')}">
+        <mwc-icon-button
+          slot="action"
+          mini
+          @click="${() => {
+            startMove(this, PowerTransformerEditor, [
+              SubstationEditor,
+              VoltageLevelEditor,
+              BayEditor,
+            ]);
+          }}"
+          icon="forward"
+        ></mwc-icon-button>
+      </abbr>
+      <abbr slot="action" title="${translate('remove')}">
+        <mwc-icon-button
+          slot="action"
+          mini
+          icon="delete"
+          @click="${() => this.removeElement()}}"
+        ></mwc-icon-button>
+      </abbr> `;
+  }
+
+  renderContentIcon(): TemplateResult {
+    return html`<mwc-icon slot="icon"
+        >${powerTransformerTwoWindingIcon}</mwc-icon
+      >
       <mwc-fab
         slot="action"
         class="edit"
@@ -90,13 +138,28 @@ export class PowerTransformerEditor extends LitElement {
         mini
         @click="${() => this.openLNodeWizard()}"
         icon="account_tree"
-      ></mwc-fab>
-    </action-icon> `;
+      ></mwc-fab>`;
+  }
+
+  render(): TemplateResult {
+    if (this.showfunctions)
+      return html`<action-pane label="${this.name}"
+        >${this.renderContentPane()}</action-pane
+      > `;
+
+    return html`<action-icon label="${this.name}"
+      >${this.renderContentIcon()}</action-icon
+    > `;
   }
 
   static styles = css`
     :host(.moving) {
       opacity: 0.3;
+    }
+
+    abbr {
+      text-decoration: none;
+      border-bottom: none;
     }
   `;
 }

--- a/src/editors/substation/sub-function-editor.ts
+++ b/src/editors/substation/sub-function-editor.ts
@@ -8,11 +8,11 @@ import {
 } from 'lit-element';
 
 import '../../action-pane.js';
-import './subfunction-editor.js';
+import './sub-function-editor.js';
 import { getChildElementsByTagName } from '../../foundation.js';
 
 /** Pane rendering `SubFunction` element with its children */
-@customElement('subfunction-editor')
+@customElement('sub-function-editor')
 export class SubFunctionEditor extends LitElement {
   /** The edited `SubFunction` element */
   @property({ attribute: false })
@@ -30,7 +30,9 @@ export class SubFunctionEditor extends LitElement {
     const subfunctions = getChildElementsByTagName(this.element, 'SubFunction');
     return html` ${subfunctions.map(
       subFunction =>
-        html`<subfunction-editor .element=${subFunction}></subfunction-editor>`
+        html`<sub-function-editor
+          .element=${subFunction}
+        ></sub-function-editor>`
     )}`;
   }
 

--- a/src/editors/substation/sub-function-editor.ts
+++ b/src/editors/substation/sub-function-editor.ts
@@ -18,7 +18,7 @@ export class SubFunctionEditor extends LitElement {
   @property({ attribute: false })
   element!: Element;
   @state()
-  get header(): string {
+  private get header(): string {
     const name = this.element.getAttribute('name');
     const desc = this.element.getAttribute('desc');
     const type = this.element.getAttribute('type');
@@ -26,7 +26,7 @@ export class SubFunctionEditor extends LitElement {
     return `${name}${desc ? ` - ${desc}` : ''}${type ? ` (${type})` : ''}`;
   }
 
-  renderSubFunctions(): TemplateResult {
+  private renderSubFunctions(): TemplateResult {
     const subfunctions = getChildElementsByTagName(this.element, 'SubFunction');
     return html` ${subfunctions.map(
       subFunction =>

--- a/src/editors/substation/substation-editor.ts
+++ b/src/editors/substation/substation-editor.ts
@@ -32,6 +32,7 @@ import {
   startMove,
   styles,
 } from './foundation.js';
+import { classMap } from 'lit-html/directives/class-map';
 
 function childTags(element: Element | null | undefined): SCLTag[] {
   if (!element) return [];
@@ -129,11 +130,17 @@ export class SubstationEditor extends LitElement {
       ) ?? []
     );
     return pwts?.length
-      ? html`<div id="powertransformercontainer">
+      ? html`<div
+          class="${classMap({
+            ptrContent: true,
+            actionicon: !this.showfunctions,
+          })}"
+        >
           ${pwts.map(
             pwt =>
               html`<powertransformer-editor
                 .element=${pwt}
+                ?showfunctions=${this.showfunctions}
               ></powertransformer-editor>`
           )}
         </div>`

--- a/src/editors/substation/substation-editor.ts
+++ b/src/editors/substation/substation-editor.ts
@@ -50,7 +50,7 @@ export class SubstationEditor extends LitElement {
   element!: Element;
   @property({ type: Boolean })
   readonly = false;
-  /** Wheter `Function` and `SubFunction` are rendered */
+  /** Whether `Function` and `SubFunction` are rendered */
   @property({ type: Boolean })
   showfunctions = false;
 

--- a/src/editors/substation/voltage-level-editor.ts
+++ b/src/editors/substation/voltage-level-editor.ts
@@ -7,6 +7,7 @@ import {
   css,
   query,
 } from 'lit-element';
+import { classMap } from 'lit-html/directives/class-map';
 import { translate } from 'lit-translate';
 
 import '@material/mwc-icon-button';
@@ -139,11 +140,17 @@ export class VoltageLevelEditor extends LitElement {
       ) ?? []
     );
     return pwts?.length
-      ? html`<div id="powertransformercontainer">
+      ? html`<div
+          class="${classMap({
+            ptrContent: true,
+            actionicon: !this.showfunctions,
+          })}"
+        >
           ${pwts.map(
             pwt =>
               html`<powertransformer-editor
                 .element=${pwt}
+                ?showfunctions=${this.showfunctions}
               ></powertransformer-editor>`
           )}
         </div>`

--- a/src/editors/substation/voltage-level-editor.ts
+++ b/src/editors/substation/voltage-level-editor.ts
@@ -51,7 +51,7 @@ export class VoltageLevelEditor extends LitElement {
   element!: Element;
   @property({ type: Boolean })
   readonly = false;
-  /** Wheter `Function` and `SubFunction` are rendered */
+  /** Whether `Function` and `SubFunction` are rendered */
   @property({ type: Boolean })
   showfunctions = false;
 

--- a/test/testfiles/zeroline/functions.scd
+++ b/test/testfiles/zeroline/functions.scd
@@ -10,6 +10,7 @@
         <Function name="myFunc" desc="myDesc" type="myFuncType">
 			<SubFunction name="mySubFunc"/>
 		</Function>
+		<PowerTransformer name="myPtr1" type="PTR"/>
 		<VoltageLevel name="E1" desc="Voltage Level" nomFreq="50.0" numPhases="3">
 			<Voltage unit="V" multiplier="k">110.0</Voltage>
             <Function name="voltLvName">
@@ -19,6 +20,7 @@
 					</SubFunction>
 				</SubFunction> 
             </Function>
+			<PowerTransformer name="myPtr2" type="PTR"/>
 			<Bay name="COUPLING_BAY" desc="Bay">
 				<Function name="bayName">
 					<SubFunction name="myBaySubFunc" desc="myDesc" type="myBaySubFuncType"/>
@@ -26,6 +28,7 @@
 				<Function name="bay2Func">
 					<SubFunction name="myBaySubFunc" desc="myDesc" type="myBaySubFuncType"/>
 				</Function>
+				<PowerTransformer name="myPtr3" type="PTR"/>
                 <ConductingEquipment>
                     <EqFunction name="myEqFunc">
                         <EqSubFunction name="myEqSubFunc"/> 

--- a/test/testfiles/zeroline/functions.scd
+++ b/test/testfiles/zeroline/functions.scd
@@ -20,7 +20,11 @@
 					</SubFunction>
 				</SubFunction> 
             </Function>
-			<PowerTransformer name="myPtr2" type="PTR"/>
+			<PowerTransformer name="myPtr2" type="PTR">
+				<EqFunction name="myEqFuncPtr2">
+                    <EqSubFunction name="myEqSubFunc"/> 
+                </EqFunction> 
+			</PowerTransformer>
 			<Bay name="COUPLING_BAY" desc="Bay">
 				<Function name="bayName">
 					<SubFunction name="myBaySubFunc" desc="myDesc" type="myBaySubFuncType"/>
@@ -29,8 +33,23 @@
 					<SubFunction name="myBaySubFunc" desc="myDesc" type="myBaySubFuncType"/>
 				</Function>
 				<PowerTransformer name="myPtr3" type="PTR"/>
-                <ConductingEquipment>
-                    <EqFunction name="myEqFunc">
+                <ConductingEquipment name="QA1" desc="some desc" type="CRB">
+                    <EqFunction name="myEqFuncQA1" desc="funcForQA1" type="eqFuncType">
+                        <EqSubFunction name="myEqSubFunc"/> 
+                    </EqFunction> 
+                </ConductingEquipment>
+				<ConductingEquipment name="QB1" type="DIS">
+                    <EqFunction name="myEqFuncQB1">
+                        <EqSubFunction name="myEqSubFunc"/> 
+                    </EqFunction> 
+                </ConductingEquipment>
+				<ConductingEquipment name="QB1" type="DIS">
+                    <EqFunction name="myEqFuncQB1">
+                        <EqSubFunction name="myEqSubFunc"/> 
+                    </EqFunction> 
+                </ConductingEquipment>
+				<ConductingEquipment name="QC9" type="DIS">
+                    <EqFunction name="myEqFuncQC9">
                         <EqSubFunction name="myEqSubFunc"/> 
                     </EqFunction> 
                 </ConductingEquipment>

--- a/test/testfiles/zeroline/functions.scd
+++ b/test/testfiles/zeroline/functions.scd
@@ -35,7 +35,9 @@
 				<PowerTransformer name="myPtr3" type="PTR"/>
                 <ConductingEquipment name="QA1" desc="some desc" type="CRB">
                     <EqFunction name="myEqFuncQA1" desc="funcForQA1" type="eqFuncType">
-                        <EqSubFunction name="myEqSubFunc"/> 
+                        <EqSubFunction name="myEqSubFunc">
+							<EqSubFunction name="myEqSubSubFunction" desc="my desc" type="sometype"/>
+						</EqSubFunction> 
                     </EqFunction> 
                 </ConductingEquipment>
 				<ConductingEquipment name="QB1" type="DIS">

--- a/test/unit/editors/substation/__snapshots__/bay-editor.test.snap.js
+++ b/test/unit/editors/substation/__snapshots__/bay-editor.test.snap.js
@@ -87,7 +87,7 @@ snapshots["bay-editor looks like the latest snapshot"] =
       </mwc-list-item>
     </mwc-menu>
   </abbr>
-  <div id="ceContainer">
+  <div class="actionicon content">
     <conducting-equipment-editor>
     </conducting-equipment-editor>
     <conducting-equipment-editor>
@@ -189,7 +189,7 @@ snapshots["bay-editor with readonly property looks like the latest snapshot"] =
       </mwc-list-item>
     </mwc-menu>
   </abbr>
-  <div id="ceContainer">
+  <div class="actionicon content">
     <conducting-equipment-editor readonly="">
     </conducting-equipment-editor>
     <conducting-equipment-editor readonly="">
@@ -205,7 +205,7 @@ snapshots["bay-editor with readonly property looks like the latest snapshot"] =
 `;
 /* end snapshot bay-editor with readonly property looks like the latest snapshot */
 
-snapshots["bay-editor with function filter deactivated shows connected Function`s in the Substation looks like the latest snapshot"] = 
+snapshots["bay-editor with function filter deactivated looks like the latest snapshot"] = 
 `<action-pane
   label="COUPLING_BAY - Bay"
   tabindex="0"
@@ -295,11 +295,13 @@ snapshots["bay-editor with function filter deactivated shows connected Function`
   </function-editor>
   <function-editor>
   </function-editor>
-  <div id="ceContainer">
-    <conducting-equipment-editor>
+  <div class="content">
+    <powertransformer-editor showfunctions="">
+    </powertransformer-editor>
+    <conducting-equipment-editor showfunctions="">
     </conducting-equipment-editor>
   </div>
 </action-pane>
 `;
-/* end snapshot bay-editor with function filter deactivated shows connected Function`s in the Substation looks like the latest snapshot */
+/* end snapshot bay-editor with function filter deactivated looks like the latest snapshot */
 

--- a/test/unit/editors/substation/__snapshots__/bay-editor.test.snap.js
+++ b/test/unit/editors/substation/__snapshots__/bay-editor.test.snap.js
@@ -300,6 +300,12 @@ snapshots["bay-editor with function filter deactivated looks like the latest sna
     </powertransformer-editor>
     <conducting-equipment-editor showfunctions="">
     </conducting-equipment-editor>
+    <conducting-equipment-editor showfunctions="">
+    </conducting-equipment-editor>
+    <conducting-equipment-editor showfunctions="">
+    </conducting-equipment-editor>
+    <conducting-equipment-editor showfunctions="">
+    </conducting-equipment-editor>
   </div>
 </action-pane>
 `;

--- a/test/unit/editors/substation/__snapshots__/conducting-equipment-editor.test.snap.js
+++ b/test/unit/editors/substation/__snapshots__/conducting-equipment-editor.test.snap.js
@@ -94,3 +94,63 @@ snapshots["conducting-equipment-editor rendered as action pane looks like the la
 `;
 /* end snapshot conducting-equipment-editor rendered as action pane looks like the latest snapshot */
 
+snapshots["conducting-equipment-editor rendered as action pane with EqFunction children looks like the latest snapshot"] = 
+`<action-pane
+  label="QA1"
+  tabindex="0"
+>
+  <mwc-icon
+    slot="icon"
+    style="width:24px;height:24px"
+  >
+  </mwc-icon>
+  <abbr
+    slot="action"
+    title="[lnode.tooltip]"
+  >
+    <mwc-icon-button
+      icon="account_tree"
+      mini=""
+      slot="action"
+    >
+    </mwc-icon-button>
+  </abbr>
+  <abbr
+    slot="action"
+    title="[edit]"
+  >
+    <mwc-icon-button
+      icon="edit"
+      mini=""
+      slot="action"
+    >
+    </mwc-icon-button>
+  </abbr>
+  <abbr
+    slot="action"
+    title="[move]"
+  >
+    <mwc-icon-button
+      icon="forward"
+      mini=""
+      slot="action"
+    >
+    </mwc-icon-button>
+  </abbr>
+  <abbr
+    slot="action"
+    title="[remove]"
+  >
+    <mwc-icon-button
+      icon="delete"
+      mini=""
+      slot="action"
+    >
+    </mwc-icon-button>
+  </abbr>
+  <eq-function-editor>
+  </eq-function-editor>
+</action-pane>
+`;
+/* end snapshot conducting-equipment-editor rendered as action pane with EqFunction children looks like the latest snapshot */
+

--- a/test/unit/editors/substation/__snapshots__/conducting-equipment-editor.test.snap.js
+++ b/test/unit/editors/substation/__snapshots__/conducting-equipment-editor.test.snap.js
@@ -1,13 +1,13 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["conducting-equipment-editor looks like the latest snapshot"] = 
+snapshots["conducting-equipment-editor rendered as action icon looks like the latest snapshot"] = 
 `<action-icon
   label="QA1"
   tabindex="0"
 >
-  <span slot="icon">
-  </span>
+  <mwc-icon slot="icon">
+  </mwc-icon>
   <mwc-fab
     icon="account_tree"
     mini=""
@@ -34,5 +34,63 @@ snapshots["conducting-equipment-editor looks like the latest snapshot"] =
   </mwc-fab>
 </action-icon>
 `;
-/* end snapshot conducting-equipment-editor looks like the latest snapshot */
+/* end snapshot conducting-equipment-editor rendered as action icon looks like the latest snapshot */
+
+snapshots["conducting-equipment-editor rendered as action pane looks like the latest snapshot"] = 
+`<action-pane
+  label="QA1"
+  tabindex="0"
+>
+  <mwc-icon
+    slot="icon"
+    style="width:24px;height:24px"
+  >
+  </mwc-icon>
+  <abbr
+    slot="action"
+    title="[lnode.tooltip]"
+  >
+    <mwc-icon-button
+      icon="account_tree"
+      mini=""
+      slot="action"
+    >
+    </mwc-icon-button>
+  </abbr>
+  <abbr
+    slot="action"
+    title="[edit]"
+  >
+    <mwc-icon-button
+      icon="edit"
+      mini=""
+      slot="action"
+    >
+    </mwc-icon-button>
+  </abbr>
+  <abbr
+    slot="action"
+    title="[move]"
+  >
+    <mwc-icon-button
+      icon="forward"
+      mini=""
+      slot="action"
+    >
+    </mwc-icon-button>
+  </abbr>
+  <abbr
+    slot="action"
+    title="[remove]"
+  >
+    <mwc-icon-button
+      icon="delete"
+      mini=""
+      slot="action"
+    >
+    </mwc-icon-button>
+  </abbr>
+</action-pane>
+`;
+/* end snapshot conducting-equipment-editor rendered as action pane looks like the latest snapshot */
 

--- a/test/unit/editors/substation/__snapshots__/eq-function-editor.test.snap.js
+++ b/test/unit/editors/substation/__snapshots__/eq-function-editor.test.snap.js
@@ -9,6 +9,8 @@ snapshots["web component rendering EqFunction element with complete attribute se
   secondary=""
   tabindex="0"
 >
+  <eq-sub-function-editor>
+  </eq-sub-function-editor>
 </action-pane>
 `;
 /* end snapshot web component rendering EqFunction element with complete attribute set and existing children looks like the latest snapshot */
@@ -21,6 +23,8 @@ snapshots["web component rendering EqFunction element with missing desc and type
   secondary=""
   tabindex="0"
 >
+  <eq-sub-function-editor>
+  </eq-sub-function-editor>
 </action-pane>
 `;
 /* end snapshot web component rendering EqFunction element with missing desc and type attribute looks like the latest snapshot */

--- a/test/unit/editors/substation/__snapshots__/eq-function-editor.test.snap.js
+++ b/test/unit/editors/substation/__snapshots__/eq-function-editor.test.snap.js
@@ -1,0 +1,27 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["web component rendering EqFunction element with complete attribute set and existing children looks like the latest snapshot"] = 
+`<action-pane
+  highlighted=""
+  icon="functions"
+  label="myEqFuncQA1 - funcForQA1 (eqFuncType)"
+  secondary=""
+  tabindex="0"
+>
+</action-pane>
+`;
+/* end snapshot web component rendering EqFunction element with complete attribute set and existing children looks like the latest snapshot */
+
+snapshots["web component rendering EqFunction element with missing desc and type attribute looks like the latest snapshot"] = 
+`<action-pane
+  highlighted=""
+  icon="functions"
+  label="myEqFuncPtr2"
+  secondary=""
+  tabindex="0"
+>
+</action-pane>
+`;
+/* end snapshot web component rendering EqFunction element with missing desc and type attribute looks like the latest snapshot */
+

--- a/test/unit/editors/substation/__snapshots__/eq-sub-function-editor.test.snap.js
+++ b/test/unit/editors/substation/__snapshots__/eq-sub-function-editor.test.snap.js
@@ -1,0 +1,27 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["web component rendering EqSubFunction element with complete attribute set and existing children looks like the latest snapshot"] = 
+`<action-pane
+  icon="functions"
+  label="myEqSubSubFunction - my desc (sometype)"
+  secondary=""
+  tabindex="0"
+>
+</action-pane>
+`;
+/* end snapshot web component rendering EqSubFunction element with complete attribute set and existing children looks like the latest snapshot */
+
+snapshots["web component rendering EqSubFunction element with missing desc and type attribute looks like the latest snapshot"] = 
+`<action-pane
+  icon="functions"
+  label="myEqSubFunc"
+  secondary=""
+  tabindex="0"
+>
+  <eq-sub-function-editor>
+  </eq-sub-function-editor>
+</action-pane>
+`;
+/* end snapshot web component rendering EqSubFunction element with missing desc and type attribute looks like the latest snapshot */
+

--- a/test/unit/editors/substation/__snapshots__/function-editor.test.snap.js
+++ b/test/unit/editors/substation/__snapshots__/function-editor.test.snap.js
@@ -9,8 +9,8 @@ snapshots["web component rendering Function element with complete attribute set 
   secondary=""
   tabindex="0"
 >
-  <subfunction-editor>
-  </subfunction-editor>
+  <sub-function-editor>
+  </sub-function-editor>
 </action-pane>
 `;
 /* end snapshot web component rendering Function element with complete attribute set and existing children looks like the latest snapshot */
@@ -23,8 +23,8 @@ snapshots["web component rendering Function element with missing desc and type a
   secondary=""
   tabindex="0"
 >
-  <subfunction-editor>
-  </subfunction-editor>
+  <sub-function-editor>
+  </sub-function-editor>
 </action-pane>
 `;
 /* end snapshot web component rendering Function element with missing desc and type attribute looks like the latest snapshot */

--- a/test/unit/editors/substation/__snapshots__/powertransformer-editor.test.snap.js
+++ b/test/unit/editors/substation/__snapshots__/powertransformer-editor.test.snap.js
@@ -95,3 +95,63 @@ snapshots["powertransformer-editor rendered as action pane looks like the latest
 `;
 /* end snapshot powertransformer-editor rendered as action pane looks like the latest snapshot */
 
+snapshots["powertransformer-editor rendered as action pane with EqFunction childrend looks like the latest snapshot"] = 
+`<action-pane
+  label="myPtr2"
+  tabindex="0"
+>
+  <mwc-icon
+    slot="icon"
+    style="width:24px;height:24px"
+  >
+  </mwc-icon>
+  <abbr
+    slot="action"
+    title="[lnode.tooltip]"
+  >
+    <mwc-icon-button
+      icon="account_tree"
+      mini=""
+      slot="action"
+    >
+    </mwc-icon-button>
+  </abbr>
+  <abbr
+    slot="action"
+    title="[edit]"
+  >
+    <mwc-icon-button
+      icon="edit"
+      mini=""
+      slot="action"
+    >
+    </mwc-icon-button>
+  </abbr>
+  <abbr
+    slot="action"
+    title="[move]"
+  >
+    <mwc-icon-button
+      icon="forward"
+      mini=""
+      slot="action"
+    >
+    </mwc-icon-button>
+  </abbr>
+  <abbr
+    slot="action"
+    title="[remove]"
+  >
+    <mwc-icon-button
+      icon="delete"
+      mini=""
+      slot="action"
+    >
+    </mwc-icon-button>
+  </abbr>
+  <eq-function-editor>
+  </eq-function-editor>
+</action-pane>
+`;
+/* end snapshot powertransformer-editor rendered as action pane with EqFunction childrend looks like the latest snapshot */
+

--- a/test/unit/editors/substation/__snapshots__/powertransformer-editor.test.snap.js
+++ b/test/unit/editors/substation/__snapshots__/powertransformer-editor.test.snap.js
@@ -1,11 +1,13 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["powertransformer-editor looks like the latest snapshot"] = 
+snapshots["powertransformer-editor rendered as action icon looks like the latest snapshot"] = 
 `<action-icon
   label="TA1"
   tabindex="0"
 >
+  <mwc-icon slot="icon">
+  </mwc-icon>
   <mwc-fab
     class="edit"
     icon="edit"
@@ -33,5 +35,63 @@ snapshots["powertransformer-editor looks like the latest snapshot"] =
   </mwc-fab>
 </action-icon>
 `;
-/* end snapshot powertransformer-editor looks like the latest snapshot */
+/* end snapshot powertransformer-editor rendered as action icon looks like the latest snapshot */
+
+snapshots["powertransformer-editor rendered as action pane looks like the latest snapshot"] = 
+`<action-pane
+  label="TA1"
+  tabindex="0"
+>
+  <mwc-icon
+    slot="icon"
+    style="width:24px;height:24px"
+  >
+  </mwc-icon>
+  <abbr
+    slot="action"
+    title="[lnode.tooltip]"
+  >
+    <mwc-icon-button
+      icon="account_tree"
+      mini=""
+      slot="action"
+    >
+    </mwc-icon-button>
+  </abbr>
+  <abbr
+    slot="action"
+    title="[edit]"
+  >
+    <mwc-icon-button
+      icon="edit"
+      mini=""
+      slot="action"
+    >
+    </mwc-icon-button>
+  </abbr>
+  <abbr
+    slot="action"
+    title="[move]"
+  >
+    <mwc-icon-button
+      icon="forward"
+      mini=""
+      slot="action"
+    >
+    </mwc-icon-button>
+  </abbr>
+  <abbr
+    slot="action"
+    title="[remove]"
+  >
+    <mwc-icon-button
+      icon="delete"
+      mini=""
+      slot="action"
+    >
+    </mwc-icon-button>
+  </abbr>
+</action-pane>
+`;
+/* end snapshot powertransformer-editor rendered as action pane looks like the latest snapshot */
 

--- a/test/unit/editors/substation/__snapshots__/sub-function-editor.test.snap.js
+++ b/test/unit/editors/substation/__snapshots__/sub-function-editor.test.snap.js
@@ -8,8 +8,8 @@ snapshots["web component rendering SubFunction element with complete attribute s
   secondary=""
   tabindex="0"
 >
-  <subfunction-editor>
-  </subfunction-editor>
+  <sub-function-editor>
+  </sub-function-editor>
 </action-pane>
 `;
 /* end snapshot web component rendering SubFunction element with complete attribute set and existing children looks like the latest snapshot */

--- a/test/unit/editors/substation/__snapshots__/substation-editor.test.snap.js
+++ b/test/unit/editors/substation/__snapshots__/substation-editor.test.snap.js
@@ -189,7 +189,7 @@ snapshots["substation-editor with readonly property looks like the latest snapsh
 `;
 /* end snapshot substation-editor with readonly property looks like the latest snapshot */
 
-snapshots["substation-editor with function filter deactivated shows connected Function`s in the Substation looks like the latest snapshot"] = 
+snapshots["substation-editor with function filter deactivated looks like the latest snapshot"] = 
 `<action-pane
   label="AA1 - Substation"
   tabindex="0"
@@ -277,9 +277,13 @@ snapshots["substation-editor with function filter deactivated shows connected Fu
   </abbr>
   <function-editor>
   </function-editor>
+  <div class="ptrContent">
+    <powertransformer-editor showfunctions="">
+    </powertransformer-editor>
+  </div>
   <voltage-level-editor showfunctions="">
   </voltage-level-editor>
 </action-pane>
 `;
-/* end snapshot substation-editor with function filter deactivated shows connected Function`s in the Substation looks like the latest snapshot */
+/* end snapshot substation-editor with function filter deactivated looks like the latest snapshot */
 

--- a/test/unit/editors/substation/__snapshots__/voltage-level-editor.test.snap.js
+++ b/test/unit/editors/substation/__snapshots__/voltage-level-editor.test.snap.js
@@ -195,7 +195,7 @@ snapshots["voltage-level-editor with readonly property looks like the latest sna
 `;
 /* end snapshot voltage-level-editor with readonly property looks like the latest snapshot */
 
-snapshots["voltage-level-editor with function filter deactivated shows connected Function`s in the Substation looks like the latest snapshot"] = 
+snapshots["voltage-level-editor with function filter deactivated looks like the latest snapshot"] = 
 `<action-pane
   label="E1 - Voltage Level
     (110.0 kV)"
@@ -284,11 +284,15 @@ snapshots["voltage-level-editor with function filter deactivated shows connected
   </abbr>
   <function-editor>
   </function-editor>
+  <div class="ptrContent">
+    <powertransformer-editor showfunctions="">
+    </powertransformer-editor>
+  </div>
   <div id="bayContainer">
     <bay-editor showfunctions="">
     </bay-editor>
   </div>
 </action-pane>
 `;
-/* end snapshot voltage-level-editor with function filter deactivated shows connected Function`s in the Substation looks like the latest snapshot */
+/* end snapshot voltage-level-editor with function filter deactivated looks like the latest snapshot */
 

--- a/test/unit/editors/substation/bay-editor.test.ts
+++ b/test/unit/editors/substation/bay-editor.test.ts
@@ -32,7 +32,7 @@ describe('bay-editor', () => {
     });
   });
 
-  describe('with function filter deactivated shows connected Function`s in the Substation', () => {
+  describe('with function filter deactivated', () => {
     beforeEach(async () => {
       doc = await fetch('/test/testfiles/zeroline/functions.scd')
         .then(response => response.text())

--- a/test/unit/editors/substation/conducting-equipment-editor.test.ts
+++ b/test/unit/editors/substation/conducting-equipment-editor.test.ts
@@ -98,6 +98,22 @@ describe('conducting-equipment-editor', () => {
       await expect(element).shadowDom.to.equalSnapshot();
     });
 
+    describe('with EqFunction children', () => {
+      beforeEach(async () => {
+        const doc = await fetch('/test/testfiles/zeroline/functions.scd')
+          .then(response => response.text())
+          .then(str => new DOMParser().parseFromString(str, 'application/xml'));
+
+        element.element = doc.querySelector(
+          'Bay[name="COUPLING_BAY"] > ConductingEquipment[name="QA1"]'
+        )!;
+        await element.requestUpdate();
+      });
+
+      it('looks like the latest snapshot', async () =>
+        await expect(element).shadowDom.to.equalSnapshot());
+    });
+
     it('renders empty string in case ConductingEquipment name attribute is missing', async () => {
       const condEq = validSCL.querySelector('ConductingEquipment');
       condEq?.removeAttribute('name');

--- a/test/unit/editors/substation/conducting-equipment-editor.test.ts
+++ b/test/unit/editors/substation/conducting-equipment-editor.test.ts
@@ -31,49 +31,119 @@ describe('conducting-equipment-editor', () => {
     window.addEventListener('editor-action', actionEvent);
   });
 
-  it('looks like the latest snapshot', async () => {
-    await expect(element).shadowDom.to.equalSnapshot();
+  describe('rendered as action icon', () => {
+    beforeEach(async () => {
+      element.showfunctions = false;
+      await element.requestUpdate();
+    });
+
+    it('looks like the latest snapshot', async () => {
+      await expect(element).shadowDom.to.equalSnapshot();
+    });
+
+    it('renders empty string in case ConductingEquipment name attribute is missing', async () => {
+      const condEq = validSCL.querySelector('ConductingEquipment');
+      condEq?.removeAttribute('name');
+      await element.requestUpdate();
+
+      expect(element).to.have.property('name', '');
+    });
+
+    it('triggers edit wizard for LNode element on action button click', async () => {
+      (<HTMLElement>(
+        element.shadowRoot?.querySelector('mwc-fab[icon="account_tree"]')
+      )).click();
+
+      await element.requestUpdate();
+
+      expect(wizardEvent).to.have.be.calledOnce;
+      expect(wizardEvent.args[0][0].detail.wizard()[0].title).to.contain(
+        'lnode'
+      );
+    });
+
+    it('triggers edit wizard for ConductingEquipment element on action button click', async () => {
+      (<HTMLElement>(
+        element.shadowRoot?.querySelector('mwc-fab[icon="edit"]')
+      )).click();
+
+      await element.requestUpdate();
+
+      expect(wizardEvent).to.have.be.calledOnce;
+      expect(wizardEvent.args[0][0].detail.wizard()[0].title).to.contain(
+        'edit'
+      );
+    });
+
+    it('triggers remove action on action button click', async () => {
+      (<HTMLElement>(
+        element.shadowRoot?.querySelector('mwc-fab[icon="delete"]')
+      )).click();
+
+      await element.requestUpdate();
+
+      expect(wizardEvent).to.not.have.been.called;
+      expect(actionEvent).to.have.been.calledOnce;
+      expect(actionEvent.args[0][0].detail.action).to.satisfy(isDelete);
+    });
   });
 
-  it('renders empty string in case ConductingEquipment name attribute is missing', async () => {
-    const condEq = validSCL.querySelector('ConductingEquipment');
-    condEq?.removeAttribute('name');
-    await element.requestUpdate();
+  describe('rendered as action pane', () => {
+    beforeEach(async () => {
+      element.showfunctions = true;
+      await element.requestUpdate();
+    });
 
-    expect(element).to.have.property('name', '');
-  });
+    it('looks like the latest snapshot', async () => {
+      await expect(element).shadowDom.to.equalSnapshot();
+    });
 
-  it('triggers edit wizard for LNode element on action button click', async () => {
-    (<HTMLElement>(
-      element.shadowRoot?.querySelector('mwc-fab[icon="account_tree"]')
-    )).click();
+    it('renders empty string in case ConductingEquipment name attribute is missing', async () => {
+      const condEq = validSCL.querySelector('ConductingEquipment');
+      condEq?.removeAttribute('name');
+      await element.requestUpdate();
 
-    await element.requestUpdate();
+      expect(element).to.have.property('name', '');
+    });
 
-    expect(wizardEvent).to.have.be.calledOnce;
-    expect(wizardEvent.args[0][0].detail.wizard()[0].title).to.contain('lnode');
-  });
+    it('triggers edit wizard for LNode element on action button click', async () => {
+      (<HTMLElement>(
+        element.shadowRoot?.querySelector(
+          'mwc-icon-button[icon="account_tree"]'
+        )
+      )).click();
 
-  it('triggers edit wizard for ConductingEquipment element on action button click', async () => {
-    (<HTMLElement>(
-      element.shadowRoot?.querySelector('mwc-fab[icon="edit"]')
-    )).click();
+      await element.requestUpdate();
 
-    await element.requestUpdate();
+      expect(wizardEvent).to.have.be.calledOnce;
+      expect(wizardEvent.args[0][0].detail.wizard()[0].title).to.contain(
+        'lnode'
+      );
+    });
 
-    expect(wizardEvent).to.have.be.calledOnce;
-    expect(wizardEvent.args[0][0].detail.wizard()[0].title).to.contain('edit');
-  });
+    it('triggers edit wizard for ConductingEquipment element on action button click', async () => {
+      (<HTMLElement>(
+        element.shadowRoot?.querySelector('mwc-icon-button[icon="edit"]')
+      )).click();
 
-  it('triggers remove action on action button click', async () => {
-    (<HTMLElement>(
-      element.shadowRoot?.querySelector('mwc-fab[icon="delete"]')
-    )).click();
+      await element.requestUpdate();
 
-    await element.requestUpdate();
+      expect(wizardEvent).to.have.be.calledOnce;
+      expect(wizardEvent.args[0][0].detail.wizard()[0].title).to.contain(
+        'edit'
+      );
+    });
 
-    expect(wizardEvent).to.not.have.been.called;
-    expect(actionEvent).to.have.been.calledOnce;
-    expect(actionEvent.args[0][0].detail.action).to.satisfy(isDelete);
+    it('triggers remove action on action button click', async () => {
+      (<HTMLElement>(
+        element.shadowRoot?.querySelector('mwc-icon-button[icon="delete"]')
+      )).click();
+
+      await element.requestUpdate();
+
+      expect(wizardEvent).to.not.have.been.called;
+      expect(actionEvent).to.have.been.calledOnce;
+      expect(actionEvent.args[0][0].detail.action).to.satisfy(isDelete);
+    });
   });
 });

--- a/test/unit/editors/substation/eq-function-editor.test.ts
+++ b/test/unit/editors/substation/eq-function-editor.test.ts
@@ -1,0 +1,45 @@
+import { fixture, html, expect } from '@open-wc/testing';
+
+import '../../../../src/editors/substation/eq-function-editor.js';
+import { EqFunctionEditor } from '../../../../src/editors/substation/eq-function-editor.js';
+
+describe('web component rendering EqFunction element', () => {
+  let element: EqFunctionEditor;
+  let doc: XMLDocument;
+
+  beforeEach(async () => {
+    doc = await fetch('/test/testfiles/zeroline/functions.scd')
+      .then(response => response.text())
+      .then(str => new DOMParser().parseFromString(str, 'application/xml'));
+  });
+
+  describe('with complete attribute set and existing children', () => {
+    beforeEach(async () => {
+      element = <EqFunctionEditor>(
+        await fixture(
+          html`<eq-function-editor
+            .element=${doc.querySelector('ConductingEquipment EqFunction')}
+          ></eq-function-editor>`
+        )
+      );
+    });
+
+    it('looks like the latest snapshot', async () =>
+      await expect(element).shadowDom.to.equalSnapshot());
+  });
+
+  describe('with missing desc and type attribute', () => {
+    beforeEach(async () => {
+      element = <EqFunctionEditor>(
+        await fixture(
+          html`<eq-function-editor
+            .element=${doc.querySelector('EqFunction')}
+          ></eq-function-editor>`
+        )
+      );
+    });
+
+    it('looks like the latest snapshot', async () =>
+      await expect(element).shadowDom.to.equalSnapshot());
+  });
+});

--- a/test/unit/editors/substation/eq-sub-function-editor.test.ts
+++ b/test/unit/editors/substation/eq-sub-function-editor.test.ts
@@ -1,0 +1,45 @@
+import { fixture, html, expect } from '@open-wc/testing';
+
+import '../../../../src/editors/substation/eq-sub-function-editor.js';
+import { EqSubFunctionEditor } from '../../../../src/editors/substation/eq-sub-function-editor.js';
+
+describe('web component rendering EqSubFunction element', () => {
+  let element: EqSubFunctionEditor;
+  let doc: XMLDocument;
+
+  beforeEach(async () => {
+    doc = await fetch('/test/testfiles/zeroline/functions.scd')
+      .then(response => response.text())
+      .then(str => new DOMParser().parseFromString(str, 'application/xml'));
+  });
+
+  describe('with complete attribute set and existing children', () => {
+    beforeEach(async () => {
+      element = <EqSubFunctionEditor>(
+        await fixture(
+          html`<eq-sub-function-editor
+            .element=${doc.querySelector('EqSubFunction > EqSubFunction')}
+          ></eq-sub-function-editor>`
+        )
+      );
+    });
+
+    it('looks like the latest snapshot', async () =>
+      await expect(element).shadowDom.to.equalSnapshot());
+  });
+
+  describe('with missing desc and type attribute', () => {
+    beforeEach(async () => {
+      element = <EqSubFunctionEditor>(
+        await fixture(
+          html`<eq-sub-function-editor
+            .element=${doc.querySelector('ConductingEquipment EqSubFunction')}
+          ></eq-sub-function-editor>`
+        )
+      );
+    });
+
+    it('looks like the latest snapshot', async () =>
+      await expect(element).shadowDom.to.equalSnapshot());
+  });
+});

--- a/test/unit/editors/substation/powertransformer-editor.test.ts
+++ b/test/unit/editors/substation/powertransformer-editor.test.ts
@@ -91,6 +91,20 @@ describe('powertransformer-editor', () => {
       await expect(element).shadowDom.to.equalSnapshot();
     });
 
+    describe('with EqFunction childrend', () => {
+      beforeEach(async () => {
+        const doc = await fetch('/test/testfiles/zeroline/functions.scd')
+          .then(response => response.text())
+          .then(str => new DOMParser().parseFromString(str, 'application/xml'));
+
+        element.element = doc.querySelector('PowerTransformer[name="myPtr2"]')!;
+        await element.requestUpdate();
+      });
+
+      it('looks like the latest snapshot', async () =>
+        await expect(element).shadowDom.to.equalSnapshot());
+    });
+
     it('triggers edit wizard for Linking LNode element on action button click', async () => {
       (<HTMLElement>(
         element.shadowRoot?.querySelector(

--- a/test/unit/editors/substation/powertransformer-editor.test.ts
+++ b/test/unit/editors/substation/powertransformer-editor.test.ts
@@ -32,41 +32,103 @@ describe('powertransformer-editor', () => {
     window.addEventListener('editor-action', actionEvent);
   });
 
-  it('looks like the latest snapshot', async () => {
-    await expect(element).shadowDom.to.equalSnapshot();
+  describe('rendered as action icon', () => {
+    beforeEach(async () => {
+      element.showfunctions = false;
+      await element.requestUpdate();
+    });
+
+    it('looks like the latest snapshot', async () => {
+      await expect(element).shadowDom.to.equalSnapshot();
+    });
+
+    it('triggers edit wizard for Linking LNode element on action button click', async () => {
+      (<HTMLElement>(
+        element.shadowRoot?.querySelector('mwc-fab[icon="account_tree"]')
+      )).click();
+
+      await element.requestUpdate();
+
+      expect(wizardEvent).to.have.be.calledOnce;
+      expect(wizardEvent.args[0][0].detail.wizard()[0].title).to.contain(
+        'lnode'
+      );
+    });
+
+    it('triggers edit wizard for PowerTransformer element on action button click', async () => {
+      (<HTMLElement>(
+        element.shadowRoot?.querySelector('mwc-fab[icon="edit"]')
+      )).click();
+
+      await element.requestUpdate();
+
+      expect(wizardEvent).to.have.be.calledOnce;
+      expect(wizardEvent.args[0][0].detail.wizard()[0].title).to.contain(
+        'edit'
+      );
+    });
+
+    it('triggers remove powertransformer action on action button click', async () => {
+      (<HTMLElement>(
+        element.shadowRoot?.querySelector('mwc-fab[icon="delete"]')
+      )).click();
+
+      await element.requestUpdate();
+
+      expect(wizardEvent).to.not.have.been.called;
+      expect(actionEvent).to.have.been.calledOnce;
+      expect(actionEvent.args[0][0].detail.action).to.satisfy(isDelete);
+    });
   });
 
-  it('triggers edit wizard for Linking LNode element on action button click', async () => {
-    (<HTMLElement>(
-      element.shadowRoot?.querySelector('mwc-fab[icon="account_tree"]')
-    )).click();
+  describe('rendered as action pane', () => {
+    beforeEach(async () => {
+      element.showfunctions = true;
+      await element.requestUpdate();
+    });
 
-    await element.requestUpdate();
+    it('looks like the latest snapshot', async () => {
+      await expect(element).shadowDom.to.equalSnapshot();
+    });
 
-    expect(wizardEvent).to.have.be.calledOnce;
-    expect(wizardEvent.args[0][0].detail.wizard()[0].title).to.contain('lnode');
-  });
+    it('triggers edit wizard for Linking LNode element on action button click', async () => {
+      (<HTMLElement>(
+        element.shadowRoot?.querySelector(
+          'mwc-icon-button[icon="account_tree"]'
+        )
+      )).click();
 
-  it('triggers edit wizard for PowerTransformer element on action button click', async () => {
-    (<HTMLElement>(
-      element.shadowRoot?.querySelector('mwc-fab[icon="edit"]')
-    )).click();
+      await element.requestUpdate();
 
-    await element.requestUpdate();
+      expect(wizardEvent).to.have.be.calledOnce;
+      expect(wizardEvent.args[0][0].detail.wizard()[0].title).to.contain(
+        'lnode'
+      );
+    });
 
-    expect(wizardEvent).to.have.be.calledOnce;
-    expect(wizardEvent.args[0][0].detail.wizard()[0].title).to.contain('edit');
-  });
+    it('triggers edit wizard for PowerTransformer element on action button click', async () => {
+      (<HTMLElement>(
+        element.shadowRoot?.querySelector('mwc-icon-button[icon="edit"]')
+      )).click();
 
-  it('triggers remove powertransformer action on action button click', async () => {
-    (<HTMLElement>(
-      element.shadowRoot?.querySelector('mwc-fab[icon="delete"]')
-    )).click();
+      await element.requestUpdate();
 
-    await element.requestUpdate();
+      expect(wizardEvent).to.have.be.calledOnce;
+      expect(wizardEvent.args[0][0].detail.wizard()[0].title).to.contain(
+        'edit'
+      );
+    });
 
-    expect(wizardEvent).to.not.have.been.called;
-    expect(actionEvent).to.have.been.calledOnce;
-    expect(actionEvent.args[0][0].detail.action).to.satisfy(isDelete);
+    it('triggers remove powertransformer action on action button click', async () => {
+      (<HTMLElement>(
+        element.shadowRoot?.querySelector('mwc-icon-button[icon="delete"]')
+      )).click();
+
+      await element.requestUpdate();
+
+      expect(wizardEvent).to.not.have.been.called;
+      expect(actionEvent).to.have.been.calledOnce;
+      expect(actionEvent.args[0][0].detail.action).to.satisfy(isDelete);
+    });
   });
 });

--- a/test/unit/editors/substation/sub-function-editor.test.ts
+++ b/test/unit/editors/substation/sub-function-editor.test.ts
@@ -1,7 +1,7 @@
 import { fixture, html, expect } from '@open-wc/testing';
 
-import '../../../../src/editors/substation/subfunction-editor.js';
-import { SubFunctionEditor } from '../../../../src/editors/substation/subfunction-editor.js';
+import '../../../../src/editors/substation/sub-function-editor.js';
+import { SubFunctionEditor } from '../../../../src/editors/substation/sub-function-editor.js';
 
 describe('web component rendering SubFunction element', () => {
   let element: SubFunctionEditor;
@@ -17,9 +17,9 @@ describe('web component rendering SubFunction element', () => {
     beforeEach(async () => {
       element = <SubFunctionEditor>(
         await fixture(
-          html`<subfunction-editor
+          html`<sub-function-editor
             .element=${doc.querySelector('VoltageLevel SubFunction')}
-          ></subfunction-editor>`
+          ></sub-function-editor>`
         )
       );
     });
@@ -33,9 +33,9 @@ describe('web component rendering SubFunction element', () => {
     beforeEach(async () => {
       element = <SubFunctionEditor>(
         await fixture(
-          html`<subfunction-editor
+          html`<sub-function-editor
             .element=${doc.querySelector('SubFunction')}
-          ></subfunction-editor>`
+          ></sub-function-editor>`
         )
       );
     });

--- a/test/unit/editors/substation/substation-editor.test.ts
+++ b/test/unit/editors/substation/substation-editor.test.ts
@@ -30,7 +30,7 @@ describe('substation-editor', () => {
     });
   });
 
-  describe('with function filter deactivated shows connected Function`s in the Substation', () => {
+  describe('with function filter deactivated', () => {
     beforeEach(async () => {
       doc = await fetch('/test/testfiles/zeroline/functions.scd')
         .then(response => response.text())

--- a/test/unit/editors/substation/voltage-level-editor.test.ts
+++ b/test/unit/editors/substation/voltage-level-editor.test.ts
@@ -34,7 +34,7 @@ describe('voltage-level-editor', () => {
     });
   });
 
-  describe('with function filter deactivated shows connected Function`s in the Substation', () => {
+  describe('with function filter deactivated', () => {
     beforeEach(async () => {
       doc = await fetch('/test/testfiles/zeroline/functions.scd')
         .then(response => response.text())


### PR DESCRIPTION
The first of three requests that cover the issue #707 
1. ~~transform CondunctingEquipment and PowerTransformer to action-pane on function filter disabled~~
2. ~~show `EqFunction` element within ConductingEquipment and PowerTransformer~~
3. ~~show `EqSubFunction` within `EqFunction`~~