### PR TITLE
feat(editors/cleanup) Provide appearing/disappearing edit button on hover

### DIFF
--- a/src/editors/cleanup/control-blocks-container.ts
+++ b/src/editors/cleanup/control-blocks-container.ts
@@ -172,6 +172,18 @@ export class CleanupControlBlocks extends LitElement {
       </span>
       <span>
         <mwc-icon-button
+          label="warning"
+          icon="warning_amber"
+          class="cautionItem"
+          title="${translate(
+            'cleanup.unreferencedControls.addressDefinitionTooltip'
+          )}"
+          ?disabled="${!(getCommAddress(controlBlock) !== null)}"
+        >
+        </mwc-icon-button>
+      </span>
+      <span>
+        <mwc-icon-button
           label="Edit"
           icon="edit"
           class="editItem"
@@ -195,18 +207,6 @@ export class CleanupControlBlocks extends LitElement {
             }
           }}
         ></mwc-icon-button>
-      </span>
-      <span>
-        <mwc-icon-button
-          label="warning"
-          icon="warning_amber"
-          class="cautionItem"
-          title="${translate(
-            'cleanup.unreferencedControls.addressDefinitionTooltip'
-          )}"
-          ?disabled="${!(getCommAddress(controlBlock) !== null)}"
-        >
-        </mwc-icon-button>
       </span>
       <span slot="secondary"
         >${controlBlock.tagName} -
@@ -350,6 +350,17 @@ export class CleanupControlBlocks extends LitElement {
     .editItem,
     .cautionItem {
       --mdc-icon-size: 16px;
+    }
+
+    .editItem {
+      visibility: hidden;
+      opacity: 0;
+    }
+
+    .cleanupListItem:hover .editItem {
+      visibility: visible;
+      opacity: 1;
+      transition: visibility 0s, opacity 0.5s linear;
     }
 
     .cautionItem {

--- a/src/editors/cleanup/datasets-container.ts
+++ b/src/editors/cleanup/datasets-container.ts
@@ -206,6 +206,17 @@ export class CleanupDatasets extends LitElement {
       --mdc-icon-size: 16px;
     }
 
+    .editItem {
+      visibility: hidden;
+      opacity: 0;
+    }
+
+    .checkListItem:hover .editItem {
+      visibility: visible;
+      opacity: 1;
+      transition: visibility 0s, opacity 0.5s linear;
+    }
+
     .cleanupDeleteButton {
       float: right;
     }

--- a/test/unit/editors/cleanup/__snapshots__/control-blocks-container.test.snap.js
+++ b/test/unit/editors/cleanup/__snapshots__/control-blocks-container.test.snap.js
@@ -134,19 +134,19 @@ snapshots["Cleanup: Control Blocks Container With a test file loaded looks like 
         </span>
         <span>
           <mwc-icon-button
-            class="editItem"
-            icon="edit"
-            label="Edit"
-          >
-          </mwc-icon-button>
-        </span>
-        <span>
-          <mwc-icon-button
             class="cautionItem"
             disabled=""
             icon="warning_amber"
             label="warning"
             title="[cleanup.unreferencedControls.addressDefinitionTooltip]"
+          >
+          </mwc-icon-button>
+        </span>
+        <span>
+          <mwc-icon-button
+            class="editItem"
+            icon="edit"
+            label="Edit"
           >
           </mwc-icon-button>
         </span>
@@ -174,18 +174,18 @@ snapshots["Cleanup: Control Blocks Container With a test file loaded looks like 
         </span>
         <span>
           <mwc-icon-button
-            class="editItem"
-            icon="edit"
-            label="Edit"
+            class="cautionItem"
+            icon="warning_amber"
+            label="warning"
+            title="[cleanup.unreferencedControls.addressDefinitionTooltip]"
           >
           </mwc-icon-button>
         </span>
         <span>
           <mwc-icon-button
-            class="cautionItem"
-            icon="warning_amber"
-            label="warning"
-            title="[cleanup.unreferencedControls.addressDefinitionTooltip]"
+            class="editItem"
+            icon="edit"
+            label="Edit"
           >
           </mwc-icon-button>
         </span>
@@ -213,20 +213,20 @@ snapshots["Cleanup: Control Blocks Container With a test file loaded looks like 
         </span>
         <span>
           <mwc-icon-button
-            class="editItem"
-            disabled=""
-            icon="edit"
-            label="Edit"
-          >
-          </mwc-icon-button>
-        </span>
-        <span>
-          <mwc-icon-button
             class="cautionItem"
             disabled=""
             icon="warning_amber"
             label="warning"
             title="[cleanup.unreferencedControls.addressDefinitionTooltip]"
+          >
+          </mwc-icon-button>
+        </span>
+        <span>
+          <mwc-icon-button
+            class="editItem"
+            disabled=""
+            icon="edit"
+            label="Edit"
           >
           </mwc-icon-button>
         </span>
@@ -254,19 +254,19 @@ snapshots["Cleanup: Control Blocks Container With a test file loaded looks like 
         </span>
         <span>
           <mwc-icon-button
-            class="editItem"
-            icon="edit"
-            label="Edit"
-          >
-          </mwc-icon-button>
-        </span>
-        <span>
-          <mwc-icon-button
             class="cautionItem"
             disabled=""
             icon="warning_amber"
             label="warning"
             title="[cleanup.unreferencedControls.addressDefinitionTooltip]"
+          >
+          </mwc-icon-button>
+        </span>
+        <span>
+          <mwc-icon-button
+            class="editItem"
+            icon="edit"
+            label="Edit"
           >
           </mwc-icon-button>
         </span>
@@ -294,18 +294,18 @@ snapshots["Cleanup: Control Blocks Container With a test file loaded looks like 
         </span>
         <span>
           <mwc-icon-button
-            class="editItem"
-            icon="edit"
-            label="Edit"
+            class="cautionItem"
+            icon="warning_amber"
+            label="warning"
+            title="[cleanup.unreferencedControls.addressDefinitionTooltip]"
           >
           </mwc-icon-button>
         </span>
         <span>
           <mwc-icon-button
-            class="cautionItem"
-            icon="warning_amber"
-            label="warning"
-            title="[cleanup.unreferencedControls.addressDefinitionTooltip]"
+            class="editItem"
+            icon="edit"
+            label="Edit"
           >
           </mwc-icon-button>
         </span>


### PR DESCRIPTION
This is the CSS solution to #746. I quite like it. But I would like some feedback.
I haven't applied for the dataset cleanup yet until we can decide between this and the other PR.