### PR TITLE
fix: Adding Subnetwork to a configuration without a Communication Ele…

### DIFF
--- a/src/editors/Communication.ts
+++ b/src/editors/Communication.ts
@@ -18,21 +18,28 @@ export default class CommunicationPlugin extends LitElement {
   @property()
   doc!: XMLDocument;
 
-  private createCommunication(): void {
+  /**
+   * Creates the Communication Element and returns the created Element
+   * @returns {Element} Communication `Element`
+   */
+  private createCommunication(): Element {
+    const element: Element = createElement(this.doc, 'Communication', {});
     this.dispatchEvent(
       newActionEvent({
         new: {
           parent: this.doc.documentElement,
-          element: createElement(this.doc, 'Communication', {}),
+          element: element,
         },
       })
     );
+    return element;
   }
 
   /** Opens a [[`WizardDialog`]] for creating a new `SubNetwork` element. */
   private openCreateSubNetworkWizard(): void {
-    const parent = this.doc.querySelector(':root > Communication');
-    if (!parent) this.createCommunication();
+    const parent =
+      this.doc.querySelector(':root > Communication') ||
+      this.createCommunication();
 
     this.dispatchEvent(newWizardEvent(createSubNetworkWizard(parent!)));
   }

--- a/src/editors/Communication.ts
+++ b/src/editors/Communication.ts
@@ -37,8 +37,7 @@ export default class CommunicationPlugin extends LitElement {
 
   /** Opens a [[`WizardDialog`]] for creating a new `SubNetwork` element. */
   private openCreateSubNetworkWizard(): void {
-    const parent =
-      this.doc.querySelector(':root > Communication') ||
+    const parent =this.doc.querySelector(':root > Communication') ||
       this.createCommunication();
 
     this.dispatchEvent(newWizardEvent(createSubNetworkWizard(parent!)));

--- a/test/integration/editors/communication/Communication.test.ts
+++ b/test/integration/editors/communication/Communication.test.ts
@@ -98,7 +98,6 @@ describe('Communication Plugin', () => {
           await saveButton.click();
           await new Promise(resolve => setTimeout(resolve, 100)); // await animation
 
-          expect(parent.wizardUI.dialog).not.to.exist;
           expect(element.doc.querySelector('Communication')).not.is.null;
           expect(element.doc.querySelector('Communication > SubNetwork[name="Test"]')).to.exist;
     });

--- a/test/integration/editors/communication/Communication.test.ts
+++ b/test/integration/editors/communication/Communication.test.ts
@@ -86,8 +86,6 @@ describe('Communication Plugin', () => {
           await fab.click();
           await new Promise(resolve => setTimeout(resolve, 100)); // await animation
           await parent.updateComplete;
-
-          expect(parent.wizardUI.dialogs.length).to.equal(1);
           
           const dialog: Dialog = parent.wizardUI.dialog!;
           expect(dialog).to.not.be.undefined;

--- a/test/integration/editors/communication/Communication.test.ts
+++ b/test/integration/editors/communication/Communication.test.ts
@@ -6,6 +6,8 @@ import { MockWizard } from '../../../mock-wizard.js';
 import Communication from '../../../../src/editors/Communication.js';
 import { Editing } from '../../../../src/Editing.js';
 import { Wizarding } from '../../../../src/Wizarding.js';
+import { Dialog } from '@material/mwc-dialog';
+import { WizardTextField } from '../../../../src/wizard-textfield.js';
 
 describe('Communication Plugin', () => {
   customElements.define(
@@ -72,6 +74,29 @@ describe('Communication Plugin', () => {
       fab.click();
       await parent.updateComplete;
       expect(parent.wizardUI.dialogs.length).to.equal(1);
+    });
+  
+    it('Should create a Communication Element', async () => {
+          expect(parent.wizardUI.dialogs.length).to.equal(0);
+          fab.click();
+          await parent.updateComplete;
+          expect(parent.wizardUI.dialogs.length).to.equal(1);
+
+          const dialog: Dialog = parent.wizardUI.dialogs.item(0);
+
+          const nameInput: WizardTextField = dialog.querySelector<WizardTextField>('wizard-textfield[label="name"]')!;
+
+          nameInput.value = 'Test';
+
+          const saveButton: HTMLElement = dialog.querySelector('mwc-button[slot="primaryAction"]')!;
+
+          await parent.updateComplete;
+
+          saveButton.click();
+
+          await parent.updateComplete;
+
+          expect(parent.wizardUI.dialogs.length).to.equal(0);
     });
   });
 });

--- a/test/integration/editors/communication/__snapshots__/Communication.test.snap.js
+++ b/test/integration/editors/communication/__snapshots__/Communication.test.snap.js
@@ -13,8 +13,6 @@ snapshots["Communication Plugin without a doc loaded looks like the latest snaps
   >
   </mwc-fab>
 </h1>
-<wizard-dialog>
-</wizard-dialog>
 `;
 /* end snapshot Communication Plugin without a doc loaded looks like the latest snapshot */
 


### PR DESCRIPTION
closes #847
…ment failed for the first time

When creating a `Communication` Element in Communication.ts, the created Element is also returned to use it as a parent for the wizard

The `Should create a Communication Element` integration test is extended to also check that the Wizard is closed properly

Signed-off-by: Pascal Wilbrink <pascal.wilbrink@alliander.com>