### PR TITLE
feat(menu/VirtualTemplateIED): automatically create virtual IEDs

### DIFF
--- a/public/js/plugins.js
+++ b/public/js/plugins.js
@@ -113,6 +113,15 @@ export const officialPlugins = [
     position: 'middle',
   },
   {
+    name: 'Create Virtual IED',
+    src: '/src/menu/VirtualTemplateIED.js',
+    icon: 'developer_board',
+    default: false,
+    kind: 'menu',
+    requireDoc: true,
+    position: 'middle'
+  },
+  {
     name: 'Subscriber Update',
     src: '/src/menu/SubscriberInfo.js',
     default: true,

--- a/src/foundation.ts
+++ b/src/foundation.ts
@@ -598,19 +598,21 @@ function lNodeSelector(tagName: SCLTag, identity: string): string {
   if (identity.endsWith(')')) {
     const [parentIdentity, childIdentity] = pathParts(identity);
     const [lnClass, lnType] = childIdentity
-      .substring(1, identity.length - 2)
+      .substring(1, childIdentity.length - 1)
       .split(' ');
 
     if (!lnClass || !lnType) return voidSelector;
 
-    return tags[tagName].parents
-      .map(
-        parentTag =>
-          `${selector(
-            parentTag,
-            parentIdentity
-          )}>${tagName}[iedName="None"][lnClass="${lnClass}"][lnType="${lnType}"]`
-      )
+    const parentSelectors = tags[tagName].parents.flatMap(parentTag =>
+      selector(parentTag, parentIdentity).split(',')
+    );
+
+    return crossProduct(
+      parentSelectors,
+      ['>'],
+      [`${tagName}[iedName="None"][lnClass="${lnClass}"][lnType="${lnType}"]`]
+    )
+      .map(strings => strings.join(''))
       .join(',');
   }
 

--- a/src/menu/VirtualTemplateIED.ts
+++ b/src/menu/VirtualTemplateIED.ts
@@ -1,0 +1,259 @@
+import { html, LitElement, property, TemplateResult } from 'lit-element';
+import { get } from 'lit-translate';
+
+import '@material/mwc-dialog';
+import '@material/mwc-list';
+import '@material/mwc-list/mwc-list-item';
+import '@material/mwc-list/mwc-check-list-item';
+import '@material/mwc-list/mwc-radio-list-item';
+
+import '../filtered-list.js';
+import {
+  EditorAction,
+  getChildElementsByTagName,
+  getValue,
+  identity,
+  newWizardEvent,
+  selector,
+  Wizard,
+  WizardActor,
+  WizardInputElement,
+} from '../foundation.js';
+import { CheckListItem } from '@material/mwc-list/mwc-check-list-item';
+import {
+  getFunctionNamingPrefix,
+  getNonLeafParent,
+  getSpecificationIED,
+  getUniqueFunctionName,
+  LDeviceDescription,
+} from './virtualtemplateied/foundation.js';
+
+export type FunctionElementDescription = {
+  uniqueName: string;
+  lNodes: Element[];
+  lln0?: Element;
+};
+
+/** converts FunctionElementDescription's to LDeviceDescription's */
+function getLDeviceDescriptions(
+  functions: Record<string, FunctionElementDescription>,
+  selectedLNodes: Element[],
+  selectedLLN0s: string[]
+): LDeviceDescription[] {
+  const lDeviceDescriptions: LDeviceDescription[] = [];
+
+  Object.values(functions).forEach(functionDescription => {
+    if (
+      functionDescription.lNodes.some(lNode => selectedLNodes.includes(lNode))
+    ) {
+      const lLN0 = selectedLLN0s.find(selectedLLN0 =>
+        selectedLLN0.includes(functionDescription.uniqueName)
+      )!;
+      const lnType = lLN0?.split(' ')[0];
+
+      lDeviceDescriptions.push({
+        validLdInst: functionDescription.uniqueName,
+        anyLNs: [
+          { prefix: null, lnClass: 'LLN0', inst: '', lnType },
+          ...functionDescription.lNodes.map(lNode => {
+            return {
+              prefix: getFunctionNamingPrefix(lNode),
+              lnClass: lNode.getAttribute('lnClass')!,
+              inst: lNode.getAttribute('lnInst')!,
+              lnType: lNode.getAttribute('lnType')!,
+            };
+          }),
+        ],
+      });
+    }
+  });
+
+  return lDeviceDescriptions;
+}
+
+/** Groups all incomming LNode's with non-leaf parent function type elements */
+function groupLNodesToFunctions(
+  lNodes: Element[]
+): Record<string, FunctionElementDescription> {
+  const functionElements: Record<string, FunctionElementDescription> = {};
+
+  lNodes.forEach(lNode => {
+    const parentFunction = getNonLeafParent(lNode);
+    if (!parentFunction) return;
+
+    if (functionElements[identity(parentFunction)])
+      functionElements[identity(parentFunction)].lNodes.push(lNode);
+    else {
+      functionElements[identity(parentFunction)] = {
+        uniqueName: getUniqueFunctionName(parentFunction),
+        lNodes: [lNode],
+        lln0: getChildElementsByTagName(parentFunction, 'LNode').find(
+          lNode => lNode.getAttribute('lnClass') === 'LLN0'
+        ),
+      };
+    }
+  });
+
+  return functionElements;
+}
+
+function createSpecificationIEDAction(
+  parent: Element,
+  functions: Record<string, FunctionElementDescription>
+): WizardActor {
+  return (inputs: WizardInputElement[], wizard: Element): EditorAction[] => {
+    const selectedLNode = Array.from(
+      wizard.shadowRoot?.querySelectorAll<CheckListItem>(
+        'mwc-check-list-item[selected]:not([disabled])'
+      ) ?? []
+    ).map(
+      selectedItem =>
+        parent.querySelector(selector('LNode', selectedItem.value))!
+    );
+    if (!selectedLNode.length) return [];
+
+    const selectedLLN0s = Array.from(
+      wizard.shadowRoot?.querySelectorAll<CheckListItem>(
+        'mwc-radio-list-item[selected]'
+      ) ?? []
+    ).map(selectedItem => selectedItem.value);
+
+    const manufacturer = getValue(
+      inputs.find(i => i.label === 'manufacturer')!
+    )!;
+    const desc = getValue(inputs.find(i => i.label === 'desc')!);
+    const apName = getValue(inputs.find(i => i.label === 'AccessPoint name')!)!;
+
+    const ied = getSpecificationIED(parent.ownerDocument, {
+      manufacturer,
+      desc,
+      apName,
+      lDevices: getLDeviceDescriptions(functions, selectedLNode, selectedLLN0s),
+    });
+
+    // checkValidity: () => true disables name check as is the same here: SPECIFICATION
+    return [{ new: { parent, element: ied }, checkValidity: () => true }];
+  };
+}
+
+/** renders LNode of class `LLN0` OR all available LNodeType[lnClass="LLN0"] */
+function renderLLN0s(
+  functionID: string,
+  lLN0Types: Element[],
+  lNode?: Element
+): TemplateResult[] {
+  if (!lNode && !lLN0Types.length) return [html``];
+
+  if (lNode)
+    return [
+      html`<mwc-radio-list-item
+        group="${functionID}"
+        value="${functionID} ${lNode.getAttribute('lnType')}"
+        twoline
+        selected
+        ><span>LLN0</span
+        ><span slot="secondary">${lNode.getAttribute('lnType')}</span>
+      </mwc-radio-list-item>`,
+    ];
+
+  return lLN0Types.map(lLN0Type => {
+    return html`<mwc-radio-list-item
+      group="${functionID}"
+      value="${functionID} ${lLN0Type.getAttribute('id')}"
+      twoline
+      ?selected=${lLN0Types[0] === lLN0Type}
+      ><span>${'LLN0'}</span
+      ><span slot="secondary"
+        >${lLN0Type.getAttribute('id')}</span
+      ></mwc-radio-list-item
+    >`;
+  });
+}
+
+/** renders `LNode` elements */
+function renderLNodes(lNodes: Element[], disabled: boolean): TemplateResult[] {
+  return lNodes.map(lNode => {
+    const prefix = getFunctionNamingPrefix(lNode);
+    const lnClass = lNode.getAttribute('lnClass')!;
+    const lnInst = lNode.getAttribute('lnInst')!;
+
+    const label = prefix + ' ' + lnClass + ' ' + lnInst;
+    return html`<mwc-check-list-item
+      ?disabled=${disabled}
+      value="${identity(lNode)}"
+      >${label}</mwc-check-list-item
+    >`;
+  });
+}
+
+function createSpecificationIEDFromFunctionWizard(doc: XMLDocument): Wizard {
+  const lNodes = Array.from(
+    doc.querySelectorAll('LNode[iedName="None"]')
+  ).filter(lNode => lNode.getAttribute('lnClass') !== 'LLN0');
+
+  const lln0s = Array.from(doc.querySelectorAll('LNodeType[lnClass="LLN0"]'));
+  const existValidLLN0 = lln0s.length !== 0;
+
+  const functionElementDescriptions = groupLNodesToFunctions(lNodes);
+
+  return [
+    {
+      title: 'Create SPECIFICATION type IED',
+      primary: {
+        icon: 'save',
+        label: get('save'),
+        action: createSpecificationIEDAction(
+          doc.querySelector('SCL')!,
+          functionElementDescriptions
+        ),
+      },
+      content: [
+        html`<wizard-textfield
+          label="manufacturer"
+          .maybeValue=${''}
+          required
+        ></wizard-textfield>`,
+        html`<wizard-textfield
+          label="desc"
+          .maybeValue=${null}
+          nullable
+        ></wizard-textfield>`,
+        html`<wizard-textfield
+          label="AccessPoint name"
+          .maybeValue=${''}
+          required
+        ></wizard-textfield>`,
+        html`<filtered-list multi
+          >${Object.entries(functionElementDescriptions).flatMap(
+            ([id, functionDescription]) => [
+              html`<mwc-list-item twoline noninteractive value="${id}"
+                ><span>${functionDescription.uniqueName}</span
+                ><span slot="secondary"
+                  >${existValidLLN0 ? id : 'Invalid LD: Missing LLN0'}</span
+                ></mwc-list-item
+              >`,
+              html`<li padded divider role="separator"></li>`,
+              ...renderLLN0s(
+                functionDescription.uniqueName,
+                lln0s,
+                functionDescription.lln0
+              ),
+              ...renderLNodes(functionDescription.lNodes, !existValidLLN0),
+            ]
+          )}</filtered-list
+        >`,
+      ],
+    },
+  ];
+}
+
+export default class VirtualTemplateIED extends LitElement {
+  @property({ attribute: false })
+  doc!: XMLDocument;
+
+  async run(): Promise<void> {
+    this.dispatchEvent(
+      newWizardEvent(createSpecificationIEDFromFunctionWizard(this.doc))
+    );
+  }
+}

--- a/src/menu/VirtualTemplateIED.ts
+++ b/src/menu/VirtualTemplateIED.ts
@@ -27,6 +27,7 @@ import {
   getUniqueFunctionName,
   LDeviceDescription,
 } from './virtualtemplateied/foundation.js';
+import { Select } from '@material/mwc-select';
 
 export type FunctionElementDescription = {
   uniqueName: string;
@@ -49,7 +50,7 @@ function getLDeviceDescriptions(
       const lLN0 = selectedLLN0s.find(selectedLLN0 =>
         selectedLLN0.includes(functionDescription.uniqueName)
       )!;
-      const lnType = lLN0?.split(' ')[0];
+      const lnType = lLN0?.split(': ')[1];
 
       lDeviceDescriptions.push({
         validLdInst: functionDescription.uniqueName,
@@ -113,9 +114,7 @@ function createSpecificationIEDAction(
     if (!selectedLNode.length) return [];
 
     const selectedLLN0s = Array.from(
-      wizard.shadowRoot?.querySelectorAll<CheckListItem>(
-        'mwc-radio-list-item[selected]'
-      ) ?? []
+      wizard.shadowRoot?.querySelectorAll<Select>('mwc-select') ?? []
     ).map(selectedItem => selectedItem.value);
 
     const manufacturer = getValue(
@@ -141,33 +140,34 @@ function renderLLN0s(
   functionID: string,
   lLN0Types: Element[],
   lNode?: Element
-): TemplateResult[] {
-  if (!lNode && !lLN0Types.length) return [html``];
+): TemplateResult {
+  if (!lNode && !lLN0Types.length) return html``;
 
   if (lNode)
-    return [
-      html`<mwc-radio-list-item
-        group="${functionID}"
-        value="${functionID} ${lNode.getAttribute('lnType')}"
-        twoline
-        selected
-        ><span>LLN0</span
-        ><span slot="secondary">${lNode.getAttribute('lnType')}</span>
-      </mwc-radio-list-item>`,
-    ];
-
-  return lLN0Types.map(lLN0Type => {
-    return html`<mwc-radio-list-item
-      group="${functionID}"
-      value="${functionID} ${lLN0Type.getAttribute('id')}"
-      twoline
-      ?selected=${lLN0Types[0] === lLN0Type}
-      ><span>${'LLN0'}</span
-      ><span slot="secondary"
-        >${lLN0Type.getAttribute('id')}</span
-      ></mwc-radio-list-item
+    return html`<mwc-select
+      disabled
+      naturalMenuWidth
+      value="${functionID + ': ' + lNode.getAttribute('lnType')}"
+      style="width:100%"
+      label="LLN0"
+      >${html`<mwc-list-item
+        value="${functionID + ': ' + lNode.getAttribute('lnType')}"
+        >${lNode.getAttribute('lnType')}
+      </mwc-list-item>`}</mwc-select
     >`;
-  });
+
+  return html`<mwc-select
+    naturalMenuWidth
+    style="width:100%"
+    label="LLN0"
+    value="${functionID + ': ' + lLN0Types[0].getAttribute('id')}"
+    >${lLN0Types.map(lLN0Type => {
+      return html`<mwc-list-item
+        value="${functionID + ': ' + lLN0Type.getAttribute('id')}"
+        >${lLN0Type.getAttribute('id')}</mwc-list-item
+      >`;
+    })}</mwc-select
+  >`;
 }
 
 /** renders `LNode` elements */
@@ -226,14 +226,18 @@ function createSpecificationIEDFromFunctionWizard(doc: XMLDocument): Wizard {
         html`<filtered-list multi
           >${Object.entries(functionElementDescriptions).flatMap(
             ([id, functionDescription]) => [
-              html`<mwc-list-item twoline noninteractive value="${id}"
+              html`<mwc-list-item
+                twoline
+                noninteractive
+                value="${id}"
+                style="font-weight:500"
                 ><span>${functionDescription.uniqueName}</span
                 ><span slot="secondary"
                   >${existValidLLN0 ? id : 'Invalid LD: Missing LLN0'}</span
                 ></mwc-list-item
               >`,
               html`<li padded divider role="separator"></li>`,
-              ...renderLLN0s(
+              renderLLN0s(
                 functionDescription.uniqueName,
                 lln0s,
                 functionDescription.lln0

--- a/src/menu/virtualtemplateied/foundation.ts
+++ b/src/menu/virtualtemplateied/foundation.ts
@@ -1,9 +1,17 @@
+import {
+  createElement,
+  getChildElementsByTagName,
+  identity,
+} from '../../foundation.js';
+
 const functionTypeElementTags = [
   'Function',
   'SubFunction',
   'EqFunction',
   'EqSubFunction',
 ];
+
+const functionTypeSelector = functionTypeElementTags.join(',');
 
 /**
  * @param element - Some element Function, SubFunction, EqFunction or EqSubFunction

--- a/src/menu/virtualtemplateied/foundation.ts
+++ b/src/menu/virtualtemplateied/foundation.ts
@@ -1,3 +1,10 @@
+const functionTypeElementTags = [
+  'Function',
+  'SubFunction',
+  'EqFunction',
+  'EqSubFunction',
+];
+
 /**
  * @param element - Some element Function, SubFunction, EqFunction or EqSubFunction
  * @returns Whether the element is a leaf function acc. to IEC 61850-6-100
@@ -11,4 +18,17 @@ export function isLeafFunction(element: Element | null): boolean {
   return (
     element.children.length === 1 && element.children[0].tagName === 'LNode'
   );
+}
+
+/** @returns closest non-leaf function type parent element */
+export function getNonLeafParent(element: Element | null): Element | null {
+  if (!element) return null;
+
+  const directParent = element.parentElement;
+  if (!directParent || !functionTypeElementTags.includes(directParent.tagName))
+    return null;
+
+  if (isLeafFunction(directParent)) return getNonLeafParent(directParent);
+
+  return directParent;
 }

--- a/src/menu/virtualtemplateied/foundation.ts
+++ b/src/menu/virtualtemplateied/foundation.ts
@@ -1,0 +1,14 @@
+/**
+ * @param element - Some element Function, SubFunction, EqFunction or EqSubFunction
+ * @returns Whether the element is a leaf function acc. to IEC 61850-6-100
+ * */
+export function isLeafFunction(element: Element | null): boolean {
+  if (!element) return false;
+
+  if (element.tagName !== 'SubFunction' && element.tagName !== 'EqSubFunction')
+    return false;
+
+  return (
+    element.children.length === 1 && element.children[0].tagName === 'LNode'
+  );
+}

--- a/src/menu/virtualtemplateied/foundation.ts
+++ b/src/menu/virtualtemplateied/foundation.ts
@@ -32,3 +32,13 @@ export function getNonLeafParent(element: Element | null): Element | null {
 
   return directParent;
 }
+
+/** @returns prefix of LNode element acc. to IEC 61850-6-100 */
+export function getFunctionNamingPrefix(lNode: Element): string {
+  const lNodesPrefix = lNode.getAttribute('prefix');
+  if (lNodesPrefix) return lNodesPrefix;
+
+  return isLeafFunction(lNode.parentElement)
+    ? lNode.parentElement?.getAttribute('name') ?? ''
+    : '';
+}

--- a/test/integration/__snapshots__/open-scd.test.snap.js
+++ b/test/integration/__snapshots__/open-scd.test.snap.js
@@ -851,6 +851,21 @@ snapshots["open-scd looks like its snapshot"] =
       hasmeta=""
       left=""
       mwc-list-item=""
+      tabindex="-1"
+      value="/src/menu/VirtualTemplateIED.js"
+    >
+      <mwc-icon slot="meta">
+        developer_board
+      </mwc-icon>
+      Create Virtual IED
+    </mwc-check-list-item>
+    <mwc-check-list-item
+      aria-disabled="false"
+      class="official"
+      graphic="control"
+      hasmeta=""
+      left=""
+      mwc-list-item=""
       selected=""
       tabindex="-1"
       value="/src/menu/SubscriberInfo.js"

--- a/test/testfiles/virtualied/specificfromfunctions.ssd
+++ b/test/testfiles/virtualied/specificfromfunctions.ssd
@@ -1,0 +1,392 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SCL xmlns="http://www.iec.ch/61850/2003/SCL" version="2007" revision="B" release="4">
+	<Header id="virtualtemplate"/>
+	<Substation name="AA1">
+		<VoltageLevel name="E1" desc="" nomFreq="50" numPhases="3">
+			<Voltage unit="V" multiplier="k">110</Voltage>
+			<Bay name="Q01" desc="">
+				<ConductingEquipment name="QC9" type="DIS" desc="">
+					<Terminal name="T1" cNodeName="grounded" substationName="AA1" voltageLevelName="E1" bayName="Q01" connectivityNode="AA1/E1/Q01/grounded"/>
+					<EqFunction name="Earth_Switch">
+						<LNode iedName="None" lnClass="CSWI" lnInst="1" lnType="OpenSCD_CSWI"/>
+						<LNode iedName="None" lnClass="CILO" lnInst="1" lnType="OpenSCD_CILO"/>
+						<LNode iedName="None" lnClass="XSWI" lnInst="1" lnType="OpenSCD_XSWI_EarthSwitch"/>
+					</EqFunction>
+				</ConductingEquipment>
+				<ConductingEquipment name="QB1" type="DIS" desc="">
+					<EqFunction name="Disconnector">
+						<LNode iedName="None" lnClass="CSWI" lnInst="1" lnType="OpenSCD_CSWI"/>
+						<LNode iedName="None" lnClass="XSWI" lnInst="1" lnType="OpenSCD_XSWI_DIS"/>
+						<LNode iedName="None" lnClass="CILO" lnInst="1" lnType="OpenSCD_CILO"/>
+					</EqFunction>
+				</ConductingEquipment>
+				<ConductingEquipment name="QA1" type="CBR" desc="">
+					<EqFunction name="Circuit_Breaker">
+						<LNode iedName="None" lnClass="CSWI" lnInst="1" lnType="OpenSCD_CSWI"/>
+						<LNode iedName="None" lnClass="CILO" lnInst="1" lnType="OpenSCD_CILO"/>
+						<LNode iedName="None" lnClass="XCBR" lnInst="1" lnType="OpenSCD_XCBR"/>
+					</EqFunction>
+				</ConductingEquipment>
+				<ConnectivityNode name="grounded" pathName="AA1/E1/Q01/grounded"/>
+				<Function name="Timed_Overcurrent">
+					<LNode iedName="None" lnClass="PTOC" lnInst="2" lnType="OpenSCD_PTOC" prefix="ID_"/>
+					<LNode iedName="None" lnClass="PTOC" lnInst="1" lnType="OpenSCD_PTOC" prefix="IDD_"/>
+				</Function>
+				<Function name="Distance_Protection">
+					<SubFunction name="Zone4">
+						<LNode iedName="None" lnClass="PDIS" lnInst="1" lnType="OpenSCD_PDIS"/>
+					</SubFunction>
+					<SubFunction name="Zon3">
+						<LNode iedName="None" lnClass="PDIS" lnInst="1" lnType="OpenSCD_PDIS"/>
+					</SubFunction>
+					<SubFunction name="Zone2">
+						<LNode iedName="None" lnClass="PDIS" lnInst="1" lnType="OpenSCD_PDIS"/>
+					</SubFunction>
+					<SubFunction name="Zone1">
+						<LNode iedName="None" lnClass="PDIS" lnInst="1" lnType="OpenSCD_PDIS"/>
+					</SubFunction>
+				</Function>
+			</Bay>
+			<Bay name="Q02" desc="">
+				<ConductingEquipment name="QC9" type="DIS" desc="">
+					<Terminal name="T1" cNodeName="grounded" substationName="AA1" voltageLevelName="E1" bayName="Q01" connectivityNode="AA1/E1/Q01/grounded"/>
+					<EqFunction name="Earth_Switch">
+					</EqFunction>
+				</ConductingEquipment>
+				<ConductingEquipment name="QB1" type="DIS" desc="">
+					<EqFunction name="Disconnector">
+						<LNode iedName="None" lnClass="CSWI" lnInst="1" lnType="OpenSCD_CSWI"/>
+						<LNode iedName="None" lnClass="XSWI" lnInst="1" lnType="OpenSCD_XSWI_DIS"/>
+						<LNode iedName="None" lnClass="CILO" lnInst="1" lnType="OpenSCD_CILO"/>
+					</EqFunction>
+				</ConductingEquipment>
+				<ConductingEquipment name="QA1" type="CBR" desc="">
+					<EqFunction name="Circuit_Breaker">
+					</EqFunction>
+				</ConductingEquipment>
+			</Bay>
+		</VoltageLevel>
+		<VoltageLevel name="J1" desc="" nomFreq="50" numPhases="3">
+			<Voltage unit="V" multiplier="k">20</Voltage>
+			<Bay name="Q01" desc="">
+				<ConductingEquipment name="QC9" type="DIS" desc="">
+					<Terminal name="T1" cNodeName="grounded" substationName="AA1" voltageLevelName="E1" bayName="Q01" connectivityNode="AA1/E1/Q01/grounded"/>
+					<EqFunction name="Earth_Switch">
+					<LNode iedName="None" lnClass="CSWI" lnInst="1" lnType="OpenSCD_CSWI"/>
+						<LNode iedName="None" lnClass="CILO" lnInst="1" lnType="OpenSCD_CILO"/>
+						<LNode iedName="None" lnClass="XSWI" lnInst="1" lnType="OpenSCD_XSWI_EarthSwitch"/>
+					</EqFunction>
+				</ConductingEquipment>
+			</Bay>
+		</VoltageLevel>
+	</Substation>
+	<DataTypeTemplates>
+		<LNodeType lnClass="LLN0" id="OpenSCD_LLN0" desc="Logical device LN: parent">
+			<DO name="Mod" type="OpenSCD_ENC_Mod"/>
+			<DO name="Beh" type="OpenSCD_ENS_Beh"/>
+			<DO name="Health" type="OpenSCD_ENS_Health"/>
+			<DO name="NamPlt" type="OpenSCD_LPL_LD"/>
+			<DO name="LocKey" type="OpenSCD_SPS_simple"/>
+			<DO name="Loc" type="OpenSCD_SPS_simple"/>
+		</LNodeType>
+		<LNodeType lnClass="PTOC" id="OpenSCD_PTOC">
+			<DO name="Op" type="OpenSCD_ACT_general"/>
+			<DO name="Str" type="OpenSCD_ACD_general"/>
+			<DO name="Mod" type="OpenSCD_ENC_Mod"/>
+			<DO name="Health" type="OpenSCD_ENS_Health"/>
+			<DO name="Beh" type="OpenSCD_ENS_Beh"/>
+			<DO name="NamPlt" type="OpenSCD_LPL_noLD"/>
+		</LNodeType>
+		<LNodeType lnClass="PDIS" id="OpenSCD_PDIS">
+			<DO name="Op" type="OpenSCD_ACT_general"/>
+			<DO name="Str" type="OpenSCD_ACD_general"/>
+			<DO name="Mod" type="OpenSCD_ENC_Mod"/>
+			<DO name="Health" type="OpenSCD_ENS_Health"/>
+			<DO name="Beh" type="OpenSCD_ENS_Beh"/>
+			<DO name="NamPlt" type="OpenSCD_LPL_noLD"/>
+		</LNodeType>
+		<LNodeType lnClass="XCBR" id="OpenSCD_XCBR" desc="Circuit Breaker: one phase representation">
+			<DO name="Mod" type="OpenSCD_ENC_Mod"/>
+			<DO name="Beh" type="OpenSCD_ENS_Beh"/>
+			<DO name="Health" type="OpenSCD_ENS_Health"/>
+			<DO name="NamPlt" type="OpenSCD_LPL_noLD"/>
+			<DO name="LocKey" type="OpenSCD_SPS_simple"/>
+			<DO name="Loc" type="OpenSCD_SPS_simple"/>
+			<DO name="OpCnt" type="OpenSCD_INS_simple"/>
+			<DO name="Pos" type="OpenSCD_DPC_statusonly"/>
+			<DO name="BlkOpn" type="OpenSCD_SPC_statusonly"/>
+			<DO name="BlkCls" type="OpenSCD_SPC_statusonly"/>
+		</LNodeType>
+		<LNodeType lnClass="XSWI" id="OpenSCD_XSWI_EarthSwitch" desc="Switch: one phase represenation">
+			<DO name="Mod" type="OpenSCD_ENC_Mod"/>
+			<DO name="Beh" type="OpenSCD_ENS_Beh"/>
+			<DO name="Health" type="OpenSCD_ENS_Health"/>
+			<DO name="NamPlt" type="OpenSCD_LPL_noLD"/>
+			<DO name="LocKey" type="OpenSCD_SPS_simple"/>
+			<DO name="Loc" type="OpenSCD_SPS_simple"/>
+			<DO name="OpCnt" type="OpenSCD_INS_simple"/>
+			<DO name="Pos" type="OpenSCD_DPC_statusonly"/>
+			<DO name="BlkOpn" type="OpenSCD_SPC_statusonly"/>
+			<DO name="BlkCls" type="OpenSCD_SPC_statusonly"/>
+			<DO name="SwTyp" type="OpenSCD_SwType_EarthSwitch"/>
+		</LNodeType>
+		<LNodeType lnClass="PTRC" id="OpenSCD_PTRC" desc="Trip conditioning: General trip signal">
+			<DO name="Mod" type="OpenSCD_ENC_Mod"/>
+			<DO name="Beh" type="OpenSCD_ENS_Beh"/>
+			<DO name="Health" type="OpenSCD_ENS_Health"/>
+			<DO name="NamPlt" type="OpenSCD_LPL_noLD"/>
+			<DO name="Tr" type="OpenSCD_ACT_general"/>
+			<DO name="Op" transient="true" type="OpenSCD_ACT_general"/>
+			<DO name="Str" type="OpenSCD_ACD_general"/>
+		</LNodeType>
+		<LNodeType lnClass="CILO" id="OpenSCD_CILO" desc="Interlocking">
+			<DO name="Mod" type="OpenSCD_ENC_Mod"/>
+			<DO name="Beh" type="OpenSCD_ENS_Beh"/>
+			<DO name="Health" type="OpenSCD_ENS_Health"/>
+			<DO name="NamPlt" type="OpenSCD_LPL_noLD"/>
+			<DO name="EnaOpn" type="OpenSCD_SPS_simple"/>
+			<DO name="EnaCls" type="OpenSCD_SPS_simple"/>
+		</LNodeType>
+		<LNodeType lnClass="XSWI" id="OpenSCD_XSWI_DIS" desc="Disconnector single phase">
+			<DO name="Mod" type="OpenSCD_ENC_Mod"/>
+			<DO name="Beh" type="OpenSCD_ENS_Beh"/>
+			<DO name="Health" type="OpenSCD_ENS_Health"/>
+			<DO name="NamPlt" type="OpenSCD_LPL_noLD"/>
+			<DO name="LocKey" type="OpenSCD_SPS_simple"/>
+			<DO name="Loc" type="OpenSCD_SPS_simple"/>
+			<DO name="OpCnt" type="OpenSCD_INS_simple"/>
+			<DO name="Pos" type="OpenSCD_DPC_statusonly"/>
+			<DO name="BlkOpn" type="OpenSCD_SPC_statusonly"/>
+			<DO name="BlkCls" type="OpenSCD_SPC_statusonly"/>
+			<DO name="SwTyp" type="OpenSCD_ENS_SwTyp_DIS"/>
+		</LNodeType>
+		<LNodeType lnClass="CSWI" id="OpenSCD_CSWI" desc="Switch control: three phase">
+			<DO name="Mod" type="OpenSCD_ENC_Mod"/>
+			<DO name="Beh" type="OpenSCD_ENS_Beh"/>
+			<DO name="Health" type="OpenSCD_ENS_Health"/>
+			<DO name="NamPlt" type="OpenSCD_LPL_noLD"/>
+			<DO name="LocKey" type="OpenSCD_SPS_simple"/>
+			<DO name="Loc" type="OpenSCD_SPS_simple"/>
+			<DO name="Pos" type="OpenSCD_DPC"/>
+			<DO name="OpOpn" transient="true" type="OpenSCD_ACT_general_control"/>
+			<DO name="OpCls" transient="true" type="OpenSCD_ACT_general_control"/>
+			<DO name="SelOpn" type="OpenSCD_SPS_simple"/>
+			<DO name="SelCls" type="OpenSCD_SPS_simple"/>
+		</LNodeType>
+		<DOType cdc="LPL" id="OpenSCD_LPL_LD">
+			<DA name="vendor" bType="VisString255" fc="DC"/>
+			<DA name="swRev" bType="VisString255" fc="DC"/>
+			<DA name="d" bType="VisString255" fc="DC"/>
+			<DA name="configRev" bType="VisString255" fc="DC"/>
+			<DA name="ldNs" bType="VisString255" fc="EX">
+				<Val>IEC 61850-7-4:2007B4</Val>
+			</DA>
+		</DOType>
+		<DOType cdc="ENS" id="OpenSCD_SwType_EarthSwitch">
+			<DA fc="ST" dchg="true" name="stVal" bType="Enum" type="SwitchFunctionKind">
+				<Val>Earthing Switch</Val>
+			</DA>
+			<DA fc="ST" qchg="true" name="q" bType="Quality"/>
+			<DA fc="ST" name="t" bType="Timestamp"/>
+		</DOType>
+		<DOType cdc="ACD" id="OpenSCD_ACD_general">
+			<DA name="general" bType="BOOLEAN" dchg="true" fc="ST"/>
+			<DA name="dirGeneral" bType="Enum" dchg="true" type="FaultDirectionKind" fc="ST"/>
+			<DA name="q" bType="Quality" qchg="true" fc="ST"/>
+			<DA name="t" bType="Timestamp" fc="ST"/>
+		</DOType>
+		<DOType cdc="ACT" id="OpenSCD_ACT_general">
+			<DA name="general" bType="BOOLEAN" dchg="true" fc="ST"/>
+			<DA name="q" bType="Quality" qchg="true" fc="ST"/>
+			<DA name="t" bType="Timestamp" fc="ST"/>
+		</DOType>
+		<DOType cdc="ENS" id="OpenSCD_ENS_SwTyp_DIS">
+			<DA fc="ST" dchg="true" name="stVal" bType="Enum" type="SwitchFunctionKind">
+				<Val>Disconnector</Val>
+			</DA>
+			<DA fc="ST" qchg="true" name="q" bType="Quality"/>
+			<DA fc="ST" name="t" bType="Timestamp"/>
+		</DOType>
+		<DOType cdc="SPC" id="OpenSCD_SPC_statusonly">
+			<DA name="stVal" bType="BOOLEAN" dchg="true" fc="ST"/>
+			<DA name="q" bType="Quality" qchg="true" fc="ST"/>
+			<DA name="t" bType="Timestamp" fc="ST"/>
+			<DA name="ctlModel" bType="Enum" dchg="true" type="OpenSCD_StatusOnly" fc="CF">
+				<Val>status-only</Val>
+			</DA>
+		</DOType>
+		<DOType cdc="DPC" id="OpenSCD_DPC_statusonly">
+			<DA name="stVal" bType="Dbpos" dchg="true" fc="ST"/>
+			<DA name="q" bType="Quality" qchg="true" fc="ST"/>
+			<DA name="t" bType="Timestamp" fc="ST"/>
+			<DA name="ctlModel" bType="Enum" fc="CF" type="OpenSCD_StatusOnly">
+				<Val>status-only</Val>
+			</DA>
+		</DOType>
+		<DOType cdc="INS" id="OpenSCD_INS_simple">
+			<DA name="stVal" bType="INT32" dchg="true" fc="ST"/>
+			<DA name="q" bType="Quality" qchg="true" fc="ST"/>
+			<DA name="t" bType="Timestamp" fc="ST"/>
+			<DA name="d" bType="VisString255" fc="DC"/>
+		</DOType>
+		<DOType cdc="ACT" id="OpenSCD_ACT_general_control">
+			<DA name="general" bType="BOOLEAN" dchg="true" fc="ST"/>
+			<DA name="q" bType="Quality" qchg="true" fc="ST"/>
+			<DA name="t" bType="Timestamp" fc="ST"/>
+			<DA name="originSrc" bType="Struct" type="OpenSCD_Originator" fc="ST"/>
+		</DOType>
+		<DOType cdc="DPC" id="OpenSCD_DPC">
+			<DA name="origin" bType="Struct" dchg="true" fc="ST" type="OpenSCD_Originator"/>
+			<DA name="stVal" bType="Enum" dchg="true" fc="ST" type="BehaviourModeKind"/>
+			<DA name="q" bType="Quality" qchg="true" fc="ST"/>
+			<DA name="t" bType="Timestamp" fc="ST"/>
+			<DA name="ctlModel" bType="Enum" fc="CF" type="CtlModelKind">
+				<Val>sbo-with-enhanced-security</Val>
+			</DA>
+			<DA name="sboTimeout" bType="INT32U" fc="CF">
+				<Val>30000</Val>
+			</DA>
+			<DA name="operTimeout" bType="INT32U" fc="CF">
+				<Val>600</Val>
+			</DA>
+			<DA name="pulseConfig" bType="Struct" fc="CO" type="OpenSCD_PulseConfig"/>
+			<DA name="SBOw" bType="Struct" fc="CO" type="OpenSCD_OperSBOw_Dbpos"/>
+			<DA name="Oper" bType="Struct" fc="CO" type="OpenSCD_OperSBOw_Dbpos"/>
+			<DA name="Cancel" bType="Struct" fc="CO" type="OpenSCD_Cancel_Dbpos"/>
+		</DOType>
+		<DOType cdc="SPS" id="OpenSCD_SPS_simple">
+			<DA name="stVal" bType="BOOLEAN" dchg="true" fc="ST"/>
+			<DA name="q" bType="Quality" qchg="true" fc="ST"/>
+			<DA name="t" bType="Timestamp" fc="ST"/>
+			<DA name="d" bType="VisString255" fc="DC"/>
+		</DOType>
+		<DOType cdc="LPL" id="OpenSCD_LPL_noLD">
+			<DA name="vendor" bType="VisString255" fc="DC"/>
+			<DA name="swRev" bType="VisString255" fc="DC"/>
+			<DA name="d" bType="VisString255" fc="DC"/>
+			<DA name="configRev" bType="VisString255" fc="DC"/>
+		</DOType>
+		<DOType cdc="ENS" id="OpenSCD_ENS_Health">
+			<DA name="stVal" bType="Enum" dchg="true" fc="ST" type="HealthKind"/>
+			<DA name="q" bType="Quality" qchg="true" fc="ST"/>
+			<DA name="t" bType="Timestamp" fc="ST"/>
+		</DOType>
+		<DOType cdc="ENS" id="OpenSCD_ENS_Beh">
+			<DA name="stVal" bType="Enum" dchg="true" fc="ST" type="BehaviourModeKind"/>
+			<DA name="q" bType="Quality" qchg="true" fc="ST"/>
+			<DA name="t" bType="Timestamp" fc="ST"/>
+		</DOType>
+		<DOType cdc="ENC" id="OpenSCD_ENC_Mod">
+			<DA name="origin" bType="Struct" dchg="true" fc="ST" type="OpenSCD_Originator"/>
+			<DA name="stVal" bType="Enum" dchg="true" fc="ST" type="BehaviourModeKind"/>
+			<DA name="q" bType="Quality" qchg="true" fc="ST"/>
+			<DA name="t" bType="Timestamp" fc="ST"/>
+			<DA name="ctlModel" bType="Enum" fc="CF" type="CtlModelKind">
+				<Val>sbo-with-enhanced-security</Val>
+			</DA>
+			<DA name="sboTimeout" bType="INT32U" fc="CF">
+				<Val>30000</Val>
+			</DA>
+			<DA name="operTimeout" bType="INT32U" fc="CF">
+				<Val>600</Val>
+			</DA>
+			<DA name="SBOw" bType="Struct" fc="CO" type="OpenSCD_OperSBOw_BehaviourModeKind"/>
+			<DA name="Oper" bType="Struct" fc="CO" type="OpenSCD_OperSBOw_BehaviourModeKind"/>
+			<DA name="Cancel" bType="Struct" fc="CO" type="OpenSCD_Cancel_BehaviourModeKind"/>
+		</DOType>
+		<DAType id="OpenSCD_Cancel_Dbpos">
+			<BDA name="ctlVal" bType="Dbpos"/>
+			<BDA name="origin" bType="Struct" type="OpenSCD_Originator"/>
+			<BDA name="ctlNum" bType="INT8U"/>
+			<BDA name="T" bType="Timestamp"/>
+			<BDA name="Test" bType="BOOLEAN"/>
+			<ProtNs type="8-MMS">IEC 61850-8-1:2003</ProtNs>
+		</DAType>
+		<DAType id="OpenSCD_OperSBOw_Dbpos">
+			<BDA name="ctlVal" bType="Dbpos"/>
+			<BDA name="origin" bType="Struct" type="OpenSCD_Originator"/>
+			<BDA name="ctlNum" bType="INT8U"/>
+			<BDA name="T" bType="Timestamp"/>
+			<BDA name="Test" bType="BOOLEAN"/>
+			<BDA name="Check" bType="Check"/>
+			<ProtNs type="8-MMS">IEC 61850-8-1:2003</ProtNs>
+		</DAType>
+		<DAType id="OpenSCD_PulseConfig">
+			<BDA name="cmdQual" bType="Enum" type="OutputSignalKind"/>
+			<BDA name="onDur" bType="INT32U"/>
+			<BDA name="offDur" bType="INT32U"/>
+			<BDA name="numPls" bType="INT32U"/>
+		</DAType>
+		<DAType id="OpenSCD_Cancel_BehaviourModeKind">
+			<BDA name="ctlVal" bType="Enum" type="BehaviourModeKind"/>
+			<BDA name="origin" bType="Struct" type="OpenSCD_Originator"/>
+			<BDA name="ctlNum" bType="INT8U"/>
+			<BDA name="T" bType="Timestamp"/>
+			<BDA name="Test" bType="BOOLEAN"/>
+			<ProtNs type="8-MMS">IEC 61850-8-1:2003</ProtNs>
+		</DAType>
+		<DAType id="OpenSCD_OperSBOw_BehaviourModeKind">
+			<BDA name="ctlVal" bType="Enum" type="BehaviourModeKind"/>
+			<BDA name="origin" bType="Struct" type="OpenSCD_Originator"/>
+			<BDA name="ctlNum" bType="INT8U"/>
+			<BDA name="T" bType="Timestamp"/>
+			<BDA name="Test" bType="BOOLEAN"/>
+			<BDA name="Check" bType="Check"/>
+			<ProtNs type="8-MMS">IEC 61850-8-1:2003</ProtNs>
+		</DAType>
+		<DAType id="OpenSCD_Originator">
+			<BDA name="orCat" bType="Enum" type="OriginatorCategoryKind"/>
+			<BDA name="orIdent" bType="Octet64"/>
+		</DAType>
+		<EnumType id="FaultDirectionKind">
+			<EnumVal ord="0">unknown</EnumVal>
+			<EnumVal ord="1">forward</EnumVal>
+			<EnumVal ord="2">backward</EnumVal>
+			<EnumVal ord="3">both</EnumVal>
+		</EnumType>
+		<EnumType id="SwitchFunctionKind">
+			<EnumVal ord="1">Load Break</EnumVal>
+			<EnumVal ord="2">Disconnector</EnumVal>
+			<EnumVal ord="3">Earthing Switch</EnumVal>
+			<EnumVal ord="4">High Speed Earthing Switch</EnumVal>
+		</EnumType>
+		<EnumType id="OpenSCD_StatusOnly">
+			<EnumVal ord="0">status-only</EnumVal>
+		</EnumType>
+		<EnumType id="OutputSignalKind">
+			<EnumVal ord="0">pulse</EnumVal>
+			<EnumVal ord="1">persistent</EnumVal>
+			<EnumVal ord="2">persistent-feedback</EnumVal>
+		</EnumType>
+		<EnumType id="HealthKind">
+			<EnumVal ord="1">Ok</EnumVal>
+			<EnumVal ord="2">Warning</EnumVal>
+			<EnumVal ord="3">Alarm</EnumVal>
+		</EnumType>
+		<EnumType id="CtlModelKind">
+			<EnumVal ord="0">status-only</EnumVal>
+			<EnumVal ord="1">direct-with-normal-security</EnumVal>
+			<EnumVal ord="2">sbo-with-normal-security</EnumVal>
+			<EnumVal ord="3">direct-with-enhanced-security</EnumVal>
+			<EnumVal ord="4">sbo-with-enhanced-security</EnumVal>
+		</EnumType>
+		<EnumType id="BehaviourModeKind">
+			<EnumVal ord="1">on</EnumVal>
+			<EnumVal ord="2">blocked</EnumVal>
+			<EnumVal ord="3">test</EnumVal>
+			<EnumVal ord="4">test/blocked</EnumVal>
+			<EnumVal ord="5">off</EnumVal>
+		</EnumType>
+		<EnumType id="OriginatorCategoryKind">
+			<EnumVal ord="0">not-supported</EnumVal>
+			<EnumVal ord="1">bay-control</EnumVal>
+			<EnumVal ord="2">station-control</EnumVal>
+			<EnumVal ord="3">remote-control</EnumVal>
+			<EnumVal ord="4">automatic-bay</EnumVal>
+			<EnumVal ord="5">automatic-station</EnumVal>
+			<EnumVal ord="6">automatic-remote</EnumVal>
+			<EnumVal ord="7">maintenance</EnumVal>
+			<EnumVal ord="8">process</EnumVal>
+		</EnumType>
+	</DataTypeTemplates>
+</SCL>

--- a/test/testfiles/virtualied/specificfromfunctions.ssd
+++ b/test/testfiles/virtualied/specificfromfunctions.ssd
@@ -29,6 +29,7 @@
 				</ConductingEquipment>
 				<ConnectivityNode name="grounded" pathName="AA1/E1/Q01/grounded"/>
 				<Function name="Timed_Overcurrent">
+					<LNode iedName="None" lnClass="LLN0" lnInst="" lnType="OpenSCD_LLN01" prefix=""/>
 					<LNode iedName="None" lnClass="PTOC" lnInst="2" lnType="OpenSCD_PTOC" prefix="ID_"/>
 					<LNode iedName="None" lnClass="PTOC" lnInst="1" lnType="OpenSCD_PTOC" prefix="IDD_"/>
 				</Function>
@@ -81,7 +82,15 @@
 		</VoltageLevel>
 	</Substation>
 	<DataTypeTemplates>
-		<LNodeType lnClass="LLN0" id="OpenSCD_LLN0" desc="Logical device LN: parent">
+		<LNodeType lnClass="LLN0" id="OpenSCD_LLN0" desc="some LLN0">
+			<DO name="Mod" type="OpenSCD_ENC_Mod"/>
+			<DO name="Beh" type="OpenSCD_ENS_Beh"/>
+			<DO name="Health" type="OpenSCD_ENS_Health"/>
+			<DO name="NamPlt" type="OpenSCD_LPL_LD"/>
+			<DO name="LocKey" type="OpenSCD_SPS_simple"/>
+			<DO name="Loc" type="OpenSCD_SPS_simple"/>
+		</LNodeType>
+		<LNodeType lnClass="LLN0" id="OpenSCD_LLN01" desc="some other LLN0">
 			<DO name="Mod" type="OpenSCD_ENC_Mod"/>
 			<DO name="Beh" type="OpenSCD_ENS_Beh"/>
 			<DO name="Health" type="OpenSCD_ENS_Health"/>

--- a/test/unit/menu/VirtualTemplateIED.test.ts
+++ b/test/unit/menu/VirtualTemplateIED.test.ts
@@ -1,0 +1,142 @@
+import { expect, fixture, html } from '@open-wc/testing';
+import { SinonSpy, spy } from 'sinon';
+
+import '../../mock-wizard.js';
+import { MockWizard } from '../../mock-wizard.js';
+
+import {
+  Create,
+  isCreate,
+  WizardInputElement,
+} from '../../../src/foundation.js';
+import VirtualTemplateIED from '../../../src/menu/VirtualTemplateIED.js';
+import { CheckListItem } from '@material/mwc-list/mwc-check-list-item';
+
+describe('Plugin that creates with some user input a virtual template IED - SPECIFICATION', () => {
+  if (customElements.get('virtual-template-i-e-d') === undefined)
+    customElements.define('virtual-template-i-e-d', VirtualTemplateIED);
+
+  let doc: XMLDocument;
+  let parent: MockWizard;
+  let element: VirtualTemplateIED;
+
+  let primaryAction: HTMLElement;
+  let inputs: WizardInputElement[];
+  let checkItems: CheckListItem[];
+
+  let editorAction: SinonSpy;
+
+  beforeEach(async () => {
+    doc = await fetch('/test/testfiles/virtualied/specificfromfunctions.ssd')
+      .then(response => response.text())
+      .then(str => new DOMParser().parseFromString(str, 'application/xml'));
+
+    parent = await fixture(html`
+      <mock-wizard
+        ><virtual-template-i-e-d .doc=${doc}></virtual-template-i-e-d
+      ></mock-wizard>
+    `);
+
+    element = <VirtualTemplateIED>(
+      parent.querySelector('virtual-template-i-e-d')!
+    );
+
+    editorAction = spy();
+    window.addEventListener('editor-action', editorAction);
+
+    element.run();
+    await parent.requestUpdate();
+
+    inputs = Array.from(parent.wizardUI.inputs);
+
+    checkItems = Array.from(
+      parent.wizardUI.dialog?.querySelectorAll('mwc-check-list-item') ?? []
+    );
+
+    primaryAction = <HTMLElement>(
+      parent.wizardUI.dialog?.querySelector('mwc-button[slot="primaryAction"]')
+    );
+  });
+
+  it('looks like the latest snapshot', async () =>
+    await expect(parent.wizardUI.dialog).dom.to.equalSnapshot());
+
+  it('shows all LNode that is not class LLN0 as check list items', () =>
+    expect(checkItems.length).to.equal(
+      doc.querySelectorAll('LNode[iedName="None"]:not([lnClass="LLN0"])').length
+    ));
+
+  it('does not trigger any actions with missing input fields', () => {
+    primaryAction.click();
+
+    expect(editorAction).to.not.have.been.called;
+  });
+
+  it('does not trigger any actions with missing input fields', () => {
+    inputs[0].value = 'SomeCompanyName';
+    inputs[2].value = 'P1';
+
+    primaryAction.click();
+
+    expect(editorAction).to.not.have.been.called;
+  });
+
+  it('does not trigger any actions with missing input fields', () => {
+    inputs[0].value = 'SomeCompanyName';
+    inputs[2].value = 'P1';
+
+    primaryAction.click();
+
+    expect(editorAction).to.not.have.been.called;
+  });
+
+  it('does trigger an create actions if at least one LNode is selected', async () => {
+    inputs[0].value = 'SomeCompanyName';
+    inputs[2].value = 'P1';
+
+    checkItems[1].selected = true;
+
+    await parent.requestUpdate();
+
+    primaryAction.click();
+
+    expect(editorAction).to.have.been.calledOnce;
+  });
+
+  it('allows to add more than one SPECIFICATION type IED to the document', async () => {
+    inputs[0].value = 'SomeCompanyName';
+    inputs[2].value = 'P1';
+
+    checkItems[1].selected = true;
+
+    await element.requestUpdate();
+
+    primaryAction.click();
+
+    const action = editorAction.args[0][0].detail.action;
+    expect(action).to.satisfy(isCreate);
+
+    const createAction = <Create>action;
+    expect(createAction.checkValidity).to.exist;
+    expect(createAction.checkValidity!()).to.be.true;
+  });
+
+  it('IEDs data model show selected logical nodes and its structure', async () => {
+    inputs[0].value = 'SomeCompanyName';
+    inputs[2].value = 'P1';
+
+    checkItems[1].selected = true;
+    checkItems[10].selected = true;
+    checkItems[15].selected = true;
+
+    await element.requestUpdate();
+
+    primaryAction.click();
+
+    const action = editorAction.args[0][0].detail.action;
+    expect(action).to.satisfy(isCreate);
+
+    const createAction = <Create>action;
+    await expect(createAction.new.element).dom.to.equalSnapshot();
+  });
+});

--- a/test/unit/menu/VirtualTemplateIED.test.ts
+++ b/test/unit/menu/VirtualTemplateIED.test.ts
@@ -81,15 +81,6 @@ describe('Plugin that creates with some user input a virtual template IED - SPEC
     expect(editorAction).to.not.have.been.called;
   });
 
-  it('does not trigger any actions with missing input fields', () => {
-    inputs[0].value = 'SomeCompanyName';
-    inputs[2].value = 'P1';
-
-    primaryAction.click();
-
-    expect(editorAction).to.not.have.been.called;
-  });
-
   it('does trigger an create actions if at least one LNode is selected', async () => {
     inputs[0].value = 'SomeCompanyName';
     inputs[2].value = 'P1';

--- a/test/unit/menu/__snapshots__/VirtualTemplateIED.test.snap.js
+++ b/test/unit/menu/__snapshots__/VirtualTemplateIED.test.snap.js
@@ -574,7 +574,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
   </div>
   <mwc-button
     dialogaction="close"
-    label="[cancel]"
+    label="[close]"
     slot="secondaryAction"
     style="--mdc-theme-primary: var(--mdc-theme-error)"
   >

--- a/test/unit/menu/__snapshots__/VirtualTemplateIED.test.snap.js
+++ b/test/unit/menu/__snapshots__/VirtualTemplateIED.test.snap.js
@@ -29,6 +29,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
       <mwc-list-item
         aria-disabled="false"
         noninteractive=""
+        style="font-weight:500"
         tabindex="-1"
         twoline=""
         value="AA1>E1>Q01>QC9>Earth_Switch"
@@ -46,44 +47,34 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         role="separator"
       >
       </li>
-      <mwc-radio-list-item
-        aria-disabled="false"
-        graphic="control"
-        group="E1_Q01_QC9_Earth_Switch"
-        mwc-list-item=""
-        selected=""
-        tabindex="0"
-        twoline=""
-        value="E1_Q01_QC9_Earth_Switch OpenSCD_LLN0"
+      <mwc-select
+        label="LLN0"
+        naturalmenuwidth=""
+        style="width:100%"
+        value="E1_Q01_QC9_Earth_Switch: OpenSCD_LLN0"
       >
-        <span>
-          LLN0
-        </span>
-        <span slot="secondary">
+        <mwc-list-item
+          aria-disabled="false"
+          mwc-list-item=""
+          tabindex="-1"
+          value="E1_Q01_QC9_Earth_Switch: OpenSCD_LLN0"
+        >
           OpenSCD_LLN0
-        </span>
-      </mwc-radio-list-item>
-      <mwc-radio-list-item
-        aria-disabled="false"
-        graphic="control"
-        group="E1_Q01_QC9_Earth_Switch"
-        mwc-list-item=""
-        tabindex="-1"
-        twoline=""
-        value="E1_Q01_QC9_Earth_Switch OpenSCD_LLN01"
-      >
-        <span>
-          LLN0
-        </span>
-        <span slot="secondary">
+        </mwc-list-item>
+        <mwc-list-item
+          aria-disabled="false"
+          mwc-list-item=""
+          tabindex="-1"
+          value="E1_Q01_QC9_Earth_Switch: OpenSCD_LLN01"
+        >
           OpenSCD_LLN01
-        </span>
-      </mwc-radio-list-item>
+        </mwc-list-item>
+      </mwc-select>
       <mwc-check-list-item
         aria-disabled="false"
         graphic="control"
         mwc-list-item=""
-        tabindex="-1"
+        tabindex="0"
         value="AA1>E1>Q01>QC9>Earth_Switch>(CSWI OpenSCD_CSWI)"
       >
         CSWI 1
@@ -109,6 +100,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
       <mwc-list-item
         aria-disabled="false"
         noninteractive=""
+        style="font-weight:500"
         tabindex="-1"
         twoline=""
         value="AA1>E1>Q01>QB1>Disconnector"
@@ -126,39 +118,29 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         role="separator"
       >
       </li>
-      <mwc-radio-list-item
-        aria-disabled="false"
-        graphic="control"
-        group="Q01_QB1_Disconnector"
-        mwc-list-item=""
-        selected=""
-        tabindex="-1"
-        twoline=""
-        value="Q01_QB1_Disconnector OpenSCD_LLN0"
+      <mwc-select
+        label="LLN0"
+        naturalmenuwidth=""
+        style="width:100%"
+        value="Q01_QB1_Disconnector: OpenSCD_LLN0"
       >
-        <span>
-          LLN0
-        </span>
-        <span slot="secondary">
+        <mwc-list-item
+          aria-disabled="false"
+          mwc-list-item=""
+          tabindex="-1"
+          value="Q01_QB1_Disconnector: OpenSCD_LLN0"
+        >
           OpenSCD_LLN0
-        </span>
-      </mwc-radio-list-item>
-      <mwc-radio-list-item
-        aria-disabled="false"
-        graphic="control"
-        group="Q01_QB1_Disconnector"
-        mwc-list-item=""
-        tabindex="-1"
-        twoline=""
-        value="Q01_QB1_Disconnector OpenSCD_LLN01"
-      >
-        <span>
-          LLN0
-        </span>
-        <span slot="secondary">
+        </mwc-list-item>
+        <mwc-list-item
+          aria-disabled="false"
+          mwc-list-item=""
+          tabindex="-1"
+          value="Q01_QB1_Disconnector: OpenSCD_LLN01"
+        >
           OpenSCD_LLN01
-        </span>
-      </mwc-radio-list-item>
+        </mwc-list-item>
+      </mwc-select>
       <mwc-check-list-item
         aria-disabled="false"
         graphic="control"
@@ -189,6 +171,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
       <mwc-list-item
         aria-disabled="false"
         noninteractive=""
+        style="font-weight:500"
         tabindex="-1"
         twoline=""
         value="AA1>E1>Q01>QA1>Circuit_Breaker"
@@ -206,39 +189,29 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         role="separator"
       >
       </li>
-      <mwc-radio-list-item
-        aria-disabled="false"
-        graphic="control"
-        group="Circuit_Breaker"
-        mwc-list-item=""
-        selected=""
-        tabindex="-1"
-        twoline=""
-        value="Circuit_Breaker OpenSCD_LLN0"
+      <mwc-select
+        label="LLN0"
+        naturalmenuwidth=""
+        style="width:100%"
+        value="Circuit_Breaker: OpenSCD_LLN0"
       >
-        <span>
-          LLN0
-        </span>
-        <span slot="secondary">
+        <mwc-list-item
+          aria-disabled="false"
+          mwc-list-item=""
+          tabindex="-1"
+          value="Circuit_Breaker: OpenSCD_LLN0"
+        >
           OpenSCD_LLN0
-        </span>
-      </mwc-radio-list-item>
-      <mwc-radio-list-item
-        aria-disabled="false"
-        graphic="control"
-        group="Circuit_Breaker"
-        mwc-list-item=""
-        tabindex="-1"
-        twoline=""
-        value="Circuit_Breaker OpenSCD_LLN01"
-      >
-        <span>
-          LLN0
-        </span>
-        <span slot="secondary">
+        </mwc-list-item>
+        <mwc-list-item
+          aria-disabled="false"
+          mwc-list-item=""
+          tabindex="-1"
+          value="Circuit_Breaker: OpenSCD_LLN01"
+        >
           OpenSCD_LLN01
-        </span>
-      </mwc-radio-list-item>
+        </mwc-list-item>
+      </mwc-select>
       <mwc-check-list-item
         aria-disabled="false"
         graphic="control"
@@ -269,6 +242,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
       <mwc-list-item
         aria-disabled="false"
         noninteractive=""
+        style="font-weight:500"
         tabindex="-1"
         twoline=""
         value="AA1>E1>Q01>Timed_Overcurrent"
@@ -286,23 +260,22 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         role="separator"
       >
       </li>
-      <mwc-radio-list-item
-        aria-disabled="false"
-        graphic="control"
-        group="Timed_Overcurrent"
-        mwc-list-item=""
-        selected=""
-        tabindex="-1"
-        twoline=""
-        value="Timed_Overcurrent OpenSCD_LLN01"
+      <mwc-select
+        disabled=""
+        label="LLN0"
+        naturalmenuwidth=""
+        style="width:100%"
+        value="Timed_Overcurrent: OpenSCD_LLN01"
       >
-        <span>
-          LLN0
-        </span>
-        <span slot="secondary">
+        <mwc-list-item
+          aria-disabled="false"
+          mwc-list-item=""
+          tabindex="-1"
+          value="Timed_Overcurrent: OpenSCD_LLN01"
+        >
           OpenSCD_LLN01
-        </span>
-      </mwc-radio-list-item>
+        </mwc-list-item>
+      </mwc-select>
       <mwc-check-list-item
         aria-disabled="false"
         graphic="control"
@@ -324,6 +297,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
       <mwc-list-item
         aria-disabled="false"
         noninteractive=""
+        style="font-weight:500"
         tabindex="-1"
         twoline=""
         value="AA1>E1>Q01>Distance_Protection"
@@ -341,39 +315,29 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         role="separator"
       >
       </li>
-      <mwc-radio-list-item
-        aria-disabled="false"
-        graphic="control"
-        group="Distance_Protection"
-        mwc-list-item=""
-        selected=""
-        tabindex="-1"
-        twoline=""
-        value="Distance_Protection OpenSCD_LLN0"
+      <mwc-select
+        label="LLN0"
+        naturalmenuwidth=""
+        style="width:100%"
+        value="Distance_Protection: OpenSCD_LLN0"
       >
-        <span>
-          LLN0
-        </span>
-        <span slot="secondary">
+        <mwc-list-item
+          aria-disabled="false"
+          mwc-list-item=""
+          tabindex="-1"
+          value="Distance_Protection: OpenSCD_LLN0"
+        >
           OpenSCD_LLN0
-        </span>
-      </mwc-radio-list-item>
-      <mwc-radio-list-item
-        aria-disabled="false"
-        graphic="control"
-        group="Distance_Protection"
-        mwc-list-item=""
-        tabindex="-1"
-        twoline=""
-        value="Distance_Protection OpenSCD_LLN01"
-      >
-        <span>
-          LLN0
-        </span>
-        <span slot="secondary">
+        </mwc-list-item>
+        <mwc-list-item
+          aria-disabled="false"
+          mwc-list-item=""
+          tabindex="-1"
+          value="Distance_Protection: OpenSCD_LLN01"
+        >
           OpenSCD_LLN01
-        </span>
-      </mwc-radio-list-item>
+        </mwc-list-item>
+      </mwc-select>
       <mwc-check-list-item
         aria-disabled="false"
         graphic="control"
@@ -413,6 +377,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
       <mwc-list-item
         aria-disabled="false"
         noninteractive=""
+        style="font-weight:500"
         tabindex="-1"
         twoline=""
         value="AA1>E1>Q02>QB1>Disconnector"
@@ -430,39 +395,29 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         role="separator"
       >
       </li>
-      <mwc-radio-list-item
-        aria-disabled="false"
-        graphic="control"
-        group="Q02_QB1_Disconnector"
-        mwc-list-item=""
-        selected=""
-        tabindex="-1"
-        twoline=""
-        value="Q02_QB1_Disconnector OpenSCD_LLN0"
+      <mwc-select
+        label="LLN0"
+        naturalmenuwidth=""
+        style="width:100%"
+        value="Q02_QB1_Disconnector: OpenSCD_LLN0"
       >
-        <span>
-          LLN0
-        </span>
-        <span slot="secondary">
+        <mwc-list-item
+          aria-disabled="false"
+          mwc-list-item=""
+          tabindex="-1"
+          value="Q02_QB1_Disconnector: OpenSCD_LLN0"
+        >
           OpenSCD_LLN0
-        </span>
-      </mwc-radio-list-item>
-      <mwc-radio-list-item
-        aria-disabled="false"
-        graphic="control"
-        group="Q02_QB1_Disconnector"
-        mwc-list-item=""
-        tabindex="-1"
-        twoline=""
-        value="Q02_QB1_Disconnector OpenSCD_LLN01"
-      >
-        <span>
-          LLN0
-        </span>
-        <span slot="secondary">
+        </mwc-list-item>
+        <mwc-list-item
+          aria-disabled="false"
+          mwc-list-item=""
+          tabindex="-1"
+          value="Q02_QB1_Disconnector: OpenSCD_LLN01"
+        >
           OpenSCD_LLN01
-        </span>
-      </mwc-radio-list-item>
+        </mwc-list-item>
+      </mwc-select>
       <mwc-check-list-item
         aria-disabled="false"
         graphic="control"
@@ -493,6 +448,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
       <mwc-list-item
         aria-disabled="false"
         noninteractive=""
+        style="font-weight:500"
         tabindex="-1"
         twoline=""
         value="AA1>J1>Q01>QC9>Earth_Switch"
@@ -510,39 +466,29 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         role="separator"
       >
       </li>
-      <mwc-radio-list-item
-        aria-disabled="false"
-        graphic="control"
-        group="J1_Q01_QC9_Earth_Switch"
-        mwc-list-item=""
-        selected=""
-        tabindex="-1"
-        twoline=""
-        value="J1_Q01_QC9_Earth_Switch OpenSCD_LLN0"
+      <mwc-select
+        label="LLN0"
+        naturalmenuwidth=""
+        style="width:100%"
+        value="J1_Q01_QC9_Earth_Switch: OpenSCD_LLN0"
       >
-        <span>
-          LLN0
-        </span>
-        <span slot="secondary">
+        <mwc-list-item
+          aria-disabled="false"
+          mwc-list-item=""
+          tabindex="-1"
+          value="J1_Q01_QC9_Earth_Switch: OpenSCD_LLN0"
+        >
           OpenSCD_LLN0
-        </span>
-      </mwc-radio-list-item>
-      <mwc-radio-list-item
-        aria-disabled="false"
-        graphic="control"
-        group="J1_Q01_QC9_Earth_Switch"
-        mwc-list-item=""
-        tabindex="-1"
-        twoline=""
-        value="J1_Q01_QC9_Earth_Switch OpenSCD_LLN01"
-      >
-        <span>
-          LLN0
-        </span>
-        <span slot="secondary">
+        </mwc-list-item>
+        <mwc-list-item
+          aria-disabled="false"
+          mwc-list-item=""
+          tabindex="-1"
+          value="J1_Q01_QC9_Earth_Switch: OpenSCD_LLN01"
+        >
           OpenSCD_LLN01
-        </span>
-      </mwc-radio-list-item>
+        </mwc-list-item>
+      </mwc-select>
       <mwc-check-list-item
         aria-disabled="false"
         graphic="control"
@@ -603,7 +549,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         <LN0
           inst=""
           lnClass="LLN0"
-          lnType="E1_Q01_QC9_Earth_Switch"
+          lnType="OpenSCD_LLN0"
         >
         </LN0>
         <LN
@@ -632,7 +578,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         <LN0
           inst=""
           lnClass="LLN0"
-          lnType="Timed_Overcurrent"
+          lnType="OpenSCD_LLN01"
         >
         </LN0>
         <LN
@@ -654,7 +600,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         <LN0
           inst=""
           lnClass="LLN0"
-          lnType="Q02_QB1_Disconnector"
+          lnType="OpenSCD_LLN0"
         >
         </LN0>
         <LN

--- a/test/unit/menu/__snapshots__/VirtualTemplateIED.test.snap.js
+++ b/test/unit/menu/__snapshots__/VirtualTemplateIED.test.snap.js
@@ -3,12 +3,10 @@ export const snapshots = {};
 
 snapshots["Plugin that creates with some user input a virtual template IED - SPECIFICATION looks like the latest snapshot"] = 
 `<mwc-dialog
-  defaultaction="next"
   heading="Create SPECIFICATION type IED"
   open=""
-  style="--mdc-dialog-min-width:calc(100% + 0px)"
 >
-  <div id="wizard-content">
+  <div>
     <wizard-textfield
       label="manufacturer"
       required=""
@@ -41,12 +39,6 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
           AA1>E1>Q01>QC9>Earth_Switch
         </span>
       </mwc-list-item>
-      <li
-        divider=""
-        padded=""
-        role="separator"
-      >
-      </li>
       <mwc-select
         label="LLN0"
         naturalmenuwidth=""
@@ -54,9 +46,13 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         value="E1_Q01_QC9_Earth_Switch: OpenSCD_LLN0"
       >
         <mwc-list-item
+          activated=""
           aria-disabled="false"
+          aria-selected="true"
           mwc-list-item=""
-          tabindex="-1"
+          role="option"
+          selected=""
+          tabindex="0"
           value="E1_Q01_QC9_Earth_Switch: OpenSCD_LLN0"
         >
           OpenSCD_LLN0
@@ -64,6 +60,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         <mwc-list-item
           aria-disabled="false"
           mwc-list-item=""
+          role="option"
           tabindex="-1"
           value="E1_Q01_QC9_Earth_Switch: OpenSCD_LLN01"
         >
@@ -97,6 +94,12 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
       >
         XSWI 1
       </mwc-check-list-item>
+      <li
+        divider=""
+        padded=""
+        role="separator"
+      >
+      </li>
       <mwc-list-item
         aria-disabled="false"
         noninteractive=""
@@ -112,12 +115,6 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
           AA1>E1>Q01>QB1>Disconnector
         </span>
       </mwc-list-item>
-      <li
-        divider=""
-        padded=""
-        role="separator"
-      >
-      </li>
       <mwc-select
         label="LLN0"
         naturalmenuwidth=""
@@ -125,9 +122,13 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         value="Q01_QB1_Disconnector: OpenSCD_LLN0"
       >
         <mwc-list-item
+          activated=""
           aria-disabled="false"
+          aria-selected="true"
           mwc-list-item=""
-          tabindex="-1"
+          role="option"
+          selected=""
+          tabindex="0"
           value="Q01_QB1_Disconnector: OpenSCD_LLN0"
         >
           OpenSCD_LLN0
@@ -135,6 +136,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         <mwc-list-item
           aria-disabled="false"
           mwc-list-item=""
+          role="option"
           tabindex="-1"
           value="Q01_QB1_Disconnector: OpenSCD_LLN01"
         >
@@ -168,6 +170,12 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
       >
         CILO 1
       </mwc-check-list-item>
+      <li
+        divider=""
+        padded=""
+        role="separator"
+      >
+      </li>
       <mwc-list-item
         aria-disabled="false"
         noninteractive=""
@@ -183,12 +191,6 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
           AA1>E1>Q01>QA1>Circuit_Breaker
         </span>
       </mwc-list-item>
-      <li
-        divider=""
-        padded=""
-        role="separator"
-      >
-      </li>
       <mwc-select
         label="LLN0"
         naturalmenuwidth=""
@@ -196,9 +198,13 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         value="Circuit_Breaker: OpenSCD_LLN0"
       >
         <mwc-list-item
+          activated=""
           aria-disabled="false"
+          aria-selected="true"
           mwc-list-item=""
-          tabindex="-1"
+          role="option"
+          selected=""
+          tabindex="0"
           value="Circuit_Breaker: OpenSCD_LLN0"
         >
           OpenSCD_LLN0
@@ -206,6 +212,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         <mwc-list-item
           aria-disabled="false"
           mwc-list-item=""
+          role="option"
           tabindex="-1"
           value="Circuit_Breaker: OpenSCD_LLN01"
         >
@@ -239,6 +246,12 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
       >
         XCBR 1
       </mwc-check-list-item>
+      <li
+        divider=""
+        padded=""
+        role="separator"
+      >
+      </li>
       <mwc-list-item
         aria-disabled="false"
         noninteractive=""
@@ -254,12 +267,6 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
           AA1>E1>Q01>Timed_Overcurrent
         </span>
       </mwc-list-item>
-      <li
-        divider=""
-        padded=""
-        role="separator"
-      >
-      </li>
       <mwc-select
         disabled=""
         label="LLN0"
@@ -268,9 +275,13 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         value="Timed_Overcurrent: OpenSCD_LLN01"
       >
         <mwc-list-item
+          activated=""
           aria-disabled="false"
+          aria-selected="true"
           mwc-list-item=""
-          tabindex="-1"
+          role="option"
+          selected=""
+          tabindex="0"
           value="Timed_Overcurrent: OpenSCD_LLN01"
         >
           OpenSCD_LLN01
@@ -294,6 +305,12 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
       >
         IDD_ PTOC 1
       </mwc-check-list-item>
+      <li
+        divider=""
+        padded=""
+        role="separator"
+      >
+      </li>
       <mwc-list-item
         aria-disabled="false"
         noninteractive=""
@@ -309,12 +326,6 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
           AA1>E1>Q01>Distance_Protection
         </span>
       </mwc-list-item>
-      <li
-        divider=""
-        padded=""
-        role="separator"
-      >
-      </li>
       <mwc-select
         label="LLN0"
         naturalmenuwidth=""
@@ -322,9 +333,13 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         value="Distance_Protection: OpenSCD_LLN0"
       >
         <mwc-list-item
+          activated=""
           aria-disabled="false"
+          aria-selected="true"
           mwc-list-item=""
-          tabindex="-1"
+          role="option"
+          selected=""
+          tabindex="0"
           value="Distance_Protection: OpenSCD_LLN0"
         >
           OpenSCD_LLN0
@@ -332,6 +347,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         <mwc-list-item
           aria-disabled="false"
           mwc-list-item=""
+          role="option"
           tabindex="-1"
           value="Distance_Protection: OpenSCD_LLN01"
         >
@@ -374,6 +390,12 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
       >
         Zone1 PDIS 1
       </mwc-check-list-item>
+      <li
+        divider=""
+        padded=""
+        role="separator"
+      >
+      </li>
       <mwc-list-item
         aria-disabled="false"
         noninteractive=""
@@ -389,12 +411,6 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
           AA1>E1>Q02>QB1>Disconnector
         </span>
       </mwc-list-item>
-      <li
-        divider=""
-        padded=""
-        role="separator"
-      >
-      </li>
       <mwc-select
         label="LLN0"
         naturalmenuwidth=""
@@ -402,9 +418,13 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         value="Q02_QB1_Disconnector: OpenSCD_LLN0"
       >
         <mwc-list-item
+          activated=""
           aria-disabled="false"
+          aria-selected="true"
           mwc-list-item=""
-          tabindex="-1"
+          role="option"
+          selected=""
+          tabindex="0"
           value="Q02_QB1_Disconnector: OpenSCD_LLN0"
         >
           OpenSCD_LLN0
@@ -412,6 +432,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         <mwc-list-item
           aria-disabled="false"
           mwc-list-item=""
+          role="option"
           tabindex="-1"
           value="Q02_QB1_Disconnector: OpenSCD_LLN01"
         >
@@ -445,6 +466,12 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
       >
         CILO 1
       </mwc-check-list-item>
+      <li
+        divider=""
+        padded=""
+        role="separator"
+      >
+      </li>
       <mwc-list-item
         aria-disabled="false"
         noninteractive=""
@@ -460,12 +487,6 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
           AA1>J1>Q01>QC9>Earth_Switch
         </span>
       </mwc-list-item>
-      <li
-        divider=""
-        padded=""
-        role="separator"
-      >
-      </li>
       <mwc-select
         label="LLN0"
         naturalmenuwidth=""
@@ -473,9 +494,13 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         value="J1_Q01_QC9_Earth_Switch: OpenSCD_LLN0"
       >
         <mwc-list-item
+          activated=""
           aria-disabled="false"
+          aria-selected="true"
           mwc-list-item=""
-          tabindex="-1"
+          role="option"
+          selected=""
+          tabindex="0"
           value="J1_Q01_QC9_Earth_Switch: OpenSCD_LLN0"
         >
           OpenSCD_LLN0
@@ -483,6 +508,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         <mwc-list-item
           aria-disabled="false"
           mwc-list-item=""
+          role="option"
           tabindex="-1"
           value="J1_Q01_QC9_Earth_Switch: OpenSCD_LLN01"
         >
@@ -516,6 +542,12 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
       >
         XSWI 1
       </mwc-check-list-item>
+      <li
+        divider=""
+        padded=""
+        role="separator"
+      >
+      </li>
     </filtered-list>
   </div>
   <mwc-button
@@ -526,6 +558,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
   >
   </mwc-button>
   <mwc-button
+    disabled=""
     icon="save"
     label="[save]"
     slot="primaryAction"
@@ -554,22 +587,8 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         </LN0>
         <LN
           inst="1"
-          lnClass="CSWI"
-          lnType="OpenSCD_CSWI"
-          prefix=""
-        >
-        </LN>
-        <LN
-          inst="1"
           lnClass="CILO"
           lnType="OpenSCD_CILO"
-          prefix=""
-        >
-        </LN>
-        <LN
-          inst="1"
-          lnClass="XSWI"
-          lnType="OpenSCD_XSWI_EarthSwitch"
           prefix=""
         >
         </LN>
@@ -588,13 +607,6 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
           prefix="ID_"
         >
         </LN>
-        <LN
-          inst="1"
-          lnClass="PTOC"
-          lnType="OpenSCD_PTOC"
-          prefix="IDD_"
-        >
-        </LN>
       </LDevice>
       <LDevice inst="Q02_QB1_Disconnector">
         <LN0
@@ -607,20 +619,6 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
           inst="1"
           lnClass="CSWI"
           lnType="OpenSCD_CSWI"
-          prefix=""
-        >
-        </LN>
-        <LN
-          inst="1"
-          lnClass="XSWI"
-          lnType="OpenSCD_XSWI_DIS"
-          prefix=""
-        >
-        </LN>
-        <LN
-          inst="1"
-          lnClass="CILO"
-          lnType="OpenSCD_CILO"
           prefix=""
         >
         </LN>

--- a/test/unit/menu/__snapshots__/VirtualTemplateIED.test.snap.js
+++ b/test/unit/menu/__snapshots__/VirtualTemplateIED.test.snap.js
@@ -1,0 +1,687 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["Plugin that creates with some user input a virtual template IED - SPECIFICATION looks like the latest snapshot"] = 
+`<mwc-dialog
+  defaultaction="next"
+  heading="Create SPECIFICATION type IED"
+  open=""
+  style="--mdc-dialog-min-width:calc(100% + 0px)"
+>
+  <div id="wizard-content">
+    <wizard-textfield
+      label="manufacturer"
+      required=""
+    >
+    </wizard-textfield>
+    <wizard-textfield
+      disabled=""
+      label="desc"
+      nullable=""
+    >
+    </wizard-textfield>
+    <wizard-textfield
+      label="AccessPoint name"
+      required=""
+    >
+    </wizard-textfield>
+    <filtered-list multi="">
+      <mwc-list-item
+        aria-disabled="false"
+        noninteractive=""
+        tabindex="-1"
+        twoline=""
+        value="AA1>E1>Q01>QC9>Earth_Switch"
+      >
+        <span>
+          E1_Q01_QC9_Earth_Switch
+        </span>
+        <span slot="secondary">
+          AA1>E1>Q01>QC9>Earth_Switch
+        </span>
+      </mwc-list-item>
+      <li
+        divider=""
+        padded=""
+        role="separator"
+      >
+      </li>
+      <mwc-radio-list-item
+        aria-disabled="false"
+        graphic="control"
+        group="E1_Q01_QC9_Earth_Switch"
+        mwc-list-item=""
+        selected=""
+        tabindex="0"
+        twoline=""
+        value="E1_Q01_QC9_Earth_Switch OpenSCD_LLN0"
+      >
+        <span>
+          LLN0
+        </span>
+        <span slot="secondary">
+          OpenSCD_LLN0
+        </span>
+      </mwc-radio-list-item>
+      <mwc-radio-list-item
+        aria-disabled="false"
+        graphic="control"
+        group="E1_Q01_QC9_Earth_Switch"
+        mwc-list-item=""
+        tabindex="-1"
+        twoline=""
+        value="E1_Q01_QC9_Earth_Switch OpenSCD_LLN01"
+      >
+        <span>
+          LLN0
+        </span>
+        <span slot="secondary">
+          OpenSCD_LLN01
+        </span>
+      </mwc-radio-list-item>
+      <mwc-check-list-item
+        aria-disabled="false"
+        graphic="control"
+        mwc-list-item=""
+        tabindex="-1"
+        value="AA1>E1>Q01>QC9>Earth_Switch>(CSWI OpenSCD_CSWI)"
+      >
+        CSWI 1
+      </mwc-check-list-item>
+      <mwc-check-list-item
+        aria-disabled="false"
+        graphic="control"
+        mwc-list-item=""
+        tabindex="-1"
+        value="AA1>E1>Q01>QC9>Earth_Switch>(CILO OpenSCD_CILO)"
+      >
+        CILO 1
+      </mwc-check-list-item>
+      <mwc-check-list-item
+        aria-disabled="false"
+        graphic="control"
+        mwc-list-item=""
+        tabindex="-1"
+        value="AA1>E1>Q01>QC9>Earth_Switch>(XSWI OpenSCD_XSWI_EarthSwitch)"
+      >
+        XSWI 1
+      </mwc-check-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        noninteractive=""
+        tabindex="-1"
+        twoline=""
+        value="AA1>E1>Q01>QB1>Disconnector"
+      >
+        <span>
+          Q01_QB1_Disconnector
+        </span>
+        <span slot="secondary">
+          AA1>E1>Q01>QB1>Disconnector
+        </span>
+      </mwc-list-item>
+      <li
+        divider=""
+        padded=""
+        role="separator"
+      >
+      </li>
+      <mwc-radio-list-item
+        aria-disabled="false"
+        graphic="control"
+        group="Q01_QB1_Disconnector"
+        mwc-list-item=""
+        selected=""
+        tabindex="-1"
+        twoline=""
+        value="Q01_QB1_Disconnector OpenSCD_LLN0"
+      >
+        <span>
+          LLN0
+        </span>
+        <span slot="secondary">
+          OpenSCD_LLN0
+        </span>
+      </mwc-radio-list-item>
+      <mwc-radio-list-item
+        aria-disabled="false"
+        graphic="control"
+        group="Q01_QB1_Disconnector"
+        mwc-list-item=""
+        tabindex="-1"
+        twoline=""
+        value="Q01_QB1_Disconnector OpenSCD_LLN01"
+      >
+        <span>
+          LLN0
+        </span>
+        <span slot="secondary">
+          OpenSCD_LLN01
+        </span>
+      </mwc-radio-list-item>
+      <mwc-check-list-item
+        aria-disabled="false"
+        graphic="control"
+        mwc-list-item=""
+        tabindex="-1"
+        value="AA1>E1>Q01>QB1>Disconnector>(CSWI OpenSCD_CSWI)"
+      >
+        CSWI 1
+      </mwc-check-list-item>
+      <mwc-check-list-item
+        aria-disabled="false"
+        graphic="control"
+        mwc-list-item=""
+        tabindex="-1"
+        value="AA1>E1>Q01>QB1>Disconnector>(XSWI OpenSCD_XSWI_DIS)"
+      >
+        XSWI 1
+      </mwc-check-list-item>
+      <mwc-check-list-item
+        aria-disabled="false"
+        graphic="control"
+        mwc-list-item=""
+        tabindex="-1"
+        value="AA1>E1>Q01>QB1>Disconnector>(CILO OpenSCD_CILO)"
+      >
+        CILO 1
+      </mwc-check-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        noninteractive=""
+        tabindex="-1"
+        twoline=""
+        value="AA1>E1>Q01>QA1>Circuit_Breaker"
+      >
+        <span>
+          Circuit_Breaker
+        </span>
+        <span slot="secondary">
+          AA1>E1>Q01>QA1>Circuit_Breaker
+        </span>
+      </mwc-list-item>
+      <li
+        divider=""
+        padded=""
+        role="separator"
+      >
+      </li>
+      <mwc-radio-list-item
+        aria-disabled="false"
+        graphic="control"
+        group="Circuit_Breaker"
+        mwc-list-item=""
+        selected=""
+        tabindex="-1"
+        twoline=""
+        value="Circuit_Breaker OpenSCD_LLN0"
+      >
+        <span>
+          LLN0
+        </span>
+        <span slot="secondary">
+          OpenSCD_LLN0
+        </span>
+      </mwc-radio-list-item>
+      <mwc-radio-list-item
+        aria-disabled="false"
+        graphic="control"
+        group="Circuit_Breaker"
+        mwc-list-item=""
+        tabindex="-1"
+        twoline=""
+        value="Circuit_Breaker OpenSCD_LLN01"
+      >
+        <span>
+          LLN0
+        </span>
+        <span slot="secondary">
+          OpenSCD_LLN01
+        </span>
+      </mwc-radio-list-item>
+      <mwc-check-list-item
+        aria-disabled="false"
+        graphic="control"
+        mwc-list-item=""
+        tabindex="-1"
+        value="AA1>E1>Q01>QA1>Circuit_Breaker>(CSWI OpenSCD_CSWI)"
+      >
+        CSWI 1
+      </mwc-check-list-item>
+      <mwc-check-list-item
+        aria-disabled="false"
+        graphic="control"
+        mwc-list-item=""
+        tabindex="-1"
+        value="AA1>E1>Q01>QA1>Circuit_Breaker>(CILO OpenSCD_CILO)"
+      >
+        CILO 1
+      </mwc-check-list-item>
+      <mwc-check-list-item
+        aria-disabled="false"
+        graphic="control"
+        mwc-list-item=""
+        tabindex="-1"
+        value="AA1>E1>Q01>QA1>Circuit_Breaker>(XCBR OpenSCD_XCBR)"
+      >
+        XCBR 1
+      </mwc-check-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        noninteractive=""
+        tabindex="-1"
+        twoline=""
+        value="AA1>E1>Q01>Timed_Overcurrent"
+      >
+        <span>
+          Timed_Overcurrent
+        </span>
+        <span slot="secondary">
+          AA1>E1>Q01>Timed_Overcurrent
+        </span>
+      </mwc-list-item>
+      <li
+        divider=""
+        padded=""
+        role="separator"
+      >
+      </li>
+      <mwc-radio-list-item
+        aria-disabled="false"
+        graphic="control"
+        group="Timed_Overcurrent"
+        mwc-list-item=""
+        selected=""
+        tabindex="-1"
+        twoline=""
+        value="Timed_Overcurrent OpenSCD_LLN01"
+      >
+        <span>
+          LLN0
+        </span>
+        <span slot="secondary">
+          OpenSCD_LLN01
+        </span>
+      </mwc-radio-list-item>
+      <mwc-check-list-item
+        aria-disabled="false"
+        graphic="control"
+        mwc-list-item=""
+        tabindex="-1"
+        value="AA1>E1>Q01>Timed_Overcurrent>(PTOC OpenSCD_PTOC)"
+      >
+        ID_ PTOC 2
+      </mwc-check-list-item>
+      <mwc-check-list-item
+        aria-disabled="false"
+        graphic="control"
+        mwc-list-item=""
+        tabindex="-1"
+        value="AA1>E1>Q01>Timed_Overcurrent>(PTOC OpenSCD_PTOC)"
+      >
+        IDD_ PTOC 1
+      </mwc-check-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        noninteractive=""
+        tabindex="-1"
+        twoline=""
+        value="AA1>E1>Q01>Distance_Protection"
+      >
+        <span>
+          Distance_Protection
+        </span>
+        <span slot="secondary">
+          AA1>E1>Q01>Distance_Protection
+        </span>
+      </mwc-list-item>
+      <li
+        divider=""
+        padded=""
+        role="separator"
+      >
+      </li>
+      <mwc-radio-list-item
+        aria-disabled="false"
+        graphic="control"
+        group="Distance_Protection"
+        mwc-list-item=""
+        selected=""
+        tabindex="-1"
+        twoline=""
+        value="Distance_Protection OpenSCD_LLN0"
+      >
+        <span>
+          LLN0
+        </span>
+        <span slot="secondary">
+          OpenSCD_LLN0
+        </span>
+      </mwc-radio-list-item>
+      <mwc-radio-list-item
+        aria-disabled="false"
+        graphic="control"
+        group="Distance_Protection"
+        mwc-list-item=""
+        tabindex="-1"
+        twoline=""
+        value="Distance_Protection OpenSCD_LLN01"
+      >
+        <span>
+          LLN0
+        </span>
+        <span slot="secondary">
+          OpenSCD_LLN01
+        </span>
+      </mwc-radio-list-item>
+      <mwc-check-list-item
+        aria-disabled="false"
+        graphic="control"
+        mwc-list-item=""
+        tabindex="-1"
+        value="AA1>E1>Q01>Distance_Protection>Zone4>(PDIS OpenSCD_PDIS)"
+      >
+        Zone4 PDIS 1
+      </mwc-check-list-item>
+      <mwc-check-list-item
+        aria-disabled="false"
+        graphic="control"
+        mwc-list-item=""
+        tabindex="-1"
+        value="AA1>E1>Q01>Distance_Protection>Zon3>(PDIS OpenSCD_PDIS)"
+      >
+        Zon3 PDIS 1
+      </mwc-check-list-item>
+      <mwc-check-list-item
+        aria-disabled="false"
+        graphic="control"
+        mwc-list-item=""
+        tabindex="-1"
+        value="AA1>E1>Q01>Distance_Protection>Zone2>(PDIS OpenSCD_PDIS)"
+      >
+        Zone2 PDIS 1
+      </mwc-check-list-item>
+      <mwc-check-list-item
+        aria-disabled="false"
+        graphic="control"
+        mwc-list-item=""
+        tabindex="-1"
+        value="AA1>E1>Q01>Distance_Protection>Zone1>(PDIS OpenSCD_PDIS)"
+      >
+        Zone1 PDIS 1
+      </mwc-check-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        noninteractive=""
+        tabindex="-1"
+        twoline=""
+        value="AA1>E1>Q02>QB1>Disconnector"
+      >
+        <span>
+          Q02_QB1_Disconnector
+        </span>
+        <span slot="secondary">
+          AA1>E1>Q02>QB1>Disconnector
+        </span>
+      </mwc-list-item>
+      <li
+        divider=""
+        padded=""
+        role="separator"
+      >
+      </li>
+      <mwc-radio-list-item
+        aria-disabled="false"
+        graphic="control"
+        group="Q02_QB1_Disconnector"
+        mwc-list-item=""
+        selected=""
+        tabindex="-1"
+        twoline=""
+        value="Q02_QB1_Disconnector OpenSCD_LLN0"
+      >
+        <span>
+          LLN0
+        </span>
+        <span slot="secondary">
+          OpenSCD_LLN0
+        </span>
+      </mwc-radio-list-item>
+      <mwc-radio-list-item
+        aria-disabled="false"
+        graphic="control"
+        group="Q02_QB1_Disconnector"
+        mwc-list-item=""
+        tabindex="-1"
+        twoline=""
+        value="Q02_QB1_Disconnector OpenSCD_LLN01"
+      >
+        <span>
+          LLN0
+        </span>
+        <span slot="secondary">
+          OpenSCD_LLN01
+        </span>
+      </mwc-radio-list-item>
+      <mwc-check-list-item
+        aria-disabled="false"
+        graphic="control"
+        mwc-list-item=""
+        tabindex="-1"
+        value="AA1>E1>Q02>QB1>Disconnector>(CSWI OpenSCD_CSWI)"
+      >
+        CSWI 1
+      </mwc-check-list-item>
+      <mwc-check-list-item
+        aria-disabled="false"
+        graphic="control"
+        mwc-list-item=""
+        tabindex="-1"
+        value="AA1>E1>Q02>QB1>Disconnector>(XSWI OpenSCD_XSWI_DIS)"
+      >
+        XSWI 1
+      </mwc-check-list-item>
+      <mwc-check-list-item
+        aria-disabled="false"
+        graphic="control"
+        mwc-list-item=""
+        tabindex="-1"
+        value="AA1>E1>Q02>QB1>Disconnector>(CILO OpenSCD_CILO)"
+      >
+        CILO 1
+      </mwc-check-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        noninteractive=""
+        tabindex="-1"
+        twoline=""
+        value="AA1>J1>Q01>QC9>Earth_Switch"
+      >
+        <span>
+          J1_Q01_QC9_Earth_Switch
+        </span>
+        <span slot="secondary">
+          AA1>J1>Q01>QC9>Earth_Switch
+        </span>
+      </mwc-list-item>
+      <li
+        divider=""
+        padded=""
+        role="separator"
+      >
+      </li>
+      <mwc-radio-list-item
+        aria-disabled="false"
+        graphic="control"
+        group="J1_Q01_QC9_Earth_Switch"
+        mwc-list-item=""
+        selected=""
+        tabindex="-1"
+        twoline=""
+        value="J1_Q01_QC9_Earth_Switch OpenSCD_LLN0"
+      >
+        <span>
+          LLN0
+        </span>
+        <span slot="secondary">
+          OpenSCD_LLN0
+        </span>
+      </mwc-radio-list-item>
+      <mwc-radio-list-item
+        aria-disabled="false"
+        graphic="control"
+        group="J1_Q01_QC9_Earth_Switch"
+        mwc-list-item=""
+        tabindex="-1"
+        twoline=""
+        value="J1_Q01_QC9_Earth_Switch OpenSCD_LLN01"
+      >
+        <span>
+          LLN0
+        </span>
+        <span slot="secondary">
+          OpenSCD_LLN01
+        </span>
+      </mwc-radio-list-item>
+      <mwc-check-list-item
+        aria-disabled="false"
+        graphic="control"
+        mwc-list-item=""
+        tabindex="-1"
+        value="AA1>J1>Q01>QC9>Earth_Switch>(CSWI OpenSCD_CSWI)"
+      >
+        CSWI 1
+      </mwc-check-list-item>
+      <mwc-check-list-item
+        aria-disabled="false"
+        graphic="control"
+        mwc-list-item=""
+        tabindex="-1"
+        value="AA1>J1>Q01>QC9>Earth_Switch>(CILO OpenSCD_CILO)"
+      >
+        CILO 1
+      </mwc-check-list-item>
+      <mwc-check-list-item
+        aria-disabled="false"
+        graphic="control"
+        mwc-list-item=""
+        tabindex="-1"
+        value="AA1>J1>Q01>QC9>Earth_Switch>(XSWI OpenSCD_XSWI_EarthSwitch)"
+      >
+        XSWI 1
+      </mwc-check-list-item>
+    </filtered-list>
+  </div>
+  <mwc-button
+    dialogaction="close"
+    label="[cancel]"
+    slot="secondaryAction"
+    style="--mdc-theme-primary: var(--mdc-theme-error)"
+  >
+  </mwc-button>
+  <mwc-button
+    icon="save"
+    label="[save]"
+    slot="primaryAction"
+    trailingicon=""
+  >
+  </mwc-button>
+</mwc-dialog>
+`;
+/* end snapshot Plugin that creates with some user input a virtual template IED - SPECIFICATION looks like the latest snapshot */
+
+snapshots["Plugin that creates with some user input a virtual template IED - SPECIFICATION IEDs data model show selected logical nodes and its structure"] = 
+`<IED
+  manufacturer="SomeCompanyName"
+  name="SPECIFICATION"
+>
+  <AccessPoint name="P1">
+    <Server>
+      <Authentication>
+      </Authentication>
+      <LDevice inst="E1_Q01_QC9_Earth_Switch">
+        <LN0
+          inst=""
+          lnClass="LLN0"
+          lnType="E1_Q01_QC9_Earth_Switch"
+        >
+        </LN0>
+        <LN
+          inst="1"
+          lnClass="CSWI"
+          lnType="OpenSCD_CSWI"
+          prefix=""
+        >
+        </LN>
+        <LN
+          inst="1"
+          lnClass="CILO"
+          lnType="OpenSCD_CILO"
+          prefix=""
+        >
+        </LN>
+        <LN
+          inst="1"
+          lnClass="XSWI"
+          lnType="OpenSCD_XSWI_EarthSwitch"
+          prefix=""
+        >
+        </LN>
+      </LDevice>
+      <LDevice inst="Timed_Overcurrent">
+        <LN0
+          inst=""
+          lnClass="LLN0"
+          lnType="Timed_Overcurrent"
+        >
+        </LN0>
+        <LN
+          inst="2"
+          lnClass="PTOC"
+          lnType="OpenSCD_PTOC"
+          prefix="ID_"
+        >
+        </LN>
+        <LN
+          inst="1"
+          lnClass="PTOC"
+          lnType="OpenSCD_PTOC"
+          prefix="IDD_"
+        >
+        </LN>
+      </LDevice>
+      <LDevice inst="Q02_QB1_Disconnector">
+        <LN0
+          inst=""
+          lnClass="LLN0"
+          lnType="Q02_QB1_Disconnector"
+        >
+        </LN0>
+        <LN
+          inst="1"
+          lnClass="CSWI"
+          lnType="OpenSCD_CSWI"
+          prefix=""
+        >
+        </LN>
+        <LN
+          inst="1"
+          lnClass="XSWI"
+          lnType="OpenSCD_XSWI_DIS"
+          prefix=""
+        >
+        </LN>
+        <LN
+          inst="1"
+          lnClass="CILO"
+          lnType="OpenSCD_CILO"
+          prefix=""
+        >
+        </LN>
+      </LDevice>
+    </Server>
+  </AccessPoint>
+</IED>
+`;
+/* end snapshot Plugin that creates with some user input a virtual template IED - SPECIFICATION IEDs data model show selected logical nodes and its structure */
+

--- a/test/unit/menu/virtualtemplateied/__snapshots__/foundation.test.snap.js
+++ b/test/unit/menu/virtualtemplateied/__snapshots__/foundation.test.snap.js
@@ -1,0 +1,48 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["foundation for virtual IED creation getSpecificationIED function looks like the latest snapshot"] = 
+`<IED
+  manufacturer="some manufactorer"
+  name="SPECIFICATION"
+>
+  <AccessPoint name="P1">
+    <Server>
+      <Authentication>
+      </Authentication>
+      <LDevice inst="someProtection">
+        <LN0
+          inst=""
+          lnClass="LLN0"
+          lnType="someLLN0"
+        >
+        </LN0>
+        <LN
+          inst="1"
+          lnClass="PTOC"
+          lnType="somePTOC"
+          prefix="IDD"
+        >
+        </LN>
+      </LDevice>
+      <LDevice inst="someControl">
+        <LN0
+          inst=""
+          lnClass="LLN0"
+          lnType="someLLN0"
+        >
+        </LN0>
+        <LN
+          inst="1"
+          lnClass="CSWI"
+          lnType="someCSWI"
+          prefix=""
+        >
+        </LN>
+      </LDevice>
+    </Server>
+  </AccessPoint>
+</IED>
+`;
+/* end snapshot foundation for virtual IED creation getSpecificationIED function looks like the latest snapshot */
+

--- a/test/unit/menu/virtualtemplateied/foundation.test.ts
+++ b/test/unit/menu/virtualtemplateied/foundation.test.ts
@@ -1,6 +1,9 @@
 import { expect } from '@open-wc/testing';
 
-import { isLeafFunction } from '../../../../src/menu/virtualtemplateied/foundation.js';
+import {
+  getNonLeafParent,
+  isLeafFunction,
+} from '../../../../src/menu/virtualtemplateied/foundation.js';
 
 describe('foundation for virtual IED creation', () => {
   describe('function checking for leaf function type elements', () => {
@@ -54,5 +57,44 @@ describe('foundation for virtual IED creation', () => {
 
     it('returns true for non-leaf SubFunction element', () =>
       expect(isLeafFunction(nonLeafEqSubFunction)).to.be.false);
+  });
+
+  describe('getNonLeafParent function', () => {
+    let invalidParantTag: Element;
+    let directParent: Element;
+    let directParentsLNode: Element | null;
+    let leafParent: Element;
+    let leafParentsLNode: Element | null;
+
+    beforeEach(() => {
+      invalidParantTag = new DOMParser().parseFromString(
+        '<Element name="someElement"><LNode/></Element>',
+        'application/xml'
+      ).documentElement;
+
+      directParent = new DOMParser().parseFromString(
+        '<SubFunction name="leafFunction"><LNode/><LNode/></SubFunction>',
+        'application/xml'
+      ).documentElement;
+      directParentsLNode = directParent.querySelector('LNode');
+
+      leafParent = new DOMParser().parseFromString(
+        '<Function name="onLeaf"><SubFunction name="leafFunction"><LNode/></SubFunction></Function>',
+        'application/xml'
+      ).documentElement;
+      leafParentsLNode = leafParent.querySelector('LNode');
+    });
+
+    it('return null for null inputs', () =>
+      expect(getNonLeafParent(null)).to.be.null);
+
+    it('returns null for invalid closest parent tag', () =>
+      expect(getNonLeafParent(invalidParantTag)).to.be.null);
+
+    it('returns null for invalid parent tag', () =>
+      expect(getNonLeafParent(directParentsLNode)).to.equal(directParent));
+
+    it('returns null for invalid parent tag', () =>
+      expect(getNonLeafParent(leafParentsLNode)).to.equal(leafParent));
   });
 });

--- a/test/unit/menu/virtualtemplateied/foundation.test.ts
+++ b/test/unit/menu/virtualtemplateied/foundation.test.ts
@@ -1,0 +1,58 @@
+import { expect } from '@open-wc/testing';
+
+import { isLeafFunction } from '../../../../src/menu/virtualtemplateied/foundation.js';
+
+describe('foundation for virtual IED creation', () => {
+  describe('function checking for leaf function type elements', () => {
+    let randomElement: Element;
+    let leafSubFunction: Element;
+    let nonLeafSubFunction: Element;
+    let leafEqSubFunction: Element;
+    let nonLeafEqSubFunction: Element;
+
+    beforeEach(() => {
+      randomElement = new DOMParser().parseFromString(
+        '<Element name="someFunction"></Element>',
+        'application/xml'
+      ).documentElement;
+
+      leafSubFunction = new DOMParser().parseFromString(
+        '<SubFunction name="leafFunction"><LNode/></SubFunction>',
+        'application/xml'
+      ).documentElement;
+
+      nonLeafSubFunction = new DOMParser().parseFromString(
+        '<SubFunction name="nonLeafFunction"><LNode/><LNode/></SubFunction>',
+        'application/xml'
+      ).documentElement;
+
+      leafEqSubFunction = new DOMParser().parseFromString(
+        '<EqSubFunction name="leafFunction"><LNode/></EqSubFunction>',
+        'application/xml'
+      ).documentElement;
+
+      nonLeafEqSubFunction = new DOMParser().parseFromString(
+        '<EqSubFunction name="nonLeafFunction"><LNode/><LNode/></EqSubFunction>',
+        'application/xml'
+      ).documentElement;
+    });
+
+    it('returns false for input null', () =>
+      expect(isLeafFunction(null)).to.be.false);
+
+    it('returns false for Function element', () =>
+      expect(isLeafFunction(randomElement)).to.be.false);
+
+    it('returns true for leaf SubFcuntion element', () =>
+      expect(isLeafFunction(leafSubFunction)).to.be.true);
+
+    it('returns true for non-leaf SubFuction element', () =>
+      expect(isLeafFunction(nonLeafSubFunction)).to.be.false);
+
+    it('returns true for leaf EqSubFunction element', () =>
+      expect(isLeafFunction(leafEqSubFunction)).to.be.true);
+
+    it('returns true for non-leaf SubFunction element', () =>
+      expect(isLeafFunction(nonLeafEqSubFunction)).to.be.false);
+  });
+});

--- a/test/unit/menu/virtualtemplateied/foundation.test.ts
+++ b/test/unit/menu/virtualtemplateied/foundation.test.ts
@@ -4,8 +4,10 @@ import { identity } from '../../../../src/foundation.js';
 import {
   getFunctionNamingPrefix,
   getNonLeafParent,
+  getSpecificationIED,
   getUniqueFunctionName,
   isLeafFunction,
+  VirtualIEDDescription,
 } from '../../../../src/menu/virtualtemplateied/foundation.js';
 
 describe('foundation for virtual IED creation', () => {
@@ -186,5 +188,79 @@ describe('foundation for virtual IED creation', () => {
       expect(getUniqueFunctionName(doc.querySelector('Bay')!)).to.equal(
         identity(doc.querySelector('Bay'))
       ));
+  });
+
+  describe('getUniqueFunctionName function', () => {
+    let doc: XMLDocument;
+
+    beforeEach(async () => {
+      doc = await fetch('/test/testfiles/virtualied/specificfromfunctions.ssd')
+        .then(response => response.text())
+        .then(str => new DOMParser().parseFromString(str, 'application/xml'));
+    });
+
+    it('return unique name for function type element', () =>
+      expect(
+        getUniqueFunctionName(
+          doc.querySelector('EqFunction[name="Disconnector"]')!
+        )
+      ).to.equal('Q01_QB1_Disconnector'));
+
+    it('return unique name for another function type element', () =>
+      expect(
+        getUniqueFunctionName(
+          doc.querySelector('EqFunction[name="Earth_Switch"]')!
+        )
+      ).to.equal('E1_Q01_QC9_Earth_Switch'));
+
+    it('return function type element name if already unique in project', () =>
+      expect(
+        getUniqueFunctionName(
+          doc.querySelector('Function[name="Distance_Protection"]')!
+        )
+      ).to.equal('Distance_Protection'));
+
+    it('return identity string in case input element is not function type element', () =>
+      expect(getUniqueFunctionName(doc.querySelector('Bay')!)).to.equal(
+        identity(doc.querySelector('Bay'))
+      ));
+  });
+
+  describe('getSpecificationIED function', () => {
+    let doc: XMLDocument;
+    let virtualIED: VirtualIEDDescription;
+
+    beforeEach(async () => {
+      doc = await fetch('/test/testfiles/virtualied/specificfromfunctions.ssd')
+        .then(response => response.text())
+        .then(str => new DOMParser().parseFromString(str, 'application/xml'));
+
+      virtualIED = {
+        manufacturer: 'some manufactorer',
+        desc: null,
+        apName: 'P1',
+        lDevices: [
+          {
+            validLdInst: 'someProtection',
+            anyLNs: [
+              { lnClass: 'LLN0', inst: '', prefix: null, lnType: 'someLLN0' },
+              { lnClass: 'PTOC', inst: '1', prefix: 'IDD', lnType: 'somePTOC' },
+            ],
+          },
+          {
+            validLdInst: 'someControl',
+            anyLNs: [
+              { lnClass: 'LLN0', inst: '', prefix: null, lnType: 'someLLN0' },
+              { lnClass: 'CSWI', inst: '1', prefix: '', lnType: 'someCSWI' },
+            ],
+          },
+        ],
+      };
+    });
+
+    it('looks like the latest snapshot', async () =>
+      await expect(
+        getSpecificationIED(doc, virtualIED)
+      ).dom.to.equalSnapshot());
   });
 });

--- a/test/unit/menu/virtualtemplateied/foundation.test.ts
+++ b/test/unit/menu/virtualtemplateied/foundation.test.ts
@@ -1,6 +1,7 @@
 import { expect } from '@open-wc/testing';
 
 import {
+  getFunctionNamingPrefix,
   getNonLeafParent,
   isLeafFunction,
 } from '../../../../src/menu/virtualtemplateied/foundation.js';
@@ -96,5 +97,56 @@ describe('foundation for virtual IED creation', () => {
 
     it('returns null for invalid parent tag', () =>
       expect(getNonLeafParent(leafParentsLNode)).to.equal(leafParent));
+  });
+
+  describe('getFunctionNamingPrefix function', () => {
+    let lNodeWithPrefix: Element;
+    let lNodeWithOutPrefix: Element;
+    let leafSubFunction: Element;
+    let leafSubFunctionsLNode: Element;
+    let nonLeafSubFunction: Element;
+    let nonLeafSubFunctionsLNode: Element;
+
+    beforeEach(() => {
+      lNodeWithPrefix = new DOMParser().parseFromString(
+        '<LNode prefix=""/>',
+        'application/xml'
+      ).documentElement;
+
+      lNodeWithOutPrefix = new DOMParser().parseFromString(
+        '<LNode />',
+        'application/xml'
+      ).documentElement;
+
+      leafSubFunction = new DOMParser().parseFromString(
+        '<SubFunction name="leafFunction"><LNode/></SubFunction>',
+        'application/xml'
+      ).documentElement;
+      leafSubFunctionsLNode = leafSubFunction.querySelector('LNode')!;
+
+      nonLeafSubFunction = new DOMParser().parseFromString(
+        '<SubFunction name="leafFunction"><LNode/><LNode/></SubFunction>',
+        'application/xml'
+      ).documentElement;
+      nonLeafSubFunctionsLNode = nonLeafSubFunction.querySelector('LNode')!;
+    });
+
+    it('return prefix attribute if present in LNode', () =>
+      expect(getFunctionNamingPrefix(lNodeWithPrefix)).to.equal(
+        lNodeWithPrefix.getAttribute('prefix')
+      ));
+
+    it('return empty string if no valid prefix exist', () =>
+      expect(getFunctionNamingPrefix(lNodeWithOutPrefix)).to.equal(''));
+
+    it('returns leaf SubFunction name for missing prefix attribute', () =>
+      expect(getFunctionNamingPrefix(leafSubFunctionsLNode)).to.be.equal(
+        'leafFunction'
+      ));
+
+    it('returns empty string if no valid string exist', () =>
+      expect(getFunctionNamingPrefix(nonLeafSubFunctionsLNode)).to.be.equal(
+        ''
+      ));
   });
 });

--- a/test/unit/menu/virtualtemplateied/foundation.test.ts
+++ b/test/unit/menu/virtualtemplateied/foundation.test.ts
@@ -1,8 +1,10 @@
 import { expect } from '@open-wc/testing';
+import { identity } from '../../../../src/foundation.js';
 
 import {
   getFunctionNamingPrefix,
   getNonLeafParent,
+  getUniqueFunctionName,
   isLeafFunction,
 } from '../../../../src/menu/virtualtemplateied/foundation.js';
 
@@ -147,6 +149,42 @@ describe('foundation for virtual IED creation', () => {
     it('returns empty string if no valid string exist', () =>
       expect(getFunctionNamingPrefix(nonLeafSubFunctionsLNode)).to.be.equal(
         ''
+      ));
+  });
+
+  describe('getUniqueFunctionName function', () => {
+    let doc: XMLDocument;
+
+    beforeEach(async () => {
+      doc = await fetch('/test/testfiles/virtualied/specificfromfunctions.ssd')
+        .then(response => response.text())
+        .then(str => new DOMParser().parseFromString(str, 'application/xml'));
+    });
+
+    it('return unique name for function type element', () =>
+      expect(
+        getUniqueFunctionName(
+          doc.querySelector('EqFunction[name="Disconnector"]')!
+        )
+      ).to.equal('Q01_QB1_Disconnector'));
+
+    it('return unique name for another function type element', () =>
+      expect(
+        getUniqueFunctionName(
+          doc.querySelector('EqFunction[name="Earth_Switch"]')!
+        )
+      ).to.equal('E1_Q01_QC9_Earth_Switch'));
+
+    it('return function type element name if already unique in project', () =>
+      expect(
+        getUniqueFunctionName(
+          doc.querySelector('Function[name="Distance_Protection"]')!
+        )
+      ).to.equal('Distance_Protection'));
+
+    it('return identity string in case input element is not function type element', () =>
+      expect(getUniqueFunctionName(doc.querySelector('Bay')!)).to.equal(
+        identity(doc.querySelector('Bay'))
       ));
   });
 });


### PR DESCRIPTION
This is it, the plugin that allows to automatically create a virtual template IED - name `SPECIFICATION` - based on the function structure in the substation section. 

I decided to pack it into a menu type plugin for not. When we will extend the functionality around the virtual IED creation in the future, we can convert it into an editor type plugin. 

> To test, use the *.ssd file in the testfiles folder.

Closes #742 

