### PR TITLE
fix(editors/substation): update on action

### DIFF
--- a/src/editors/substation/bay-editor.ts
+++ b/src/editors/substation/bay-editor.ts
@@ -41,6 +41,9 @@ function childTags(element: Element | null | undefined): SCLTag[] {
 /** [[`SubstationEditor`]] subeditor for a `Bay` element. */
 @customElement('bay-editor')
 export class BayEditor extends LitElement {
+  /** The document being edited as provided to editor by [[`Zeroline`]]. */
+  @property({ attribute: false })
+  doc!: XMLDocument;
   @property({ attribute: false })
   element!: Element;
   @property({ type: Boolean })
@@ -107,7 +110,11 @@ export class BayEditor extends LitElement {
     return lNodes.length
       ? html`<div class="container lnode">
           ${lNodes.map(
-            lNode => html`<l-node-editor .element=${lNode}></l-node-editor>`
+            lNode =>
+              html`<l-node-editor
+                .doc=${this.doc}
+                .element=${lNode}
+              ></l-node-editor>`
           )}
         </div>`
       : html``;
@@ -118,7 +125,11 @@ export class BayEditor extends LitElement {
 
     const functions = getChildElementsByTagName(this.element, 'Function');
     return html` ${functions.map(
-      fUnction => html`<function-editor .element=${fUnction}></function-editor>`
+      fUnction =>
+        html`<function-editor
+          .doc=${this.doc}
+          .element=${fUnction}
+        ></function-editor>`
     )}`;
   }
 
@@ -126,7 +137,10 @@ export class BayEditor extends LitElement {
     const ieds = this.getAttachedIeds?.(this.element) ?? [];
     return ieds?.length
       ? html`<div id="iedcontainer">
-          ${ieds.map(ied => html`<ied-editor .element=${ied}></ied-editor>`)}
+          ${ieds.map(
+            ied =>
+              html`<ied-editor .doc=${this.doc} .element=${ied}></ied-editor>`
+          )}
         </div>`
       : html``;
   }
@@ -203,6 +217,7 @@ export class BayEditor extends LitElement {
         ).map(
           pwt =>
             html`<powertransformer-editor
+              .doc=${this.doc}
               .element=${pwt}
               ?showfunctions=${this.showfunctions}
             ></powertransformer-editor>`
@@ -212,6 +227,7 @@ export class BayEditor extends LitElement {
         ).map(
           voltageLevel =>
             html`<conducting-equipment-editor
+              .doc=${this.doc}
               .element=${voltageLevel}
               ?readonly=${this.readonly}
               ?showfunctions=${this.showfunctions}

--- a/src/editors/substation/conducting-equipment-editor.ts
+++ b/src/editors/substation/conducting-equipment-editor.ts
@@ -43,6 +43,9 @@ function childTags(element: Element | null | undefined): SCLTag[] {
 /** [[`SubstationEditor`]] subeditor for a `ConductingEquipment` element. */
 @customElement('conducting-equipment-editor')
 export class ConductingEquipmentEditor extends LitElement {
+  /** The document being edited as provided to editor by [[`Zeroline`]]. */
+  @property({ attribute: false })
+  doc!: XMLDocument;
   /** SCL element ConductingEquipment */
   @property({ attribute: false })
   element!: Element;
@@ -98,7 +101,11 @@ export class ConductingEquipmentEditor extends LitElement {
     return lNodes.length
       ? html`<div class="container lnode">
           ${lNodes.map(
-            lNode => html`<l-node-editor .element=${lNode}></l-node-editor>`
+            lNode =>
+              html`<l-node-editor
+                .doc=${this.doc}
+                .element=${lNode}
+              ></l-node-editor>`
           )}
         </div>`
       : html``;
@@ -110,7 +117,10 @@ export class ConductingEquipmentEditor extends LitElement {
     const eqFunctions = getChildElementsByTagName(this.element, 'EqFunction');
     return html` ${eqFunctions.map(
       eqFunction =>
-        html`<eq-function-editor .element=${eqFunction}></eq-function-editor>`
+        html`<eq-function-editor
+          .doc=${this.doc}
+          .element=${eqFunction}
+        ></eq-function-editor>`
     )}`;
   }
 

--- a/src/editors/substation/eq-function-editor.ts
+++ b/src/editors/substation/eq-function-editor.ts
@@ -39,6 +39,9 @@ function childTags(element: Element | null | undefined): SCLTag[] {
 /** Pane rendering `EqFunction` element with its children */
 @customElement('eq-function-editor')
 export class EqFunctionEditor extends LitElement {
+  /** The document being edited as provided to editor by [[`Zeroline`]]. */
+  @property({ attribute: false })
+  doc!: XMLDocument;
   /** The edited `EqFunction` element */
   @property({ attribute: false })
   element!: Element;
@@ -87,7 +90,11 @@ export class EqFunctionEditor extends LitElement {
     return lNodes.length
       ? html`<div class="container lnode">
           ${lNodes.map(
-            lNode => html`<l-node-editor .element=${lNode}></l-node-editor>`
+            lNode =>
+              html`<l-node-editor
+                .doc=${this.doc}
+                .element=${lNode}
+              ></l-node-editor>`
           )}
         </div>`
       : html``;
@@ -101,6 +108,7 @@ export class EqFunctionEditor extends LitElement {
     return html` ${eqSubFunctions.map(
       eqSubFunction =>
         html`<eq-sub-function-editor
+          .doc=${this.doc}
           .element=${eqSubFunction}
         ></eq-sub-function-editor>`
     )}`;

--- a/src/editors/substation/eq-sub-function-editor.ts
+++ b/src/editors/substation/eq-sub-function-editor.ts
@@ -38,6 +38,9 @@ function childTags(element: Element | null | undefined): SCLTag[] {
 /** Pane rendering `EqSubFunction` element with its children */
 @customElement('eq-sub-function-editor')
 export class EqSubFunctionEditor extends LitElement {
+  /** The document being edited as provided to editor by [[`Zeroline`]]. */
+  @property({ attribute: false })
+  doc!: XMLDocument;
   /** The edited `EqSubFunction` element */
   @property({ attribute: false })
   element!: Element;
@@ -86,7 +89,11 @@ export class EqSubFunctionEditor extends LitElement {
     return lNodes.length
       ? html`<div class="container lnode">
           ${lNodes.map(
-            lNode => html`<l-node-editor .element=${lNode}></l-node-editor>`
+            lNode =>
+              html`<l-node-editor
+                .doc=${this.doc}
+                .element=${lNode}
+              ></l-node-editor>`
           )}
         </div>`
       : html``;
@@ -100,6 +107,7 @@ export class EqSubFunctionEditor extends LitElement {
     return html` ${eqSubFunctions.map(
       eqSubFunction =>
         html`<eq-sub-function-editor
+          .doc=${this.doc}
           .element=${eqSubFunction}
         ></eq-sub-function-editor>`
     )}`;

--- a/src/editors/substation/function-editor.ts
+++ b/src/editors/substation/function-editor.ts
@@ -35,6 +35,9 @@ function childTags(element: Element | null | undefined): SCLTag[] {
 /** Pane rendering `Function` element with its children */
 @customElement('function-editor')
 export class FunctionEditor extends LitElement {
+  /** The document being edited as provided to editor by [[`Zeroline`]]. */
+  @property({ attribute: false })
+  doc!: XMLDocument;
   /** The edited `Function` element */
   @property({ attribute: false })
   element!: Element;
@@ -83,7 +86,11 @@ export class FunctionEditor extends LitElement {
     return lNodes.length
       ? html`<div class="container lnode">
           ${lNodes.map(
-            lNode => html`<l-node-editor .element=${lNode}></l-node-editor>`
+            lNode =>
+              html`<l-node-editor
+                .doc=${this.doc}
+                .element=${lNode}
+              ></l-node-editor>`
           )}
         </div>`
       : html``;
@@ -94,6 +101,7 @@ export class FunctionEditor extends LitElement {
     return html` ${subfunctions.map(
       subFunction =>
         html`<sub-function-editor
+          .doc=${this.doc}
           .element=${subFunction}
         ></sub-function-editor>`
     )}`;

--- a/src/editors/substation/ied-editor.ts
+++ b/src/editors/substation/ied-editor.ts
@@ -19,11 +19,14 @@ import { newActionEvent, newWizardEvent } from '../../foundation.js';
 import { selectGseControlWizard } from '../../wizards/gsecontrol.js';
 import { selectSampledValueControlWizard } from '../../wizards/sampledvaluecontrol.js';
 import { selectReportControlWizard } from '../../wizards/reportcontrol.js';
-import { removeIEDWizard } from "../../wizards/ied.js";
+import { removeIEDWizard } from '../../wizards/ied.js';
 
 /** [[`SubstationEditor`]] subeditor for a child-less `IED` element. */
 @customElement('ied-editor')
 export class IedEditor extends LitElement {
+  /** The document being edited as provided to editor by [[`Zeroline`]]. */
+  @property({ attribute: false })
+  doc!: XMLDocument;
   /** SCL element IED */
   @property({ attribute: false })
   element!: Element;
@@ -72,7 +75,11 @@ export class IedEditor extends LitElement {
       this.dispatchEvent(newWizardEvent(() => wizard));
     } else {
       // If no Wizard is needed, just remove the element.
-      this.dispatchEvent(newActionEvent({ old: { parent: this.element.parentElement!, element: this.element } }));
+      this.dispatchEvent(
+        newActionEvent({
+          old: { parent: this.element.parentElement!, element: this.element },
+        })
+      );
     }
   }
 
@@ -89,7 +96,7 @@ export class IedEditor extends LitElement {
         slot="action"
         class="delete"
         mini
-        @click="${() => this.removeIED() }"
+        @click="${() => this.removeIED()}"
         icon="delete"
       ></mwc-fab
       ><mwc-fab
@@ -116,7 +123,8 @@ export class IedEditor extends LitElement {
         class="selectgse"
         mini
         @click="${() => this.openGseControlSelection()}"
-      ><mwc-icon slot="icon">${gooseIcon}</mwc-icon></mwc-fab
-    ></action-icon> `;
+        ><mwc-icon slot="icon">${gooseIcon}</mwc-icon></mwc-fab
+      ></action-icon
+    > `;
   }
 }

--- a/src/editors/substation/l-node-editor.ts
+++ b/src/editors/substation/l-node-editor.ts
@@ -62,6 +62,9 @@ const lnClassIcons: Partial<Record<string, TemplateResult>> = {
 /** Pane rendering `LNode` element with its children */
 @customElement('l-node-editor')
 export class LNodeEditor extends LitElement {
+  /** The document being edited as provided to editor by [[`Zeroline`]]. */
+  @property({ attribute: false })
+  doc!: XMLDocument;
   /** The edited `LNode` element */
   @property({ attribute: false })
   element!: Element;

--- a/src/editors/substation/powertransformer-editor.ts
+++ b/src/editors/substation/powertransformer-editor.ts
@@ -44,6 +44,9 @@ function childTags(element: Element | null | undefined): SCLTag[] {
 /** [[`SubstationEditor`]] subeditor for a child-less `PowerTransformer` element. */
 @customElement('powertransformer-editor')
 export class PowerTransformerEditor extends LitElement {
+  /** The document being edited as provided to editor by [[`Zeroline`]]. */
+  @property({ attribute: false })
+  doc!: XMLDocument;
   /** SCL element PowerTransformer */
   @property({ attribute: false })
   element!: Element;
@@ -100,7 +103,11 @@ export class PowerTransformerEditor extends LitElement {
     return lNodes.length
       ? html`<div class="container lnode">
           ${lNodes.map(
-            lNode => html`<l-node-editor .element=${lNode}></l-node-editor>`
+            lNode =>
+              html`<l-node-editor
+                .doc=${this.doc}
+                .element=${lNode}
+              ></l-node-editor>`
           )}
         </div>`
       : html``;
@@ -112,7 +119,10 @@ export class PowerTransformerEditor extends LitElement {
     const eqFunctions = getChildElementsByTagName(this.element, 'EqFunction');
     return html` ${eqFunctions.map(
       eqFunction =>
-        html`<eq-function-editor .element=${eqFunction}></eq-function-editor>`
+        html`<eq-function-editor
+          .doc=${this.doc}
+          .element=${eqFunction}
+        ></eq-function-editor>`
     )}`;
   }
 

--- a/src/editors/substation/sub-function-editor.ts
+++ b/src/editors/substation/sub-function-editor.ts
@@ -39,6 +39,9 @@ function childTags(element: Element | null | undefined): SCLTag[] {
 /** Pane rendering `SubFunction` element with its children */
 @customElement('sub-function-editor')
 export class SubFunctionEditor extends LitElement {
+  /** The document being edited as provided to editor by [[`Zeroline`]]. */
+  @property({ attribute: false })
+  doc!: XMLDocument;
   /** The edited `SubFunction` element */
   @property({ attribute: false })
   element!: Element;
@@ -87,7 +90,11 @@ export class SubFunctionEditor extends LitElement {
     return lNodes.length
       ? html`<div class="container lnode">
           ${lNodes.map(
-            lNode => html`<l-node-editor .element=${lNode}></l-node-editor>`
+            lNode =>
+              html`<l-node-editor
+                .doc=${this.doc}
+                .element=${lNode}
+              ></l-node-editor>`
           )}
         </div>`
       : html``;
@@ -98,6 +105,7 @@ export class SubFunctionEditor extends LitElement {
     return html` ${subfunctions.map(
       subFunction =>
         html`<sub-function-editor
+          .doc=${this.doc}
           .element=${subFunction}
         ></sub-function-editor>`
     )}`;

--- a/src/editors/substation/substation-editor.ts
+++ b/src/editors/substation/substation-editor.ts
@@ -45,6 +45,9 @@ function childTags(element: Element | null | undefined): SCLTag[] {
 /** [[`Substation`]] plugin subeditor for editing `Substation` sections. */
 @customElement('substation-editor')
 export class SubstationEditor extends LitElement {
+  /** The document being edited as provided to editor by [[`Zeroline`]]. */
+  @property({ attribute: false })
+  doc!: XMLDocument;
   /** The edited `Element`, a common property of all Substation subeditors. */
   @property({ attribute: false })
   element!: Element;
@@ -113,7 +116,11 @@ export class SubstationEditor extends LitElement {
     return lNodes.length
       ? html`<div class="container lnode">
           ${lNodes.map(
-            lNode => html`<l-node-editor .element=${lNode}></l-node-editor>`
+            lNode =>
+              html`<l-node-editor
+                .doc=${this.doc}
+                .element=${lNode}
+              ></l-node-editor>`
           )}
         </div>`
       : html``;
@@ -124,7 +131,11 @@ export class SubstationEditor extends LitElement {
 
     const functions = getChildElementsByTagName(this.element, 'Function');
     return html` ${functions.map(
-      fUnction => html`<function-editor .element=${fUnction}></function-editor>`
+      fUnction =>
+        html`<function-editor
+          .doc=${this.doc}
+          .element=${fUnction}
+        ></function-editor>`
     )}`;
   }
 
@@ -132,7 +143,10 @@ export class SubstationEditor extends LitElement {
     const ieds = this.getAttachedIeds?.(this.element) ?? [];
     return ieds?.length
       ? html`<div id="iedcontainer">
-          ${ieds.map(ied => html`<ied-editor .element=${ied}></ied-editor>`)}
+          ${ieds.map(
+            ied =>
+              html`<ied-editor .doc=${this.doc} .element=${ied}></ied-editor>`
+          )}
         </div>`
       : html``;
   }
@@ -153,6 +167,7 @@ export class SubstationEditor extends LitElement {
           ${pwts.map(
             pwt =>
               html`<powertransformer-editor
+                .doc=${this.doc}
                 .element=${pwt}
                 ?showfunctions=${this.showfunctions}
               ></powertransformer-editor>`
@@ -226,6 +241,7 @@ export class SubstationEditor extends LitElement {
       ${Array.from(this.element.querySelectorAll(selectors.VoltageLevel)).map(
         voltageLevel =>
           html`<voltage-level-editor
+            .doc=${this.doc}
             .element=${voltageLevel}
             .getAttachedIeds=${this.getAttachedIeds}
             ?readonly=${this.readonly}

--- a/src/editors/substation/voltage-level-editor.ts
+++ b/src/editors/substation/voltage-level-editor.ts
@@ -47,6 +47,9 @@ function childTags(element: Element | null | undefined): SCLTag[] {
 /** [[`Substation`]] subeditor for a `VoltageLevel` element. */
 @customElement('voltage-level-editor')
 export class VoltageLevelEditor extends LitElement {
+  /** The document being edited as provided to editor by [[`Zeroline`]]. */
+  @property({ attribute: false })
+  doc!: XMLDocument;
   @property({ attribute: false })
   element!: Element;
   @property({ type: Boolean })
@@ -123,7 +126,11 @@ export class VoltageLevelEditor extends LitElement {
     return lNodes.length
       ? html`<div class="container lnode">
           ${lNodes.map(
-            lNode => html`<l-node-editor .element=${lNode}></l-node-editor>`
+            lNode =>
+              html`<l-node-editor
+                .doc=${this.doc}
+                .element=${lNode}
+              ></l-node-editor>`
           )}
         </div>`
       : html``;
@@ -134,7 +141,11 @@ export class VoltageLevelEditor extends LitElement {
 
     const functions = getChildElementsByTagName(this.element, 'Function');
     return html` ${functions.map(
-      fUnction => html`<function-editor .element=${fUnction}></function-editor>`
+      fUnction =>
+        html`<function-editor
+          .doc=${this.doc}
+          .element=${fUnction}
+        ></function-editor>`
     )}`;
   }
 
@@ -142,7 +153,10 @@ export class VoltageLevelEditor extends LitElement {
     const ieds = this.getAttachedIeds?.(this.element) ?? [];
     return ieds?.length
       ? html`<div id="iedcontainer">
-          ${ieds.map(ied => html`<ied-editor .element=${ied}></ied-editor>`)}
+          ${ieds.map(
+            ied =>
+              html`<ied-editor .doc=${this.doc} .element=${ied}></ied-editor>`
+          )}
         </div>`
       : html``;
   }
@@ -163,6 +177,7 @@ export class VoltageLevelEditor extends LitElement {
           ${pwts.map(
             pwt =>
               html`<powertransformer-editor
+                .doc=${this.doc}
                 .element=${pwt}
                 ?showfunctions=${this.showfunctions}
               ></powertransformer-editor>`
@@ -237,6 +252,7 @@ export class VoltageLevelEditor extends LitElement {
       <div id="bayContainer">
         ${Array.from(this.element?.querySelectorAll(selectors.Bay) ?? []).map(
           bay => html`<bay-editor
+            .doc=${this.doc}
             .element=${bay}
             .getAttachedIeds=${this.getAttachedIeds}
             ?readonly=${this.readonly}

--- a/src/editors/substation/zeroline-pane.ts
+++ b/src/editors/substation/zeroline-pane.ts
@@ -186,6 +186,7 @@ export class ZerolinePane extends LitElement {
               .map(
                 substation =>
                   html`<substation-editor
+                    .doc=${this.doc}
                     .element=${substation}
                     .getAttachedIeds=${this.getAttachedIeds}
                     ?readonly=${this.readonly}


### PR DESCRIPTION
Close #850 

I did not add regression tests as I think they cannot be done without visual regression tests. Btw @ca-d the snapshot type regression tests you did for the `Communication` editor fixing this issue are incorrect. I did not have a close enough look at those during review. You can see by looking at the number of children. This never differs, independent whether one is deleted or added. 