### PR TITLE
feat(wizards/substation/l-node-editor): add duplicate button

### DIFF
--- a/src/editors/substation/l-node-editor.ts
+++ b/src/editors/substation/l-node-editor.ts
@@ -8,7 +8,13 @@ import {
 } from 'lit-element';
 
 import '../../action-icon.js';
-import { identity, newActionEvent, newWizardEvent } from '../../foundation.js';
+import {
+  cloneElement,
+  identity,
+  newActionEvent,
+  newLnInstGenerator,
+  newWizardEvent,
+} from '../../foundation.js';
 import {
   automationLogicalNode,
   controlLogicalNode,
@@ -75,6 +81,27 @@ export class LNodeEditor extends LitElement {
   private get missingIedReference(): boolean {
     return this.element.getAttribute('iedName') === 'None' ?? false;
   }
+  @state()
+  private get isIedRef(): boolean {
+    return this.element.getAttribute('iedName') !== 'None';
+  }
+
+  private cloneLNodeElement(): void {
+    const lnClass = this.element.getAttribute('lnClass');
+    if (!lnClass) return;
+
+    const uniqueLnInst = newLnInstGenerator(this.element.parentElement!)(
+      lnClass
+    );
+    if (!uniqueLnInst) return;
+
+    const newElement = cloneElement(this.element, { lnInst: uniqueLnInst });
+    this.dispatchEvent(
+      newActionEvent({
+        new: { parent: this.element.parentElement!, element: newElement },
+      })
+    );
+  }
 
   private openEditWizard(): void {
     const wizard = wizards['LNode'].edit(this.element);
@@ -111,6 +138,14 @@ export class LNodeEditor extends LitElement {
         icon="delete"
         @click="${() => this.remove()}}"
       ></mwc-fab
-    ></action-icon>`;
+      >${this.isIedRef
+        ? html``
+        : html`<mwc-fab
+            slot="action"
+            mini
+            icon="content_copy"
+            @click=${() => this.cloneLNodeElement()}
+          ></mwc-fab>`}
+    </action-icon>`;
   }
 }

--- a/src/editors/substation/l-node-editor.ts
+++ b/src/editors/substation/l-node-editor.ts
@@ -82,7 +82,7 @@ export class LNodeEditor extends LitElement {
     return this.element.getAttribute('iedName') === 'None' ?? false;
   }
   @state()
-  private get isIedRef(): boolean {
+  private get isIEDReference(): boolean {
     return this.element.getAttribute('iedName') !== 'None';
   }
 
@@ -138,7 +138,7 @@ export class LNodeEditor extends LitElement {
         icon="delete"
         @click="${() => this.remove()}}"
       ></mwc-fab
-      >${this.isIedRef
+      >${this.isIEDReference
         ? html``
         : html`<mwc-fab
             slot="action"

--- a/src/foundation.ts
+++ b/src/foundation.ts
@@ -2758,13 +2758,19 @@ export function getChildElementsByTagName(
   );
 }
 
-/** maxumum allow number for `lnInst` attribute */
+/** maximum value for `lnInst` attribute */
 const maxLnInst = 99;
 const lnInstRange = Array(maxLnInst)
   .fill(1)
   .map((_, i) => `${i + 1}`);
 
-/** generator function returning unique `lnInst` for a `lnClass` `LNode` element */
+/**
+ * @param parent - The LNodes' parent element to be scanned once for `lnInst`
+ * values already in use. Be sure to create a new generator every time the
+ * children of this element change.
+ * @returns a function generating increasing unused `lnInst` values for
+ * `lnClass` LNodes within `parent` on subsequent invocations
+ */
 export function newLnInstGenerator(
   parent: Element
 ): (lnClass: string) => string | undefined {

--- a/src/foundation.ts
+++ b/src/foundation.ts
@@ -662,7 +662,9 @@ function kDCSelector(tagName: SCLTag, identity: string): string {
 }
 
 function associationIdentity(e: Element): string {
-  return `${identity(e.parentElement)}>${e.getAttribute('associationID')??''}`;
+  return `${identity(e.parentElement)}>${
+    e.getAttribute('associationID') ?? ''
+  }`;
 }
 
 function associationSelector(tagName: SCLTag, identity: string): string {
@@ -2754,6 +2756,37 @@ export function getChildElementsByTagName(
   return Array.from(element.children).filter(
     element => element.tagName === tag
   );
+}
+
+/** maxumum allow number for `lnInst` attribute */
+const maxLnInst = 99;
+const lnInstRange = Array(maxLnInst)
+  .fill(1)
+  .map((_, i) => `${i + 1}`);
+
+/** generator function returning unique `lnInst` for a `lnClass` `LNode` element */
+export function newLnInstGenerator(
+  parent: Element
+): (lnClass: string) => string | undefined {
+  const generators = new Map<string, () => string | undefined>();
+
+  return (lnClass: string) => {
+    if (!generators.has(lnClass)) {
+      const lnInsts = new Set(
+        getChildElementsByTagName(parent, 'LNode')
+          .filter(lnode => lnode.getAttribute('lnClass') === lnClass)
+          .map(lNode => lNode.getAttribute('lnInst')!)
+      );
+
+      generators.set(lnClass, () => {
+        const uniqueLnInst = lnInstRange.find(lnInst => !lnInsts.has(lnInst));
+        if (uniqueLnInst) lnInsts.add(uniqueLnInst);
+        return uniqueLnInst;
+      });
+    }
+
+    return generators.get(lnClass)!();
+  };
 }
 
 declare global {

--- a/src/wizards/lnode.ts
+++ b/src/wizards/lnode.ts
@@ -27,37 +27,9 @@ import {
   WizardActor,
   WizardInputElement,
   WizardMenuActor,
+  newLnInstGenerator,
 } from '../foundation.js';
 import { patterns } from './foundation/limits.js';
-
-const maxLnInst = 99;
-const lnInstRange = Array(maxLnInst)
-  .fill(1)
-  .map((_, i) => `${i + 1}`);
-
-function uniqueLnInstGenerator(
-  parent: Element
-): (lnClass: string) => string | undefined {
-  const generators = new Map<string, () => string | undefined>();
-
-  return (lnClass: string) => {
-    if (!generators.has(lnClass)) {
-      const lnInsts = new Set(
-        getChildElementsByTagName(parent, 'LNode')
-          .filter(lnode => lnode.getAttribute('lnClass') === lnClass)
-          .map(lNode => lNode.getAttribute('lnInst')!)
-      );
-
-      generators.set(lnClass, () => {
-        const uniqueLnInst = lnInstRange.find(lnInst => !lnInsts.has(lnInst));
-        if (uniqueLnInst) lnInsts.add(uniqueLnInst);
-        return uniqueLnInst;
-      });
-    }
-
-    return generators.get(lnClass)!();
-  };
-}
 
 function createLNodeAction(parent: Element): WizardActor {
   return (
@@ -75,7 +47,7 @@ function createLNodeAction(parent: Element): WizardActor {
       })
       .filter(item => item !== null);
 
-    const lnInstGenerator = uniqueLnInstGenerator(parent);
+    const lnInstGenerator = newLnInstGenerator(parent);
 
     const createActions: Create[] = <Create[]>selectedLNodeTypes
       .map(selectedLNodeType => {

--- a/test/integration/editors/substation/l-node-editor-wizarding-editing.test.ts
+++ b/test/integration/editors/substation/l-node-editor-wizarding-editing.test.ts
@@ -113,4 +113,56 @@ describe('l-node-editor wizarding editing integration', () => {
       ).to.have.attribute('lnInst', '31');
     });
   });
+
+  describe('has a copy content icon button that', () => {
+    let contentCopyButton: HTMLElement;
+
+    beforeEach(async () => {
+      element!.element = doc.querySelector(
+        'SubFunction[name="mySubFunc2"] > LNode[lnClass="XSWI"]'
+      )!;
+      await parent.updateComplete;
+
+      contentCopyButton = <HTMLElement>(
+        element?.shadowRoot?.querySelector('mwc-fab[icon="content_copy"]')
+      );
+      await parent.updateComplete;
+    });
+
+    it('adds new LNode element', async () => {
+      contentCopyButton.click();
+      await parent.updateComplete;
+
+      expect(
+        doc.querySelectorAll(
+          'SubFunction[name="mySubFunc2"] > LNode[lnClass="XSWI"]'
+        )
+      ).to.have.lengthOf(3);
+    });
+
+    it('makes sure the lnInst is always unique', async () => {
+      contentCopyButton.click();
+      contentCopyButton.click();
+      contentCopyButton.click();
+      await parent.updateComplete;
+
+      expect(
+        doc.querySelectorAll(
+          'SubFunction[name="mySubFunc2"] > LNode[lnClass="XSWI"]'
+        )
+      ).to.have.lengthOf(5);
+
+      const lnInsts = Array.from(
+        doc.querySelectorAll(
+          'SubFunction[name="mySubFunc2"] > LNode[lnClass="XSWI"]'
+        )
+      ).map(lNode => lNode.getAttribute('lnInst')!);
+
+      const duplicates = lnInsts.filter(
+        (item, index) => lnInsts.indexOf(item) !== index
+      );
+
+      expect(duplicates).to.lengthOf(0);
+    });
+  });
 });

--- a/test/testfiles/zeroline/functions.scd
+++ b/test/testfiles/zeroline/functions.scd
@@ -37,7 +37,12 @@
 						<LNode iedName="None" prefix="DC" lnClass="CSWI" lnInst="1"/>
 						<LNode iedName="None" prefix="DC" lnClass="CILO" lnInst="1"/>
 					</SubFunction>
-					<SubFunction name="mySubFunc2"/>
+					<SubFunction name="mySubFunc2">
+						<LNode iedName="None" prefix="DC" lnClass="XSWI" lnInst="1"/>
+						<LNode iedName="None" prefix="DC" lnClass="CSWI" lnInst="1"/>
+						<LNode iedName="None" prefix="DC" lnClass="CILO" lnInst="1"/>
+						<LNode iedName="None" prefix="DC" lnClass="XSWI" lnInst="3"/>
+					</SubFunction>
 				</Function>
 				<Function name="bay2Func">
 					<LNode iedName="None" prefix="DC" lnClass="XSWI" lnInst="1"/>

--- a/test/unit/editors/substation/__snapshots__/l-node-editor.test.snap.js
+++ b/test/unit/editors/substation/__snapshots__/l-node-editor.test.snap.js
@@ -45,6 +45,12 @@ snapshots["web component rendering LNode element as instance of a LNodeType only
     slot="action"
   >
   </mwc-fab>
+  <mwc-fab
+    icon="content_copy"
+    mini=""
+    slot="action"
+  >
+  </mwc-fab>
 </action-icon>
 `;
 /* end snapshot web component rendering LNode element as instance of a LNodeType only looks like the latest snapshot */

--- a/test/unit/foundation.test.ts
+++ b/test/unit/foundation.test.ts
@@ -25,6 +25,7 @@ import {
   cloneElement,
   depth,
   getUniqueElementName,
+  newLnInstGenerator,
 } from '../../src/foundation.js';
 
 import { MockAction } from './mock-actions.js';
@@ -603,5 +604,73 @@ describe('foundation', () => {
 
     it('returns Infinity if given a circularly defined object or array', () =>
       expect(depth(circular)).to.not.be.finite);
+  });
+
+  describe('generator function for new `lnInst` attribute', () => {
+    let lnInstGenerator: (lnClass: string) => string | undefined;
+    let parent: Element;
+
+    describe('with existing unique lnInst', () => {
+      beforeEach(() => {
+        parent = new DOMParser().parseFromString(
+          `<Function name="someName">
+            <LNode name="None" lnClass="CSWI" lnInst="1"/>
+            <LNode name="None" lnClass="XCBR" lnInst="1"/>
+            <LNode name="None" lnClass="CILO" lnInst="1"/>
+            <LNode name="None" lnClass="CSWI" lnInst="2"/>
+            <LNode name="None" lnClass="PDIS" lnInst="1"/>
+            <LNode name="None" lnClass="CSWI" lnInst="5"/>
+            <LNode name="None" lnClass="CSWI" lnInst="6"/>
+            <LNode name="None" lnClass="CSWI" lnInst="8"/>
+          </Function>`,
+          'application/xml'
+        ).documentElement;
+
+        lnInstGenerator = newLnInstGenerator(parent);
+      });
+
+      it('returns unique lnInst called once', () =>
+        expect(lnInstGenerator('CSWI')).to.equal('3'));
+
+      it('returns unique lnInst called several times', () => {
+        expect(lnInstGenerator('CSWI')).to.equal('3');
+        expect(lnInstGenerator('CSWI')).to.equal('4');
+        expect(lnInstGenerator('CSWI')).to.equal('7');
+        expect(lnInstGenerator('CSWI')).to.equal('9');
+      });
+
+      it('returns unique lnInst called several times', () => {
+        expect(lnInstGenerator('CSWI')).to.equal('3');
+        expect(lnInstGenerator('CSWI')).to.equal('4');
+        expect(lnInstGenerator('CSWI')).to.equal('7');
+        expect(lnInstGenerator('CSWI')).to.equal('9');
+      });
+    });
+
+    describe('with missing unique lnInst for lnClass PDIS', () => {
+      beforeEach(() => {
+        parent = new DOMParser().parseFromString(
+          `<Function name="someName">
+          </Function>`,
+          'application/xml'
+        ).documentElement;
+
+        for (let i = 1; i <= 99; i++) {
+          const lNode = new DOMParser().parseFromString(
+            `<LNode iedName="None" lnClass="PDIS" lnInst="${i}" />`,
+            'application/xml'
+          ).documentElement;
+          parent.appendChild(lNode);
+        }
+
+        lnInstGenerator = newLnInstGenerator(parent);
+      });
+
+      it('return undefined for the lnClass PDIS', () =>
+        expect(lnInstGenerator('PDIS')).to.be.undefined);
+
+      it('return unique lnInst for another lnClass', () =>
+        expect(lnInstGenerator('CSWI')).to.equal('1'));
+    });
   });
 });


### PR DESCRIPTION
Closes #741 

This is a useful tool when working on functions with multiple logical node instances of the same `LNodeType` e.g. a distance function that consists of 5 to 7 zones where each zone is represented with a logical node `PDIS` and usually is the same structure.