### PR TITLE
feat(editors/publisher): filter for control blocks and DataSets

### DIFF
--- a/public/js/plugins.js
+++ b/public/js/plugins.js
@@ -56,6 +56,13 @@ export const officialPlugins = [
     kind: 'editor',
   },
   {
+    name: 'Publisher',
+    src: '/src/editors/Publisher.js',
+    icon: 'publish',
+    default: false,
+    kind: 'editor',
+  },
+  {
     name: 'Open project',
     src: '/src/menu/OpenProject.js',
     icon: 'folder_open',

--- a/src/editors/Publisher.ts
+++ b/src/editors/Publisher.ts
@@ -1,0 +1,94 @@
+import {
+  css,
+  html,
+  LitElement,
+  property,
+  state,
+  TemplateResult,
+} from 'lit-element';
+import { classMap } from 'lit-html/directives/class-map';
+
+import '@material/mwc-formfield';
+import '@material/mwc-radio';
+
+import './publisher/report-control-editor.js';
+import './publisher/gse-control-editor.js';
+import './publisher/sampled-value-control-editor.js';
+import './publisher/data-set-editor.js';
+
+/** An editor [[`plugin`]] to configure `Report`, `GOOSE`, `SampledValue` control blocks and its `DataSet` */
+export default class PublisherPlugin extends LitElement {
+  /** The document being edited as provided to plugins by [[`OpenSCD`]]. */
+  @property({ attribute: false })
+  doc!: XMLDocument;
+  @state()
+  private publisherType: 'Report' | 'GOOSE' | 'SampledValue' | 'DataSet' =
+    'GOOSE';
+
+  render(): TemplateResult {
+    return html`<div class="publishertypeselector">
+        <mwc-formfield label="Report"
+          ><mwc-radio
+            value="Report"
+            ?checked=${this.publisherType === 'Report'}
+            @checked=${() => (this.publisherType = 'Report')}
+          ></mwc-radio></mwc-formfield
+        ><mwc-formfield label="GOOSE"
+          ><mwc-radio
+            value="GOOSE"
+            ?checked=${this.publisherType === 'GOOSE'}
+            @checked=${() => (this.publisherType = 'GOOSE')}
+          ></mwc-radio></mwc-formfield
+        ><mwc-formfield label="SampledValue"
+          ><mwc-radio
+            value="SampledValue"
+            ?checked=${this.publisherType === 'SampledValue'}
+            @checked=${() => (this.publisherType = 'SampledValue')}
+          ></mwc-radio></mwc-formfield
+        ><mwc-formfield label="DataSet"
+          ><mwc-radio
+            value="DataSet"
+            ?checked=${this.publisherType === 'DataSet'}
+            @checked=${() => (this.publisherType = 'DataSet')}
+          ></mwc-radio
+        ></mwc-formfield>
+      </div>
+      <report-control-editor
+        .doc=${this.doc}
+        class="${classMap({
+          hidden: this.publisherType !== 'Report',
+        })}"
+      ></report-control-editor
+      ><gse-control-editor
+        .doc=${this.doc}
+        class="${classMap({
+          hidden: this.publisherType !== 'GOOSE',
+        })}"
+      ></gse-control-editor
+      ><sampled-value-control-editor
+        .doc=${this.doc}
+        class="${classMap({
+          hidden: this.publisherType !== 'SampledValue',
+        })}"
+      ></sampled-value-control-editor
+      ><data-set-editor
+        .doc=${this.doc}
+        class="${classMap({
+          hidden: this.publisherType !== 'DataSet',
+        })}"
+      ></data-set-editor>`;
+  }
+
+  static styles = css`
+    .hidden {
+      display: none;
+    }
+
+    .publishertypeselector {
+      margin: 4px 8px 16px;
+      background-color: var(--mdc-theme-surface);
+      width: calc(100% - 16px);
+      justify-content: space-around;
+    }
+  `;
+}

--- a/src/editors/publisher/data-set-editor.ts
+++ b/src/editors/publisher/data-set-editor.ts
@@ -1,0 +1,59 @@
+import {
+  css,
+  customElement,
+  html,
+  LitElement,
+  property,
+  TemplateResult,
+} from 'lit-element';
+import { compareNames, identity } from '../../foundation.js';
+
+@customElement('data-set-editor')
+export class DataSetEditor extends LitElement {
+  /** The document being edited as provided to plugins by [[`OpenSCD`]]. */
+  @property({ attribute: false })
+  doc!: XMLDocument;
+
+  renderList(): TemplateResult {
+    return html`<filtered-list
+      >${Array.from(this.doc.querySelectorAll('IED'))
+        .sort(compareNames)
+        .flatMap(ied => {
+          const ieditem = html`<mwc-list-item
+              class="listitem header"
+              noninteractive
+              graphic="icon"
+            >
+              <span>${ied.getAttribute('name')}</span>
+              <mwc-icon slot="graphic">developer_board</mwc-icon>
+            </mwc-list-item>
+            <li divider role="separator"></li>`;
+
+          const dataSets = Array.from(ied.querySelectorAll('DataSet')).map(
+            reportCb =>
+              html`<mwc-list-item twoline value="${identity(reportCb)}"
+                ><span>${reportCb.getAttribute('name')}</span
+                ><span slot="secondary">${identity(reportCb)}</span>
+              </mwc-list-item>`
+          );
+
+          return [ieditem, ...dataSets];
+        })}</filtered-list
+    >`;
+  }
+
+  render(): TemplateResult {
+    return html`${this.renderList()}`;
+  }
+
+  static styles = css`
+    filtered-list {
+      margin: 4px 8px 16px;
+      background-color: var(--mdc-theme-surface);
+    }
+
+    .listitem.header {
+      font-weight: 500;
+    }
+  `;
+}

--- a/src/editors/publisher/gse-control-editor.ts
+++ b/src/editors/publisher/gse-control-editor.ts
@@ -1,0 +1,71 @@
+import {
+  css,
+  customElement,
+  html,
+  LitElement,
+  property,
+  TemplateResult,
+} from 'lit-element';
+
+import '@material/mwc-list/mwc-list-item';
+import '@material/mwc-icon';
+
+import '../../filtered-list.js';
+import { compareNames, identity } from '../../foundation.js';
+import { gooseIcon } from '../../icons/icons.js';
+
+@customElement('gse-control-editor')
+export class GseControlEditor extends LitElement {
+  /** The document being edited as provided to plugins by [[`OpenSCD`]]. */
+  @property({ attribute: false })
+  doc!: XMLDocument;
+
+  renderList(): TemplateResult {
+    return html`<filtered-list
+      >${Array.from(this.doc.querySelectorAll('IED'))
+        .sort(compareNames)
+        .flatMap(ied => {
+          const ieditem = html`<mwc-list-item
+              class="listitem header"
+              noninteractive
+              graphic="icon"
+            >
+              <span>${ied.getAttribute('name')}</span>
+              <mwc-icon slot="graphic">developer_board</mwc-icon>
+            </mwc-list-item>
+            <li divider role="separator"></li>`;
+
+          const gseControls = Array.from(
+            ied.querySelectorAll('GSEControl')
+          ).map(
+            reportCb =>
+              html`<mwc-list-item
+                twoline
+                value="${identity(reportCb)}"
+                graphic="icon"
+                ><span>${reportCb.getAttribute('name')}</span
+                ><span slot="secondary">${identity(reportCb)}</span>
+                <mwc-icon slot="graphic">${gooseIcon}</mwc-icon>
+              </mwc-list-item>`
+          );
+
+          return [ieditem, ...gseControls];
+        })}</filtered-list
+    >`;
+  }
+
+  render(): TemplateResult {
+    return html`${this.renderList()}`;
+  }
+
+  static styles = css`
+    filtered-list {
+      margin: 4px 8px 16px;
+      background-color: var(--mdc-theme-surface);
+    }
+
+    .listitem.header {
+      font-weight: 500;
+    }
+  `;
+}

--- a/src/editors/publisher/report-control-editor.ts
+++ b/src/editors/publisher/report-control-editor.ts
@@ -1,0 +1,69 @@
+import {
+  css,
+  customElement,
+  html,
+  LitElement,
+  property,
+  TemplateResult,
+} from 'lit-element';
+
+import '@material/mwc-list/mwc-list-item';
+import '@material/mwc-icon';
+
+import '../../filtered-list.js';
+import { compareNames, identity } from '../../foundation.js';
+import { reportIcon } from '../../icons/icons.js';
+
+@customElement('report-control-editor')
+export class ReportControlEditor extends LitElement {
+  /** The document being edited as provided to plugins by [[`OpenSCD`]]. */
+  @property({ attribute: false })
+  doc!: XMLDocument;
+
+  renderList(): TemplateResult {
+    return html`<filtered-list
+      >${Array.from(this.doc.querySelectorAll('IED'))
+        .sort(compareNames)
+        .flatMap(ied => {
+          const ieditem = html`<mwc-list-item
+              class="listitem header"
+              noninteractive
+              graphic="icon"
+            >
+              <span>${ied.getAttribute('name')}</span>
+              <mwc-icon slot="graphic">developer_board</mwc-icon>
+            </mwc-list-item>
+            <li divider role="separator"></li>`;
+
+          const reports = Array.from(ied.querySelectorAll('ReportControl')).map(
+            reportCb =>
+              html`<mwc-list-item
+                twoline
+                value="${identity(reportCb)}"
+                graphic="icon"
+                ><span>${reportCb.getAttribute('name')}</span
+                ><span slot="secondary">${identity(reportCb)}</span>
+                <mwc-icon slot="graphic">${reportIcon}</mwc-icon>
+              </mwc-list-item>`
+          );
+
+          return [ieditem, ...reports];
+        })}</filtered-list
+    >`;
+  }
+
+  render(): TemplateResult {
+    return html`${this.renderList()}`;
+  }
+
+  static styles = css`
+    filtered-list {
+      margin: 4px 8px 16px;
+      background-color: var(--mdc-theme-surface);
+    }
+
+    .listitem.header {
+      font-weight: 500;
+    }
+  `;
+}

--- a/src/editors/publisher/sampled-value-control-editor.ts
+++ b/src/editors/publisher/sampled-value-control-editor.ts
@@ -1,0 +1,71 @@
+import {
+  css,
+  customElement,
+  html,
+  LitElement,
+  property,
+  TemplateResult,
+} from 'lit-element';
+
+import '@material/mwc-list/mwc-list-item';
+import '@material/mwc-icon';
+
+import '../../filtered-list.js';
+import { compareNames, identity } from '../../foundation.js';
+import { smvIcon } from '../../icons/icons.js';
+
+@customElement('sampled-value-control-editor')
+export class SampledValueControlEditor extends LitElement {
+  /** The document being edited as provided to plugins by [[`OpenSCD`]]. */
+  @property({ attribute: false })
+  doc!: XMLDocument;
+
+  renderList(): TemplateResult {
+    return html`<filtered-list
+      >${Array.from(this.doc.querySelectorAll('IED'))
+        .sort(compareNames)
+        .flatMap(ied => {
+          const ieditem = html`<mwc-list-item
+              class="listitem header"
+              noninteractive
+              graphic="icon"
+            >
+              <span>${ied.getAttribute('name')}</span>
+              <mwc-icon slot="graphic">developer_board</mwc-icon>
+            </mwc-list-item>
+            <li divider role="separator"></li>`;
+
+          const sampledValueControls = Array.from(
+            ied.querySelectorAll('SampledValueControl')
+          ).map(
+            reportCb =>
+              html`<mwc-list-item
+                twoline
+                value="${identity(reportCb)}"
+                graphic="icon"
+                ><span>${reportCb.getAttribute('name')}</span
+                ><span slot="secondary">${identity(reportCb)}</span>
+                <mwc-icon slot="graphic">${smvIcon}</mwc-icon>
+              </mwc-list-item>`
+          );
+
+          return [ieditem, ...sampledValueControls];
+        })}</filtered-list
+    >`;
+  }
+
+  render(): TemplateResult {
+    return html`${this.renderList()}`;
+  }
+
+  static styles = css`
+    filtered-list {
+      margin: 4px 8px 16px;
+      background-color: var(--mdc-theme-surface);
+    }
+
+    .listitem.header {
+      font-weight: 500;
+    }
+  `;
+}

--- a/test/integration/__snapshots__/open-scd.test.snap.js
+++ b/test/integration/__snapshots__/open-scd.test.snap.js
@@ -691,6 +691,21 @@ snapshots["open-scd looks like its snapshot"] =
       left=""
       mwc-list-item=""
       tabindex="-1"
+      value="/src/editors/Publisher.js"
+    >
+      <mwc-icon slot="meta">
+        publish
+      </mwc-icon>
+      Publisher
+    </mwc-check-list-item>
+    <mwc-check-list-item
+      aria-disabled="false"
+      class="official"
+      graphic="control"
+      hasmeta=""
+      left=""
+      mwc-list-item=""
+      tabindex="-1"
       value="/src/editors/Cleanup.js"
     >
       <mwc-icon slot="meta">

--- a/test/unit/editors/Publisher.test.ts
+++ b/test/unit/editors/Publisher.test.ts
@@ -1,0 +1,48 @@
+import { expect, fixture, html } from '@open-wc/testing';
+
+import Publisher from '../../../src/editors/Publisher.js';
+
+describe('Publisher plugin', () => {
+  customElements.define('publisher-plugin', Publisher);
+
+  let element: Publisher;
+
+  beforeEach(async () => {
+    element = await fixture(html`<publisher-plugin></publisher-plugin>`);
+  });
+
+  it('per default looks like the latest snapshot', async () =>
+    await expect(element).shadowDom.to.equalSnapshot());
+
+  it('displays report-control-editor with selected Report publisherType', async () => {
+    element
+      .shadowRoot!.querySelector<HTMLElement>('mwc-radio[value="Report"]')!
+      .click();
+
+    await element.requestUpdate();
+
+    await expect(element).shadowDom.to.equalSnapshot();
+  });
+
+  it('displays sampled-value-control-editor with selected SampledValue publisherType', async () => {
+    element
+      .shadowRoot!.querySelector<HTMLElement>(
+        'mwc-radio[value="SampledValue"]'
+      )!
+      .click();
+
+    await element.requestUpdate();
+
+    await expect(element).shadowDom.to.equalSnapshot();
+  });
+
+  it('displays data-set-editor with selected DataSet publisherType', async () => {
+    element
+      .shadowRoot!.querySelector<HTMLElement>('mwc-radio[value="DataSet"]')!
+      .click();
+
+    await element.requestUpdate();
+
+    await expect(element).shadowDom.to.equalSnapshot();
+  });
+});

--- a/test/unit/editors/__snapshots__/Publisher.test.snap.js
+++ b/test/unit/editors/__snapshots__/Publisher.test.snap.js
@@ -1,0 +1,135 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["Publisher plugin per default looks like the latest snapshot"] = 
+`<div class="publishertypeselector">
+  <mwc-formfield label="Report">
+    <mwc-radio value="Report">
+    </mwc-radio>
+  </mwc-formfield>
+  <mwc-formfield label="GOOSE">
+    <mwc-radio
+      checked=""
+      value="GOOSE"
+    >
+    </mwc-radio>
+  </mwc-formfield>
+  <mwc-formfield label="SampledValue">
+    <mwc-radio value="SampledValue">
+    </mwc-radio>
+  </mwc-formfield>
+  <mwc-formfield label="DataSet">
+    <mwc-radio value="DataSet">
+    </mwc-radio>
+  </mwc-formfield>
+</div>
+<report-control-editor class="hidden">
+</report-control-editor>
+<gse-control-editor>
+</gse-control-editor>
+<sampled-value-control-editor class="hidden">
+</sampled-value-control-editor>
+<data-set-editor class="hidden">
+</data-set-editor>
+`;
+/* end snapshot Publisher plugin per default looks like the latest snapshot */
+
+snapshots["Publisher plugin displays report-control-editor with selected Report publisherType"] = 
+`<div class="publishertypeselector">
+  <mwc-formfield label="Report">
+    <mwc-radio
+      checked=""
+      value="Report"
+    >
+    </mwc-radio>
+  </mwc-formfield>
+  <mwc-formfield label="GOOSE">
+    <mwc-radio value="GOOSE">
+    </mwc-radio>
+  </mwc-formfield>
+  <mwc-formfield label="SampledValue">
+    <mwc-radio value="SampledValue">
+    </mwc-radio>
+  </mwc-formfield>
+  <mwc-formfield label="DataSet">
+    <mwc-radio value="DataSet">
+    </mwc-radio>
+  </mwc-formfield>
+</div>
+<report-control-editor>
+</report-control-editor>
+<gse-control-editor class="hidden">
+</gse-control-editor>
+<sampled-value-control-editor class="hidden">
+</sampled-value-control-editor>
+<data-set-editor class="hidden">
+</data-set-editor>
+`;
+/* end snapshot Publisher plugin displays report-control-editor with selected Report publisherType */
+
+snapshots["Publisher plugin displays sampled-value-control-editor with selected SampledValue publisherType"] = 
+`<div class="publishertypeselector">
+  <mwc-formfield label="Report">
+    <mwc-radio value="Report">
+    </mwc-radio>
+  </mwc-formfield>
+  <mwc-formfield label="GOOSE">
+    <mwc-radio value="GOOSE">
+    </mwc-radio>
+  </mwc-formfield>
+  <mwc-formfield label="SampledValue">
+    <mwc-radio
+      checked=""
+      value="SampledValue"
+    >
+    </mwc-radio>
+  </mwc-formfield>
+  <mwc-formfield label="DataSet">
+    <mwc-radio value="DataSet">
+    </mwc-radio>
+  </mwc-formfield>
+</div>
+<report-control-editor class="hidden">
+</report-control-editor>
+<gse-control-editor class="hidden">
+</gse-control-editor>
+<sampled-value-control-editor>
+</sampled-value-control-editor>
+<data-set-editor class="hidden">
+</data-set-editor>
+`;
+/* end snapshot Publisher plugin displays sampled-value-control-editor with selected SampledValue publisherType */
+
+snapshots["Publisher plugin displays data-set-editor with selected DataSet publisherType"] = 
+`<div class="publishertypeselector">
+  <mwc-formfield label="Report">
+    <mwc-radio value="Report">
+    </mwc-radio>
+  </mwc-formfield>
+  <mwc-formfield label="GOOSE">
+    <mwc-radio value="GOOSE">
+    </mwc-radio>
+  </mwc-formfield>
+  <mwc-formfield label="SampledValue">
+    <mwc-radio value="SampledValue">
+    </mwc-radio>
+  </mwc-formfield>
+  <mwc-formfield label="DataSet">
+    <mwc-radio
+      checked=""
+      value="DataSet"
+    >
+    </mwc-radio>
+  </mwc-formfield>
+</div>
+<report-control-editor class="hidden">
+</report-control-editor>
+<gse-control-editor class="hidden">
+</gse-control-editor>
+<sampled-value-control-editor class="hidden">
+</sampled-value-control-editor>
+<data-set-editor>
+</data-set-editor>
+`;
+/* end snapshot Publisher plugin displays data-set-editor with selected DataSet publisherType */
+

--- a/test/unit/editors/publisher/__snapshots__/data-set-editor.test.snap.js
+++ b/test/unit/editors/publisher/__snapshots__/data-set-editor.test.snap.js
@@ -1,0 +1,136 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["Editor for DataSet element looks like the latest snapshot"] = 
+`<filtered-list>
+  <mwc-list-item
+    aria-disabled="false"
+    class="header listitem"
+    graphic="icon"
+    noninteractive=""
+    tabindex="-1"
+  >
+    <span>
+      IED1
+    </span>
+    <mwc-icon slot="graphic">
+      developer_board
+    </mwc-icon>
+  </mwc-list-item>
+  <li
+    divider=""
+    role="separator"
+  >
+  </li>
+  <mwc-list-item
+    aria-disabled="false"
+    mwc-list-item=""
+    tabindex="-1"
+    twoline=""
+    value="IED1>>CircuitBreaker_CB1>GooseDataSet1"
+  >
+    <span>
+      GooseDataSet1
+    </span>
+    <span slot="secondary">
+      IED1>>CircuitBreaker_CB1>GooseDataSet1
+    </span>
+  </mwc-list-item>
+  <mwc-list-item
+    aria-disabled="false"
+    class="header listitem"
+    graphic="icon"
+    noninteractive=""
+    tabindex="-1"
+  >
+    <span>
+      IED2
+    </span>
+    <mwc-icon slot="graphic">
+      developer_board
+    </mwc-icon>
+  </mwc-list-item>
+  <li
+    divider=""
+    role="separator"
+  >
+  </li>
+  <mwc-list-item
+    aria-disabled="false"
+    mwc-list-item=""
+    tabindex="-1"
+    twoline=""
+    value="IED2>>CBSW>GooseDataSet1"
+  >
+    <span>
+      GooseDataSet1
+    </span>
+    <span slot="secondary">
+      IED2>>CBSW>GooseDataSet1
+    </span>
+  </mwc-list-item>
+  <mwc-list-item
+    aria-disabled="false"
+    mwc-list-item=""
+    tabindex="-1"
+    twoline=""
+    value="IED2>>CBSW> XSWI 1>dataSet"
+  >
+    <span>
+      dataSet
+    </span>
+    <span slot="secondary">
+      IED2>>CBSW> XSWI 1>dataSet
+    </span>
+  </mwc-list-item>
+  <mwc-list-item
+    aria-disabled="false"
+    mwc-list-item=""
+    tabindex="-1"
+    twoline=""
+    value="IED2>>CBSW> XSWI 2>dataSet"
+  >
+    <span>
+      dataSet
+    </span>
+    <span slot="secondary">
+      IED2>>CBSW> XSWI 2>dataSet
+    </span>
+  </mwc-list-item>
+  <mwc-list-item
+    aria-disabled="false"
+    class="header listitem"
+    graphic="icon"
+    noninteractive=""
+    tabindex="-1"
+  >
+    <span>
+      IED3
+    </span>
+    <mwc-icon slot="graphic">
+      developer_board
+    </mwc-icon>
+  </mwc-list-item>
+  <li
+    divider=""
+    role="separator"
+  >
+  </li>
+  <mwc-list-item
+    aria-disabled="false"
+    mwc-list-item=""
+    tabindex="-1"
+    twoline=""
+    value="IED3>>MU01>PhsMeas1"
+  >
+    <span>
+      PhsMeas1
+    </span>
+    <span slot="secondary">
+      IED3>>MU01>PhsMeas1
+    </span>
+  </mwc-list-item>
+</filtered-list>
+`;
+/* end snapshot Editor for DataSet element looks like the latest snapshot */
+

--- a/test/unit/editors/publisher/__snapshots__/gse-control-editor.test.snap.js
+++ b/test/unit/editors/publisher/__snapshots__/gse-control-editor.test.snap.js
@@ -1,0 +1,117 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["Editor for GSEControl element looks like the latest snapshot"] = 
+`<filtered-list>
+  <mwc-list-item
+    aria-disabled="false"
+    class="header listitem"
+    graphic="icon"
+    noninteractive=""
+    tabindex="-1"
+  >
+    <span>
+      IED1
+    </span>
+    <mwc-icon slot="graphic">
+      developer_board
+    </mwc-icon>
+  </mwc-list-item>
+  <li
+    divider=""
+    role="separator"
+  >
+  </li>
+  <mwc-list-item
+    aria-disabled="false"
+    graphic="icon"
+    mwc-list-item=""
+    tabindex="0"
+    twoline=""
+    value="IED1>>CircuitBreaker_CB1>GCB"
+  >
+    <span>
+      GCB
+    </span>
+    <span slot="secondary">
+      IED1>>CircuitBreaker_CB1>GCB
+    </span>
+    <mwc-icon slot="graphic">
+    </mwc-icon>
+  </mwc-list-item>
+  <mwc-list-item
+    aria-disabled="false"
+    graphic="icon"
+    mwc-list-item=""
+    tabindex="-1"
+    twoline=""
+    value="IED1>>CircuitBreaker_CB1>GCB2"
+  >
+    <span>
+      GCB2
+    </span>
+    <span slot="secondary">
+      IED1>>CircuitBreaker_CB1>GCB2
+    </span>
+    <mwc-icon slot="graphic">
+    </mwc-icon>
+  </mwc-list-item>
+  <mwc-list-item
+    aria-disabled="false"
+    class="header listitem"
+    graphic="icon"
+    noninteractive=""
+    tabindex="-1"
+  >
+    <span>
+      IED2
+    </span>
+    <mwc-icon slot="graphic">
+      developer_board
+    </mwc-icon>
+  </mwc-list-item>
+  <li
+    divider=""
+    role="separator"
+  >
+  </li>
+  <mwc-list-item
+    aria-disabled="false"
+    graphic="icon"
+    mwc-list-item=""
+    tabindex="-1"
+    twoline=""
+    value="IED2>>CBSW>GCB"
+  >
+    <span>
+      GCB
+    </span>
+    <span slot="secondary">
+      IED2>>CBSW>GCB
+    </span>
+    <mwc-icon slot="graphic">
+    </mwc-icon>
+  </mwc-list-item>
+  <mwc-list-item
+    aria-disabled="false"
+    class="header listitem"
+    graphic="icon"
+    noninteractive=""
+    tabindex="-1"
+  >
+    <span>
+      IED3
+    </span>
+    <mwc-icon slot="graphic">
+      developer_board
+    </mwc-icon>
+  </mwc-list-item>
+  <li
+    divider=""
+    role="separator"
+  >
+  </li>
+</filtered-list>
+`;
+/* end snapshot Editor for GSEControl element looks like the latest snapshot */
+

--- a/test/unit/editors/publisher/__snapshots__/report-control-editor.test.snap.js
+++ b/test/unit/editors/publisher/__snapshots__/report-control-editor.test.snap.js
@@ -1,0 +1,100 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["Editor for ReportControl element looks like the latest snapshot"] = 
+`<filtered-list>
+  <mwc-list-item
+    aria-disabled="false"
+    class="header listitem"
+    graphic="icon"
+    noninteractive=""
+    tabindex="-1"
+  >
+    <span>
+      IED1
+    </span>
+    <mwc-icon slot="graphic">
+      developer_board
+    </mwc-icon>
+  </mwc-list-item>
+  <li
+    divider=""
+    role="separator"
+  >
+  </li>
+  <mwc-list-item
+    aria-disabled="false"
+    class="header listitem"
+    graphic="icon"
+    noninteractive=""
+    tabindex="-1"
+  >
+    <span>
+      IED2
+    </span>
+    <mwc-icon slot="graphic">
+      developer_board
+    </mwc-icon>
+  </mwc-list-item>
+  <li
+    divider=""
+    role="separator"
+  >
+  </li>
+  <mwc-list-item
+    aria-disabled="false"
+    graphic="icon"
+    mwc-list-item=""
+    tabindex="0"
+    twoline=""
+    value="IED2>>CBSW> XSWI 1>ReportCb"
+  >
+    <span>
+      ReportCb
+    </span>
+    <span slot="secondary">
+      IED2>>CBSW> XSWI 1>ReportCb
+    </span>
+    <mwc-icon slot="graphic">
+    </mwc-icon>
+  </mwc-list-item>
+  <mwc-list-item
+    aria-disabled="false"
+    graphic="icon"
+    mwc-list-item=""
+    tabindex="-1"
+    twoline=""
+    value="IED2>>CBSW> XSWI 2>ReportCb"
+  >
+    <span>
+      ReportCb
+    </span>
+    <span slot="secondary">
+      IED2>>CBSW> XSWI 2>ReportCb
+    </span>
+    <mwc-icon slot="graphic">
+    </mwc-icon>
+  </mwc-list-item>
+  <mwc-list-item
+    aria-disabled="false"
+    class="header listitem"
+    graphic="icon"
+    noninteractive=""
+    tabindex="-1"
+  >
+    <span>
+      IED3
+    </span>
+    <mwc-icon slot="graphic">
+      developer_board
+    </mwc-icon>
+  </mwc-list-item>
+  <li
+    divider=""
+    role="separator"
+  >
+  </li>
+</filtered-list>
+`;
+/* end snapshot Editor for ReportControl element looks like the latest snapshot */
+

--- a/test/unit/editors/publisher/__snapshots__/sampled-value-control-editor.test.snap.js
+++ b/test/unit/editors/publisher/__snapshots__/sampled-value-control-editor.test.snap.js
@@ -1,0 +1,83 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["Editor for SampledValueControl element looks like the latest snapshot"] = 
+`<filtered-list>
+  <mwc-list-item
+    aria-disabled="false"
+    class="header listitem"
+    graphic="icon"
+    noninteractive=""
+    tabindex="-1"
+  >
+    <span>
+      IED1
+    </span>
+    <mwc-icon slot="graphic">
+      developer_board
+    </mwc-icon>
+  </mwc-list-item>
+  <li
+    divider=""
+    role="separator"
+  >
+  </li>
+  <mwc-list-item
+    aria-disabled="false"
+    class="header listitem"
+    graphic="icon"
+    noninteractive=""
+    tabindex="-1"
+  >
+    <span>
+      IED2
+    </span>
+    <mwc-icon slot="graphic">
+      developer_board
+    </mwc-icon>
+  </mwc-list-item>
+  <li
+    divider=""
+    role="separator"
+  >
+  </li>
+  <mwc-list-item
+    aria-disabled="false"
+    class="header listitem"
+    graphic="icon"
+    noninteractive=""
+    tabindex="-1"
+  >
+    <span>
+      IED3
+    </span>
+    <mwc-icon slot="graphic">
+      developer_board
+    </mwc-icon>
+  </mwc-list-item>
+  <li
+    divider=""
+    role="separator"
+  >
+  </li>
+  <mwc-list-item
+    aria-disabled="false"
+    graphic="icon"
+    mwc-list-item=""
+    tabindex="0"
+    twoline=""
+    value="IED3>>MU01>MSVCB01"
+  >
+    <span>
+      MSVCB01
+    </span>
+    <span slot="secondary">
+      IED3>>MU01>MSVCB01
+    </span>
+    <mwc-icon slot="graphic">
+    </mwc-icon>
+  </mwc-list-item>
+</filtered-list>
+`;
+/* end snapshot Editor for SampledValueControl element looks like the latest snapshot */
+

--- a/test/unit/editors/publisher/data-set-editor.test.ts
+++ b/test/unit/editors/publisher/data-set-editor.test.ts
@@ -1,0 +1,22 @@
+import { expect, fixture, html } from '@open-wc/testing';
+
+import '../../../../src/editors/publisher/data-set-editor.js';
+import { DataSetEditor } from '../../../../src/editors/publisher/data-set-editor.js';
+
+describe('Editor for DataSet element', () => {
+  let doc: XMLDocument;
+  let element: DataSetEditor;
+
+  beforeEach(async () => {
+    doc = await fetch('/test/testfiles/valid2007B4.scd')
+      .then(response => response.text())
+      .then(str => new DOMParser().parseFromString(str, 'application/xml'));
+
+    element = await fixture(
+      html`<data-set-editor .doc=${doc}></data-set-editor>`
+    );
+  });
+
+  it('looks like the latest snapshot', async () =>
+    await expect(element).shadowDom.to.equalSnapshot());
+});

--- a/test/unit/editors/publisher/gse-control-editor.test.ts
+++ b/test/unit/editors/publisher/gse-control-editor.test.ts
@@ -1,0 +1,22 @@
+import { expect, fixture, html } from '@open-wc/testing';
+
+import '../../../../src/editors/publisher/gse-control-editor.js';
+import { GseControlEditor } from '../../../../src/editors/publisher/gse-control-editor.js';
+
+describe('Editor for GSEControl element', () => {
+  let doc: XMLDocument;
+  let element: GseControlEditor;
+
+  beforeEach(async () => {
+    doc = await fetch('/test/testfiles/valid2007B4.scd')
+      .then(response => response.text())
+      .then(str => new DOMParser().parseFromString(str, 'application/xml'));
+
+    element = await fixture(
+      html`<gse-control-editor .doc=${doc}></gse-control-editor>`
+    );
+  });
+
+  it('looks like the latest snapshot', async () =>
+    await expect(element).shadowDom.to.equalSnapshot());
+});

--- a/test/unit/editors/publisher/report-control-editor.test.ts
+++ b/test/unit/editors/publisher/report-control-editor.test.ts
@@ -1,0 +1,22 @@
+import { expect, fixture, html } from '@open-wc/testing';
+
+import '../../../../src/editors/publisher/report-control-editor.js';
+import { ReportControlEditor } from '../../../../src/editors/publisher/report-control-editor.js';
+
+describe('Editor for ReportControl element', () => {
+  let doc: XMLDocument;
+  let element: ReportControlEditor;
+
+  beforeEach(async () => {
+    doc = await fetch('/test/testfiles/valid2007B4.scd')
+      .then(response => response.text())
+      .then(str => new DOMParser().parseFromString(str, 'application/xml'));
+
+    element = await fixture(
+      html`<report-control-editor .doc=${doc}></report-control-editor>`
+    );
+  });
+
+  it('looks like the latest snapshot', async () =>
+    await expect(element).shadowDom.to.equalSnapshot());
+});

--- a/test/unit/editors/publisher/sampled-value-control-editor.test.ts
+++ b/test/unit/editors/publisher/sampled-value-control-editor.test.ts
@@ -1,0 +1,24 @@
+import { expect, fixture, html } from '@open-wc/testing';
+
+import '../../../../src/editors/publisher/sampled-value-control-editor.js';
+import { SampledValueControlEditor } from '../../../../src/editors/publisher/sampled-value-control-editor.js';
+
+describe('Editor for SampledValueControl element', () => {
+  let doc: XMLDocument;
+  let element: SampledValueControlEditor;
+
+  beforeEach(async () => {
+    doc = await fetch('/test/testfiles/valid2007B4.scd')
+      .then(response => response.text())
+      .then(str => new DOMParser().parseFromString(str, 'application/xml'));
+
+    element = await fixture(
+      html`<sampled-value-control-editor
+        .doc=${doc}
+      ></sampled-value-control-editor>`
+    );
+  });
+
+  it('looks like the latest snapshot', async () =>
+    await expect(element).shadowDom.to.equalSnapshot());
+});


### PR DESCRIPTION
This PR is covering issues #709 #710 and #711 in showing a filterable list of `ReportControl`, `GSEControl` and `SampledValueControl` elements. I also took into account the discussion #561 and added defined `DataSet` elements as well. This will allow users to follow a workflow where `DataSet` element are created independently of control blocks and a re combined with those in a lager engineering step or even online. 