### PR TITLE
feat(filtered-list): filter on list item value

### DIFF
--- a/src/editors/publisher/data-set-editor.ts
+++ b/src/editors/publisher/data-set-editor.ts
@@ -61,5 +61,9 @@ export class DataSetEditor extends LitElement {
     .listitem.header {
       font-weight: 500;
     }
+
+    mwc-list-item.hidden[noninteractive] + li[divider] {
+      display: none;
+    }
   `;
 }

--- a/src/editors/publisher/data-set-editor.ts
+++ b/src/editors/publisher/data-set-editor.ts
@@ -28,7 +28,7 @@ export class DataSetEditor extends LitElement {
                   const id = identity(element) as string;
                   return typeof id === 'string' ? id : '';
                 })
-                .join('')}"
+                .join(' ')}"
             >
               <span>${ied.getAttribute('name')}</span>
               <mwc-icon slot="graphic">developer_board</mwc-icon>

--- a/src/editors/publisher/data-set-editor.ts
+++ b/src/editors/publisher/data-set-editor.ts
@@ -23,6 +23,12 @@ export class DataSetEditor extends LitElement {
               class="listitem header"
               noninteractive
               graphic="icon"
+              value="${Array.from(ied.querySelectorAll('DataSet'))
+                .map(element => {
+                  const id = identity(element) as string;
+                  return typeof id === 'string' ? id : '';
+                })
+                .join('')}"
             >
               <span>${ied.getAttribute('name')}</span>
               <mwc-icon slot="graphic">developer_board</mwc-icon>

--- a/src/editors/publisher/gse-control-editor.ts
+++ b/src/editors/publisher/gse-control-editor.ts
@@ -34,7 +34,7 @@ export class GseControlEditor extends LitElement {
                   const id = identity(element) as string;
                   return typeof id === 'string' ? id : '';
                 })
-                .join('')}"
+                .join(' ')}"
             >
               <span>${ied.getAttribute('name')}</span>
               <mwc-icon slot="graphic">developer_board</mwc-icon>

--- a/src/editors/publisher/gse-control-editor.ts
+++ b/src/editors/publisher/gse-control-editor.ts
@@ -29,6 +29,12 @@ export class GseControlEditor extends LitElement {
               class="listitem header"
               noninteractive
               graphic="icon"
+              value="${Array.from(ied.querySelectorAll('GSEControl'))
+                .map(element => {
+                  const id = identity(element) as string;
+                  return typeof id === 'string' ? id : '';
+                })
+                .join('')}"
             >
               <span>${ied.getAttribute('name')}</span>
               <mwc-icon slot="graphic">developer_board</mwc-icon>

--- a/src/editors/publisher/gse-control-editor.ts
+++ b/src/editors/publisher/gse-control-editor.ts
@@ -73,5 +73,9 @@ export class GseControlEditor extends LitElement {
     .listitem.header {
       font-weight: 500;
     }
+
+    mwc-list-item.hidden[noninteractive] + li[divider] {
+      display: none;
+    }
   `;
 }

--- a/src/editors/publisher/report-control-editor.ts
+++ b/src/editors/publisher/report-control-editor.ts
@@ -29,6 +29,12 @@ export class ReportControlEditor extends LitElement {
               class="listitem header"
               noninteractive
               graphic="icon"
+              value="${Array.from(ied.querySelectorAll('ReportControl'))
+                .map(element => {
+                  const id = identity(element) as string;
+                  return typeof id === 'string' ? id : '';
+                })
+                .join('')}"
             >
               <span>${ied.getAttribute('name')}</span>
               <mwc-icon slot="graphic">developer_board</mwc-icon>

--- a/src/editors/publisher/report-control-editor.ts
+++ b/src/editors/publisher/report-control-editor.ts
@@ -34,7 +34,7 @@ export class ReportControlEditor extends LitElement {
                   const id = identity(element) as string;
                   return typeof id === 'string' ? id : '';
                 })
-                .join('')}"
+                .join(' ')}"
             >
               <span>${ied.getAttribute('name')}</span>
               <mwc-icon slot="graphic">developer_board</mwc-icon>

--- a/src/editors/publisher/report-control-editor.ts
+++ b/src/editors/publisher/report-control-editor.ts
@@ -71,5 +71,9 @@ export class ReportControlEditor extends LitElement {
     .listitem.header {
       font-weight: 500;
     }
+
+    mwc-list-item.hidden[noninteractive] + li[divider] {
+      display: none;
+    }
   `;
 }

--- a/src/editors/publisher/sampled-value-control-editor.ts
+++ b/src/editors/publisher/sampled-value-control-editor.ts
@@ -29,6 +29,12 @@ export class SampledValueControlEditor extends LitElement {
               class="listitem header"
               noninteractive
               graphic="icon"
+              value="${Array.from(ied.querySelectorAll('SampledValueControl'))
+                .map(element => {
+                  const id = identity(element) as string;
+                  return typeof id === 'string' ? id : '';
+                })
+                .join('')}"
             >
               <span>${ied.getAttribute('name')}</span>
               <mwc-icon slot="graphic">developer_board</mwc-icon>

--- a/src/editors/publisher/sampled-value-control-editor.ts
+++ b/src/editors/publisher/sampled-value-control-editor.ts
@@ -34,7 +34,7 @@ export class SampledValueControlEditor extends LitElement {
                   const id = identity(element) as string;
                   return typeof id === 'string' ? id : '';
                 })
-                .join('')}"
+                .join(' ')}"
             >
               <span>${ied.getAttribute('name')}</span>
               <mwc-icon slot="graphic">developer_board</mwc-icon>

--- a/src/editors/publisher/sampled-value-control-editor.ts
+++ b/src/editors/publisher/sampled-value-control-editor.ts
@@ -73,5 +73,9 @@ export class SampledValueControlEditor extends LitElement {
     .listitem.header {
       font-weight: 500;
     }
+
+    mwc-list-item.hidden[noninteractive] + li[divider] {
+      display: none;
+    }
   `;
 }

--- a/src/editors/subscription/goose/goose-list.ts
+++ b/src/editors/subscription/goose/goose-list.ts
@@ -129,5 +129,9 @@ export class GooseList extends LitElement {
     mwc-icon-button.hidden {
       display: none;
     }
+
+    mwc-list-item.hidden[noninteractive] + li[divider] {
+      display: none;
+    }
   `;
 }

--- a/src/editors/subscription/goose/goose-list.ts
+++ b/src/editors/subscription/goose/goose-list.ts
@@ -102,7 +102,7 @@ export class GooseList extends LitElement {
                     const id = identity(element) as string;
                     return typeof id === 'string' ? id : '';
                   })
-                  .join('')}"
+                  .join(' ')}"
               >
                 <span>${getNameAttribute(ied)}</span>
                 <mwc-icon slot="graphic">developer_board</mwc-icon>

--- a/src/editors/subscription/goose/goose-list.ts
+++ b/src/editors/subscription/goose/goose-list.ts
@@ -13,7 +13,11 @@ import '@material/mwc-icon';
 import '@material/mwc-list/mwc-list-item';
 
 import '../../../filtered-list.js';
-import { getNameAttribute, newWizardEvent } from '../../../foundation.js';
+import {
+  getNameAttribute,
+  identity,
+  newWizardEvent,
+} from '../../../foundation.js';
 import { newGOOSESelectEvent } from './foundation.js';
 import { gooseIcon } from '../../../icons/icons.js';
 import { wizards } from '../../../wizards/wizard-library.js';
@@ -31,7 +35,7 @@ addEventListener('open-doc', onOpenDocResetSelectedGooseMsg);
 /** An sub element for showing all published GOOSE messages per IED. */
 @customElement('goose-list')
 export class GooseList extends LitElement {
-  @property()
+  @property({ attribute: false })
   doc!: XMLDocument;
 
   private onSelect(gseControl: Element): void {
@@ -57,6 +61,7 @@ export class GooseList extends LitElement {
       @click=${() => this.onSelect(gseControl)}
       graphic="large"
       hasMeta
+      value="${identity(gseControl)}"
     >
       <mwc-icon slot="graphic">${gooseIcon}</mwc-icon>
       <span>${gseControl.getAttribute('name')}</span>
@@ -89,7 +94,16 @@ export class GooseList extends LitElement {
         ${getOrderedIeds(this.doc).map(
           ied =>
             html`
-              <mwc-list-item noninteractive graphic="icon">
+              <mwc-list-item
+                noninteractive
+                graphic="icon"
+                value="${Array.from(ied.querySelectorAll('GSEControl'))
+                  .map(element => {
+                    const id = identity(element) as string;
+                    return typeof id === 'string' ? id : '';
+                  })
+                  .join('')}"
+              >
                 <span>${getNameAttribute(ied)}</span>
                 <mwc-icon slot="graphic">developer_board</mwc-icon>
               </mwc-list-item>

--- a/src/editors/subscription/goose/subscriber-list.ts
+++ b/src/editors/subscription/goose/subscriber-list.ts
@@ -331,7 +331,7 @@ export class SubscriberList extends SubscriberListContainer {
             const id = identity(element.element) as string;
             return typeof id === 'string' ? id : '';
           })
-          .join('')}"
+          .join(' ')}"
       >
         <span
           >${translate('subscription.subscriber.availableToSubscribe')}</span
@@ -355,7 +355,7 @@ export class SubscriberList extends SubscriberListContainer {
             const id = identity(element.element) as string;
             return typeof id === 'string' ? id : '';
           })
-          .join('')}"
+          .join(' ')}"
       >
         <span>${translate('subscription.subscriber.partiallySubscribed')}</span>
       </mwc-list-item>
@@ -377,7 +377,7 @@ export class SubscriberList extends SubscriberListContainer {
             const id = identity(element.element) as string;
             return typeof id === 'string' ? id : '';
           })
-          .join('')}"
+          .join(' ')}"
       >
         <span>${translate('subscription.subscriber.subscribed')}</span>
       </mwc-list-item>

--- a/src/editors/subscription/goose/subscriber-list.ts
+++ b/src/editors/subscription/goose/subscriber-list.ts
@@ -16,6 +16,7 @@ import {
   Create,
   createElement,
   Delete,
+  identity,
   newActionEvent,
 } from '../../../foundation.js';
 import {
@@ -323,7 +324,15 @@ export class SubscriberList extends SubscriberListContainer {
   }
 
   renderUnSubscribers(elements: ListElement[]): TemplateResult {
-    return html`<mwc-list-item noninteractive>
+    return html`<mwc-list-item
+        noninteractive
+        value="${elements
+          .map(element => {
+            const id = identity(element.element) as string;
+            return typeof id === 'string' ? id : '';
+          })
+          .join('')}"
+      >
         <span
           >${translate('subscription.subscriber.availableToSubscribe')}</span
         >
@@ -339,7 +348,15 @@ export class SubscriberList extends SubscriberListContainer {
   }
 
   renderPartiallySubscribers(elements: ListElement[]): TemplateResult {
-    return html`<mwc-list-item noninteractive>
+    return html`<mwc-list-item
+        noninteractive
+        value="${elements
+          .map(element => {
+            const id = identity(element.element) as string;
+            return typeof id === 'string' ? id : '';
+          })
+          .join('')}"
+      >
         <span>${translate('subscription.subscriber.partiallySubscribed')}</span>
       </mwc-list-item>
       <li divider role="separator"></li>
@@ -353,7 +370,15 @@ export class SubscriberList extends SubscriberListContainer {
   }
 
   renderFullSubscribers(): TemplateResult {
-    return html`<mwc-list-item noninteractive>
+    return html`<mwc-list-item
+        noninteractive
+        value="${this.subscribedElements
+          .map(element => {
+            const id = identity(element.element) as string;
+            return typeof id === 'string' ? id : '';
+          })
+          .join('')}"
+      >
         <span>${translate('subscription.subscriber.subscribed')}</span>
       </mwc-list-item>
       <li divider role="separator"></li>

--- a/src/editors/subscription/sampledvalues/smv-list.ts
+++ b/src/editors/subscription/sampledvalues/smv-list.ts
@@ -125,5 +125,9 @@ export class SmvPublisherList extends LitElement {
     mwc-icon-button.hidden {
       display: none;
     }
+
+    mwc-list-item.hidden[noninteractive] + li[divider] {
+      display: none;
+    }
   `;
 }

--- a/src/editors/subscription/sampledvalues/smv-list.ts
+++ b/src/editors/subscription/sampledvalues/smv-list.ts
@@ -12,7 +12,11 @@ import '@material/mwc-icon';
 import '@material/mwc-list';
 import '@material/mwc-list/mwc-list-item';
 
-import { getNameAttribute, newWizardEvent } from '../../../foundation.js';
+import {
+  getNameAttribute,
+  identity,
+  newWizardEvent,
+} from '../../../foundation.js';
 import { newSmvSelectEvent } from './foundation.js';
 import { smvIcon } from '../../../icons/icons.js';
 import { getOrderedIeds, styles } from '../foundation.js';
@@ -31,7 +35,7 @@ addEventListener('open-doc', onOpenDocResetSelectedSmvMsg);
 /** An sub element for showing all Sampled Values per IED. */
 @customElement('smv-list')
 export class SmvPublisherList extends LitElement {
-  @property()
+  @property({ attribute: false })
   doc!: XMLDocument;
 
   private onSelect(smvControl: Element) {
@@ -64,6 +68,7 @@ export class SmvPublisherList extends LitElement {
       @click=${() => this.onSelect(smvControl)}
       graphic="large"
       hasMeta
+      value="${identity(smvControl)}"
     >
       <mwc-icon slot="graphic">${smvIcon}</mwc-icon>
       <span>${smvControl.getAttribute('name')}</span>
@@ -85,7 +90,16 @@ export class SmvPublisherList extends LitElement {
         ${getOrderedIeds(this.doc).map(
           ied =>
             html`
-              <mwc-list-item noninteractive graphic="icon">
+              <mwc-list-item
+                noninteractive
+                graphic="icon"
+                value="${Array.from(ied.querySelectorAll('SampledValueControl'))
+                  .map(element => {
+                    const id = identity(element) as string;
+                    return typeof id === 'string' ? id : '';
+                  })
+                  .join('')}"
+              >
                 <span>${getNameAttribute(ied)}</span>
                 <mwc-icon slot="graphic">developer_board</mwc-icon>
               </mwc-list-item>

--- a/src/editors/subscription/sampledvalues/smv-list.ts
+++ b/src/editors/subscription/sampledvalues/smv-list.ts
@@ -98,7 +98,7 @@ export class SmvPublisherList extends LitElement {
                     const id = identity(element) as string;
                     return typeof id === 'string' ? id : '';
                   })
-                  .join('')}"
+                  .join(' ')}"
               >
                 <span>${getNameAttribute(ied)}</span>
                 <mwc-icon slot="graphic">developer_board</mwc-icon>

--- a/src/editors/subscription/sampledvalues/subscriber-list.ts
+++ b/src/editors/subscription/sampledvalues/subscriber-list.ts
@@ -333,7 +333,7 @@ export class SubscriberList extends SubscriberListContainer {
             const id = identity(element.element) as string;
             return typeof id === 'string' ? id : '';
           })
-          .join('')}"
+          .join(' ')}"
       >
         <span
           >${translate('subscription.subscriber.availableToSubscribe')}</span
@@ -357,7 +357,7 @@ export class SubscriberList extends SubscriberListContainer {
             const id = identity(element.element) as string;
             return typeof id === 'string' ? id : '';
           })
-          .join('')}"
+          .join(' ')}"
       >
         <span>${translate('subscription.subscriber.partiallySubscribed')}</span>
       </mwc-list-item>
@@ -379,7 +379,7 @@ export class SubscriberList extends SubscriberListContainer {
             const id = identity(element.element) as string;
             return typeof id === 'string' ? id : '';
           })
-          .join('')}"
+          .join(' ')}"
       >
         <span>${translate('subscription.subscriber.subscribed')}</span>
       </mwc-list-item>

--- a/src/editors/subscription/sampledvalues/subscriber-list.ts
+++ b/src/editors/subscription/sampledvalues/subscriber-list.ts
@@ -16,6 +16,7 @@ import {
   Create,
   createElement,
   Delete,
+  identity,
   newActionEvent,
 } from '../../../foundation.js';
 import {
@@ -325,7 +326,15 @@ export class SubscriberList extends SubscriberListContainer {
   }
 
   renderUnSubscribers(elements: ListElement[]): TemplateResult {
-    return html`<mwc-list-item noninteractive>
+    return html`<mwc-list-item
+        noninteractive
+        value="${elements
+          .map(element => {
+            const id = identity(element.element) as string;
+            return typeof id === 'string' ? id : '';
+          })
+          .join('')}"
+      >
         <span
           >${translate('subscription.subscriber.availableToSubscribe')}</span
         >
@@ -341,7 +350,15 @@ export class SubscriberList extends SubscriberListContainer {
   }
 
   renderPartiallySubscribers(elements: ListElement[]): TemplateResult {
-    return html`<mwc-list-item noninteractive>
+    return html`<mwc-list-item
+        noninteractive
+        value="${elements
+          .map(element => {
+            const id = identity(element.element) as string;
+            return typeof id === 'string' ? id : '';
+          })
+          .join('')}"
+      >
         <span>${translate('subscription.subscriber.partiallySubscribed')}</span>
       </mwc-list-item>
       <li divider role="separator"></li>
@@ -355,7 +372,15 @@ export class SubscriberList extends SubscriberListContainer {
   }
 
   renderFullSubscribers(): TemplateResult {
-    return html`<mwc-list-item noninteractive>
+    return html`<mwc-list-item
+        noninteractive
+        value="${this.subscribedElements
+          .map(element => {
+            const id = identity(element.element) as string;
+            return typeof id === 'string' ? id : '';
+          })
+          .join('')}"
+      >
         <span>${translate('subscription.subscriber.subscribed')}</span>
       </mwc-list-item>
       <li divider role="separator"></li>

--- a/src/filtered-list.ts
+++ b/src/filtered-list.ts
@@ -30,7 +30,13 @@ function hideFiltered(item: ListItemBase, searchText: string): void {
   const childInnerText = Array.from(item.children)
     .map(child => (<HTMLElement>child).innerText)
     .join('\n');
-  const filterTarget: string = (itemInnerText + childInnerText).toUpperCase();
+  const value = item.value;
+
+  const filterTarget: string = (
+    itemInnerText +
+    childInnerText +
+    value
+  ).toUpperCase();
 
   const terms: string[] = searchText.toUpperCase().split(' ');
 
@@ -86,11 +92,9 @@ export class FilteredList extends ListBase {
       this.querySelectorAll(
         'mwc-list-item, mwc-check-list-item, mwc-radio-list-item'
       )
-    )
-      .filter(item => !(item as ListItemBase).noninteractive)
-      .forEach(item =>
-        hideFiltered(item as ListItemBase, this.searchField.value)
-      );
+    ).forEach(item =>
+      hideFiltered(item as ListItemBase, this.searchField.value)
+    );
   }
 
   protected onListItemConnected(e: CustomEvent): void {

--- a/test/integration/editors/subscription/goose/__snapshots__/GooseControlSubscription.test.snap.js
+++ b/test/integration/editors/subscription/goose/__snapshots__/GooseControlSubscription.test.snap.js
@@ -43,6 +43,7 @@ snapshots["GOOSE subscriber plugin in Publisher view per dafault the right hand 
       graphic="icon"
       noninteractive=""
       tabindex="-1"
+      value="IED1>>CircuitBreaker_CB1>GCBIED1>>CircuitBreaker_CB1>GCB2"
     >
       <span>
         IED1
@@ -62,6 +63,7 @@ snapshots["GOOSE subscriber plugin in Publisher view per dafault the right hand 
       hasmeta=""
       mwc-list-item=""
       tabindex="0"
+      value="IED1>>CircuitBreaker_CB1>GCB"
     >
       <mwc-icon slot="graphic">
       </mwc-icon>
@@ -81,6 +83,7 @@ snapshots["GOOSE subscriber plugin in Publisher view per dafault the right hand 
       hasmeta=""
       mwc-list-item=""
       tabindex="-1"
+      value="IED1>>CircuitBreaker_CB1>GCB2"
     >
       <mwc-icon slot="graphic">
       </mwc-icon>
@@ -99,6 +102,7 @@ snapshots["GOOSE subscriber plugin in Publisher view per dafault the right hand 
       graphic="icon"
       noninteractive=""
       tabindex="-1"
+      value="IED2>>CBSW>GCB"
     >
       <span>
         IED2
@@ -118,6 +122,7 @@ snapshots["GOOSE subscriber plugin in Publisher view per dafault the right hand 
       hasmeta=""
       mwc-list-item=""
       tabindex="-1"
+      value="IED2>>CBSW>GCB"
     >
       <mwc-icon slot="graphic">
       </mwc-icon>
@@ -136,6 +141,7 @@ snapshots["GOOSE subscriber plugin in Publisher view per dafault the right hand 
       graphic="icon"
       noninteractive=""
       tabindex="-1"
+      value=""
     >
       <span>
         IED3
@@ -154,6 +160,7 @@ snapshots["GOOSE subscriber plugin in Publisher view per dafault the right hand 
       graphic="icon"
       noninteractive=""
       tabindex="-1"
+      value="IED4>>CircuitBreaker_CB1>GCBIED4>>CircuitBreaker_CB1>GCB2"
     >
       <span>
         IED4
@@ -173,6 +180,7 @@ snapshots["GOOSE subscriber plugin in Publisher view per dafault the right hand 
       hasmeta=""
       mwc-list-item=""
       tabindex="-1"
+      value="IED4>>CircuitBreaker_CB1>GCB"
     >
       <mwc-icon slot="graphic">
       </mwc-icon>
@@ -192,6 +200,7 @@ snapshots["GOOSE subscriber plugin in Publisher view per dafault the right hand 
       hasmeta=""
       mwc-list-item=""
       tabindex="-1"
+      value="IED4>>CircuitBreaker_CB1>GCB2"
     >
       <mwc-icon slot="graphic">
       </mwc-icon>
@@ -241,6 +250,7 @@ snapshots["GOOSE subscriber plugin in Publisher view with a selected GOOSE messa
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value="IED1"
       >
         <span>
           [subscription.subscriber.subscribed]
@@ -269,6 +279,7 @@ snapshots["GOOSE subscriber plugin in Publisher view with a selected GOOSE messa
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value="IED4"
       >
         <span>
           [subscription.subscriber.partiallySubscribed]
@@ -297,6 +308,7 @@ snapshots["GOOSE subscriber plugin in Publisher view with a selected GOOSE messa
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value="IED3"
       >
         <span>
           [subscription.subscriber.availableToSubscribe]
@@ -338,6 +350,7 @@ snapshots["GOOSE subscriber plugin in Publisher view with a selected GOOSE messa
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value="IED1IED3"
       >
         <span>
           [subscription.subscriber.subscribed]
@@ -380,6 +393,7 @@ snapshots["GOOSE subscriber plugin in Publisher view with a selected GOOSE messa
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value="IED4"
       >
         <span>
           [subscription.subscriber.partiallySubscribed]
@@ -409,6 +423,7 @@ snapshots["GOOSE subscriber plugin in Publisher view with a selected GOOSE messa
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value=""
       >
         <span>
           [subscription.subscriber.availableToSubscribe]
@@ -446,6 +461,7 @@ snapshots["GOOSE subscriber plugin in Publisher view with a selected GOOSE messa
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value=""
       >
         <span>
           [subscription.subscriber.subscribed]
@@ -470,6 +486,7 @@ snapshots["GOOSE subscriber plugin in Publisher view with a selected GOOSE messa
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value="IED4"
       >
         <span>
           [subscription.subscriber.partiallySubscribed]
@@ -499,6 +516,7 @@ snapshots["GOOSE subscriber plugin in Publisher view with a selected GOOSE messa
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value="IED1IED3"
       >
         <span>
           [subscription.subscriber.availableToSubscribe]
@@ -554,6 +572,7 @@ snapshots["GOOSE subscriber plugin in Publisher view with a selected GOOSE messa
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value="IED1IED4"
       >
         <span>
           [subscription.subscriber.subscribed]
@@ -597,6 +616,7 @@ snapshots["GOOSE subscriber plugin in Publisher view with a selected GOOSE messa
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value=""
       >
         <span>
           [subscription.subscriber.partiallySubscribed]
@@ -621,6 +641,7 @@ snapshots["GOOSE subscriber plugin in Publisher view with a selected GOOSE messa
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value="IED3"
       >
         <span>
           [subscription.subscriber.availableToSubscribe]
@@ -776,6 +797,7 @@ snapshots["GOOSE subscriber plugin in Subscriber view with a selected IED the le
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value=""
       >
         <span>
           [subscription.subscriber.subscribed]
@@ -800,6 +822,7 @@ snapshots["GOOSE subscriber plugin in Subscriber view with a selected IED the le
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value="IED1>>CircuitBreaker_CB1>GCB"
       >
         <span>
           [subscription.subscriber.partiallySubscribed]
@@ -828,6 +851,7 @@ snapshots["GOOSE subscriber plugin in Subscriber view with a selected IED the le
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value="IED4>>CircuitBreaker_CB1>GCB"
       >
         <span>
           [subscription.subscriber.availableToSubscribe]
@@ -858,7 +882,7 @@ snapshots["GOOSE subscriber plugin in Subscriber view with a selected IED the le
 `;
 /* end snapshot GOOSE subscriber plugin in Subscriber view with a selected IED the left hand side subscriber IED list looks like the latest snapshot */
 
-snapshots["GOOSE subscriber plugin in Subscriber view with a selected IED for unsubscribed GSEControl s clicking on the GSEControl list item the left hand side subscriber IED list looks like the latest snapshot"] = 
+snapshots["GOOSE subscriber plugin in Subscriber view with a selected IED for unsubscribed GSEControl s clicking on a GSEControl list item the left hand side subscriber IED list looks like the latest snapshot"] = 
 `<section tabindex="0">
   <h1>
     [subscription.goose.subscriberGoose.publisherTitle]
@@ -869,6 +893,7 @@ snapshots["GOOSE subscriber plugin in Subscriber view with a selected IED for un
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value="IED4>>CircuitBreaker_CB1>GCB"
       >
         <span>
           [subscription.subscriber.subscribed]
@@ -897,6 +922,7 @@ snapshots["GOOSE subscriber plugin in Subscriber view with a selected IED for un
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value="IED1>>CircuitBreaker_CB1>GCB"
       >
         <span>
           [subscription.subscriber.partiallySubscribed]
@@ -926,6 +952,7 @@ snapshots["GOOSE subscriber plugin in Subscriber view with a selected IED for un
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value=""
       >
         <span>
           [subscription.subscriber.availableToSubscribe]
@@ -950,7 +977,7 @@ snapshots["GOOSE subscriber plugin in Subscriber view with a selected IED for un
   </div>
 </section>
 `;
-/* end snapshot GOOSE subscriber plugin in Subscriber view with a selected IED for unsubscribed GSEControl s clicking on the GSEControl list item the left hand side subscriber IED list looks like the latest snapshot */
+/* end snapshot GOOSE subscriber plugin in Subscriber view with a selected IED for unsubscribed GSEControl s clicking on a GSEControl list item the left hand side subscriber IED list looks like the latest snapshot */
 
 snapshots["GOOSE subscriber plugin in Subscriber view with a selected IED for subscribed GSEControl s clicking on the GSEControl list item the left hand side subscriber IED list looks like the latest snapshot"] = 
 `<section tabindex="0">
@@ -963,6 +990,7 @@ snapshots["GOOSE subscriber plugin in Subscriber view with a selected IED for su
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value=""
       >
         <span>
           [subscription.subscriber.subscribed]
@@ -987,6 +1015,7 @@ snapshots["GOOSE subscriber plugin in Subscriber view with a selected IED for su
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value="IED1>>CircuitBreaker_CB1>GCB"
       >
         <span>
           [subscription.subscriber.partiallySubscribed]
@@ -1016,6 +1045,7 @@ snapshots["GOOSE subscriber plugin in Subscriber view with a selected IED for su
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value="IED4>>CircuitBreaker_CB1>GCB"
       >
         <span>
           [subscription.subscriber.availableToSubscribe]
@@ -1057,6 +1087,7 @@ snapshots["GOOSE subscriber plugin in Subscriber view with a selected IED for pa
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value="IED1>>CircuitBreaker_CB1>GCB"
       >
         <span>
           [subscription.subscriber.subscribed]
@@ -1086,6 +1117,7 @@ snapshots["GOOSE subscriber plugin in Subscriber view with a selected IED for pa
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value=""
       >
         <span>
           [subscription.subscriber.partiallySubscribed]
@@ -1110,6 +1142,7 @@ snapshots["GOOSE subscriber plugin in Subscriber view with a selected IED for pa
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value="IED4>>CircuitBreaker_CB1>GCB"
       >
         <span>
           [subscription.subscriber.availableToSubscribe]
@@ -1139,98 +1172,4 @@ snapshots["GOOSE subscriber plugin in Subscriber view with a selected IED for pa
 </section>
 `;
 /* end snapshot GOOSE subscriber plugin in Subscriber view with a selected IED for partially subscribed GSEControl s clicking on the GSEControl list item the left hand side subscriber IED list looks like the latest snapshot */
-
-snapshots["GOOSE subscriber plugin in Subscriber view with a selected IED for unsubscribed GSEControl s clicking on a GSEControl list item the left hand side subscriber IED list looks like the latest snapshot"] = 
-`<section tabindex="0">
-  <h1>
-    [subscription.goose.subscriberGoose.publisherTitle]
-  </h1>
-  <div class="wrapper">
-    <filtered-list>
-      <mwc-list-item
-        aria-disabled="false"
-        noninteractive=""
-        tabindex="-1"
-      >
-        <span>
-          [subscription.subscriber.subscribed]
-        </span>
-      </mwc-list-item>
-      <li
-        divider=""
-        role="separator"
-      >
-      </li>
-      <mwc-list-item
-        aria-disabled="false"
-        graphic="avatar"
-        hasmeta=""
-        mwc-list-item=""
-        tabindex="0"
-      >
-        <span>
-          GCB (IED4)
-        </span>
-        <mwc-icon slot="graphic">
-          clear
-        </mwc-icon>
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        noninteractive=""
-        tabindex="-1"
-      >
-        <span>
-          [subscription.subscriber.partiallySubscribed]
-        </span>
-      </mwc-list-item>
-      <li
-        divider=""
-        role="separator"
-      >
-      </li>
-      <mwc-list-item
-        aria-disabled="false"
-        aria-selected="false"
-        graphic="avatar"
-        hasmeta=""
-        mwc-list-item=""
-        tabindex="-1"
-      >
-        <span>
-          GCB (IED1)
-        </span>
-        <mwc-icon slot="graphic">
-          add
-        </mwc-icon>
-      </mwc-list-item>
-      <mwc-list-item
-        aria-disabled="false"
-        noninteractive=""
-        tabindex="-1"
-      >
-        <span>
-          [subscription.subscriber.availableToSubscribe]
-        </span>
-      </mwc-list-item>
-      <li
-        divider=""
-        role="separator"
-      >
-      </li>
-      <mwc-list-item
-        aria-disabled="false"
-        graphic="avatar"
-        noninteractive=""
-        tabindex="-1"
-      >
-        <span>
-          [subscription.none]
-        </span>
-      </mwc-list-item>
-    </filtered-list>
-  </div>
-</section>
-`;
-/* end snapshot GOOSE subscriber plugin in Subscriber view with a selected IED for unsubscribed GSEControl s clicking on a GSEControl list item the left hand side subscriber IED list looks like the latest snapshot */
 

--- a/test/integration/editors/subscription/goose/__snapshots__/GooseControlSubscription.test.snap.js
+++ b/test/integration/editors/subscription/goose/__snapshots__/GooseControlSubscription.test.snap.js
@@ -43,7 +43,7 @@ snapshots["GOOSE subscriber plugin in Publisher view per dafault the right hand 
       graphic="icon"
       noninteractive=""
       tabindex="-1"
-      value="IED1>>CircuitBreaker_CB1>GCBIED1>>CircuitBreaker_CB1>GCB2"
+      value="IED1>>CircuitBreaker_CB1>GCB IED1>>CircuitBreaker_CB1>GCB2"
     >
       <span>
         IED1
@@ -160,7 +160,7 @@ snapshots["GOOSE subscriber plugin in Publisher view per dafault the right hand 
       graphic="icon"
       noninteractive=""
       tabindex="-1"
-      value="IED4>>CircuitBreaker_CB1>GCBIED4>>CircuitBreaker_CB1>GCB2"
+      value="IED4>>CircuitBreaker_CB1>GCB IED4>>CircuitBreaker_CB1>GCB2"
     >
       <span>
         IED4
@@ -350,7 +350,7 @@ snapshots["GOOSE subscriber plugin in Publisher view with a selected GOOSE messa
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
-        value="IED1IED3"
+        value="IED1 IED3"
       >
         <span>
           [subscription.subscriber.subscribed]
@@ -516,7 +516,7 @@ snapshots["GOOSE subscriber plugin in Publisher view with a selected GOOSE messa
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
-        value="IED1IED3"
+        value="IED1 IED3"
       >
         <span>
           [subscription.subscriber.availableToSubscribe]
@@ -572,7 +572,7 @@ snapshots["GOOSE subscriber plugin in Publisher view with a selected GOOSE messa
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
-        value="IED1IED4"
+        value="IED1 IED4"
       >
         <span>
           [subscription.subscriber.subscribed]

--- a/test/integration/editors/subscription/sampledvalues/__snapshots__/SampledValuesSubscription.test.snap.js
+++ b/test/integration/editors/subscription/sampledvalues/__snapshots__/SampledValuesSubscription.test.snap.js
@@ -43,6 +43,7 @@ snapshots["Sampled Values Plugin in Publisher view initially the Sampled Values 
       graphic="icon"
       noninteractive=""
       tabindex="-1"
+      value=""
     >
       <span>
         IED1
@@ -61,6 +62,7 @@ snapshots["Sampled Values Plugin in Publisher view initially the Sampled Values 
       graphic="icon"
       noninteractive=""
       tabindex="-1"
+      value=""
     >
       <span>
         IED2
@@ -79,6 +81,7 @@ snapshots["Sampled Values Plugin in Publisher view initially the Sampled Values 
       graphic="icon"
       noninteractive=""
       tabindex="-1"
+      value="IED3>>MU01>MSVCB01"
     >
       <span>
         IED3
@@ -98,6 +101,7 @@ snapshots["Sampled Values Plugin in Publisher view initially the Sampled Values 
       hasmeta=""
       mwc-list-item=""
       tabindex="0"
+      value="IED3>>MU01>MSVCB01"
     >
       <mwc-icon slot="graphic">
       </mwc-icon>
@@ -116,6 +120,7 @@ snapshots["Sampled Values Plugin in Publisher view initially the Sampled Values 
       graphic="icon"
       noninteractive=""
       tabindex="-1"
+      value="IED4>>CircuitBreaker_CB1>MSVCB02"
     >
       <span>
         IED4
@@ -135,6 +140,7 @@ snapshots["Sampled Values Plugin in Publisher view initially the Sampled Values 
       hasmeta=""
       mwc-list-item=""
       tabindex="-1"
+      value="IED4>>CircuitBreaker_CB1>MSVCB02"
     >
       <mwc-icon slot="graphic">
       </mwc-icon>
@@ -184,6 +190,7 @@ snapshots["Sampled Values Plugin in Publisher view when selecting a Sampled Valu
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value="IED1"
       >
         <span>
           [subscription.subscriber.subscribed]
@@ -212,6 +219,7 @@ snapshots["Sampled Values Plugin in Publisher view when selecting a Sampled Valu
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value="IED4"
       >
         <span>
           [subscription.subscriber.partiallySubscribed]
@@ -240,6 +248,7 @@ snapshots["Sampled Values Plugin in Publisher view when selecting a Sampled Valu
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value="IED2"
       >
         <span>
           [subscription.subscriber.availableToSubscribe]
@@ -281,6 +290,7 @@ snapshots["Sampled Values Plugin in Publisher view when selecting a Sampled Valu
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value="IED1IED2"
       >
         <span>
           [subscription.subscriber.subscribed]
@@ -321,6 +331,7 @@ snapshots["Sampled Values Plugin in Publisher view when selecting a Sampled Valu
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value="IED4"
       >
         <span>
           [subscription.subscriber.partiallySubscribed]
@@ -349,6 +360,7 @@ snapshots["Sampled Values Plugin in Publisher view when selecting a Sampled Valu
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value=""
       >
         <span>
           [subscription.subscriber.availableToSubscribe]
@@ -384,6 +396,7 @@ snapshots["Sampled Values Plugin in Publisher view when selecting a Sampled Valu
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value=""
       >
         <span>
           [subscription.subscriber.subscribed]
@@ -406,6 +419,7 @@ snapshots["Sampled Values Plugin in Publisher view when selecting a Sampled Valu
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value="IED4"
       >
         <span>
           [subscription.subscriber.partiallySubscribed]
@@ -434,6 +448,7 @@ snapshots["Sampled Values Plugin in Publisher view when selecting a Sampled Valu
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value="IED1IED2"
       >
         <span>
           [subscription.subscriber.availableToSubscribe]
@@ -487,6 +502,7 @@ snapshots["Sampled Values Plugin in Publisher view when selecting a Sampled Valu
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value="IED1IED4"
       >
         <span>
           [subscription.subscriber.subscribed]
@@ -527,6 +543,7 @@ snapshots["Sampled Values Plugin in Publisher view when selecting a Sampled Valu
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value=""
       >
         <span>
           [subscription.subscriber.partiallySubscribed]
@@ -549,6 +566,7 @@ snapshots["Sampled Values Plugin in Publisher view when selecting a Sampled Valu
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value="IED2"
       >
         <span>
           [subscription.subscriber.availableToSubscribe]
@@ -704,6 +722,7 @@ snapshots["Sampled Values Plugin in Subscriber view when selecting an IED the su
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value=""
       >
         <span>
           [subscription.subscriber.subscribed]
@@ -728,6 +747,7 @@ snapshots["Sampled Values Plugin in Subscriber view when selecting an IED the su
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value="IED4>>CircuitBreaker_CB1>MSVCB02"
       >
         <span>
           [subscription.subscriber.partiallySubscribed]
@@ -756,6 +776,7 @@ snapshots["Sampled Values Plugin in Subscriber view when selecting an IED the su
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value="IED3>>MU01>MSVCB01"
       >
         <span>
           [subscription.subscriber.availableToSubscribe]
@@ -797,6 +818,7 @@ snapshots["Sampled Values Plugin in Subscriber view when selecting an IED and su
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value="IED3>>MU01>MSVCB01"
       >
         <span>
           [subscription.subscriber.subscribed]
@@ -825,6 +847,7 @@ snapshots["Sampled Values Plugin in Subscriber view when selecting an IED and su
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value="IED4>>CircuitBreaker_CB1>MSVCB02"
       >
         <span>
           [subscription.subscriber.partiallySubscribed]
@@ -854,6 +877,7 @@ snapshots["Sampled Values Plugin in Subscriber view when selecting an IED and su
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value=""
       >
         <span>
           [subscription.subscriber.availableToSubscribe]
@@ -891,6 +915,7 @@ snapshots["Sampled Values Plugin in Subscriber view when selecting an IED and un
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value=""
       >
         <span>
           [subscription.subscriber.subscribed]
@@ -913,6 +938,7 @@ snapshots["Sampled Values Plugin in Subscriber view when selecting an IED and un
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value="IED4>>CircuitBreaker_CB1>MSVCB02"
       >
         <span>
           [subscription.subscriber.partiallySubscribed]
@@ -942,6 +968,7 @@ snapshots["Sampled Values Plugin in Subscriber view when selecting an IED and un
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value="IED3>>MU01>MSVCB01"
       >
         <span>
           [subscription.subscriber.availableToSubscribe]
@@ -981,6 +1008,7 @@ snapshots["Sampled Values Plugin in Subscriber view when selecting an IED and su
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value="IED4>>CircuitBreaker_CB1>MSVCB02"
       >
         <span>
           [subscription.subscriber.subscribed]
@@ -1007,6 +1035,7 @@ snapshots["Sampled Values Plugin in Subscriber view when selecting an IED and su
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value=""
       >
         <span>
           [subscription.subscriber.partiallySubscribed]
@@ -1029,6 +1058,7 @@ snapshots["Sampled Values Plugin in Subscriber view when selecting an IED and su
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
+        value="IED3>>MU01>MSVCB01"
       >
         <span>
           [subscription.subscriber.availableToSubscribe]

--- a/test/integration/editors/subscription/sampledvalues/__snapshots__/SampledValuesSubscription.test.snap.js
+++ b/test/integration/editors/subscription/sampledvalues/__snapshots__/SampledValuesSubscription.test.snap.js
@@ -290,7 +290,7 @@ snapshots["Sampled Values Plugin in Publisher view when selecting a Sampled Valu
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
-        value="IED1IED2"
+        value="IED1 IED2"
       >
         <span>
           [subscription.subscriber.subscribed]
@@ -448,7 +448,7 @@ snapshots["Sampled Values Plugin in Publisher view when selecting a Sampled Valu
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
-        value="IED1IED2"
+        value="IED1 IED2"
       >
         <span>
           [subscription.subscriber.availableToSubscribe]
@@ -502,7 +502,7 @@ snapshots["Sampled Values Plugin in Publisher view when selecting a Sampled Valu
         aria-disabled="false"
         noninteractive=""
         tabindex="-1"
-        value="IED1IED4"
+        value="IED1 IED4"
       >
         <span>
           [subscription.subscriber.subscribed]

--- a/test/unit/editors/publisher/__snapshots__/data-set-editor.test.snap.js
+++ b/test/unit/editors/publisher/__snapshots__/data-set-editor.test.snap.js
@@ -43,7 +43,7 @@ snapshots["Editor for DataSet element looks like the latest snapshot"] =
     graphic="icon"
     noninteractive=""
     tabindex="-1"
-    value="IED2>>CBSW>GooseDataSet1IED2>>CBSW> XSWI 1>dataSetIED2>>CBSW> XSWI 2>dataSet"
+    value="IED2>>CBSW>GooseDataSet1 IED2>>CBSW> XSWI 1>dataSet IED2>>CBSW> XSWI 2>dataSet"
   >
     <span>
       IED2

--- a/test/unit/editors/publisher/__snapshots__/data-set-editor.test.snap.js
+++ b/test/unit/editors/publisher/__snapshots__/data-set-editor.test.snap.js
@@ -9,6 +9,7 @@ snapshots["Editor for DataSet element looks like the latest snapshot"] =
     graphic="icon"
     noninteractive=""
     tabindex="-1"
+    value="IED1>>CircuitBreaker_CB1>GooseDataSet1"
   >
     <span>
       IED1
@@ -42,6 +43,7 @@ snapshots["Editor for DataSet element looks like the latest snapshot"] =
     graphic="icon"
     noninteractive=""
     tabindex="-1"
+    value="IED2>>CBSW>GooseDataSet1IED2>>CBSW> XSWI 1>dataSetIED2>>CBSW> XSWI 2>dataSet"
   >
     <span>
       IED2
@@ -103,6 +105,7 @@ snapshots["Editor for DataSet element looks like the latest snapshot"] =
     graphic="icon"
     noninteractive=""
     tabindex="-1"
+    value="IED3>>MU01>PhsMeas1"
   >
     <span>
       IED3

--- a/test/unit/editors/publisher/__snapshots__/gse-control-editor.test.snap.js
+++ b/test/unit/editors/publisher/__snapshots__/gse-control-editor.test.snap.js
@@ -9,6 +9,7 @@ snapshots["Editor for GSEControl element looks like the latest snapshot"] =
     graphic="icon"
     noninteractive=""
     tabindex="-1"
+    value="IED1>>CircuitBreaker_CB1>GCBIED1>>CircuitBreaker_CB1>GCB2"
   >
     <span>
       IED1
@@ -62,6 +63,7 @@ snapshots["Editor for GSEControl element looks like the latest snapshot"] =
     graphic="icon"
     noninteractive=""
     tabindex="-1"
+    value="IED2>>CBSW>GCB"
   >
     <span>
       IED2
@@ -98,6 +100,7 @@ snapshots["Editor for GSEControl element looks like the latest snapshot"] =
     graphic="icon"
     noninteractive=""
     tabindex="-1"
+    value=""
   >
     <span>
       IED3

--- a/test/unit/editors/publisher/__snapshots__/gse-control-editor.test.snap.js
+++ b/test/unit/editors/publisher/__snapshots__/gse-control-editor.test.snap.js
@@ -9,7 +9,7 @@ snapshots["Editor for GSEControl element looks like the latest snapshot"] =
     graphic="icon"
     noninteractive=""
     tabindex="-1"
-    value="IED1>>CircuitBreaker_CB1>GCBIED1>>CircuitBreaker_CB1>GCB2"
+    value="IED1>>CircuitBreaker_CB1>GCB IED1>>CircuitBreaker_CB1>GCB2"
   >
     <span>
       IED1

--- a/test/unit/editors/publisher/__snapshots__/report-control-editor.test.snap.js
+++ b/test/unit/editors/publisher/__snapshots__/report-control-editor.test.snap.js
@@ -9,6 +9,7 @@ snapshots["Editor for ReportControl element looks like the latest snapshot"] =
     graphic="icon"
     noninteractive=""
     tabindex="-1"
+    value=""
   >
     <span>
       IED1
@@ -28,6 +29,7 @@ snapshots["Editor for ReportControl element looks like the latest snapshot"] =
     graphic="icon"
     noninteractive=""
     tabindex="-1"
+    value="IED2>>CBSW> XSWI 1>ReportCbIED2>>CBSW> XSWI 2>ReportCb"
   >
     <span>
       IED2
@@ -81,6 +83,7 @@ snapshots["Editor for ReportControl element looks like the latest snapshot"] =
     graphic="icon"
     noninteractive=""
     tabindex="-1"
+    value=""
   >
     <span>
       IED3

--- a/test/unit/editors/publisher/__snapshots__/report-control-editor.test.snap.js
+++ b/test/unit/editors/publisher/__snapshots__/report-control-editor.test.snap.js
@@ -29,7 +29,7 @@ snapshots["Editor for ReportControl element looks like the latest snapshot"] =
     graphic="icon"
     noninteractive=""
     tabindex="-1"
-    value="IED2>>CBSW> XSWI 1>ReportCbIED2>>CBSW> XSWI 2>ReportCb"
+    value="IED2>>CBSW> XSWI 1>ReportCb IED2>>CBSW> XSWI 2>ReportCb"
   >
     <span>
       IED2

--- a/test/unit/editors/publisher/__snapshots__/sampled-value-control-editor.test.snap.js
+++ b/test/unit/editors/publisher/__snapshots__/sampled-value-control-editor.test.snap.js
@@ -9,6 +9,7 @@ snapshots["Editor for SampledValueControl element looks like the latest snapshot
     graphic="icon"
     noninteractive=""
     tabindex="-1"
+    value=""
   >
     <span>
       IED1
@@ -28,6 +29,7 @@ snapshots["Editor for SampledValueControl element looks like the latest snapshot
     graphic="icon"
     noninteractive=""
     tabindex="-1"
+    value=""
   >
     <span>
       IED2
@@ -47,6 +49,7 @@ snapshots["Editor for SampledValueControl element looks like the latest snapshot
     graphic="icon"
     noninteractive=""
     tabindex="-1"
+    value="IED3>>MU01>MSVCB01"
   >
     <span>
       IED3

--- a/test/unit/editors/subscription/goose/__snapshots__/goose-list.test.snap.js
+++ b/test/unit/editors/subscription/goose/__snapshots__/goose-list.test.snap.js
@@ -12,7 +12,7 @@ snapshots["goose-list looks like the latest snapshot with a document loaded"] =
       graphic="icon"
       noninteractive=""
       tabindex="-1"
-      value="IED1>>CircuitBreaker_CB1>GCBIED1>>CircuitBreaker_CB1>GCB2"
+      value="IED1>>CircuitBreaker_CB1>GCB IED1>>CircuitBreaker_CB1>GCB2"
     >
       <span>
         IED1

--- a/test/unit/editors/subscription/goose/__snapshots__/goose-list.test.snap.js
+++ b/test/unit/editors/subscription/goose/__snapshots__/goose-list.test.snap.js
@@ -12,6 +12,7 @@ snapshots["goose-list looks like the latest snapshot with a document loaded"] =
       graphic="icon"
       noninteractive=""
       tabindex="-1"
+      value="IED1>>CircuitBreaker_CB1>GCBIED1>>CircuitBreaker_CB1>GCB2"
     >
       <span>
         IED1
@@ -31,6 +32,7 @@ snapshots["goose-list looks like the latest snapshot with a document loaded"] =
       hasmeta=""
       mwc-list-item=""
       tabindex="0"
+      value="IED1>>CircuitBreaker_CB1>GCB"
     >
       <mwc-icon slot="graphic">
       </mwc-icon>
@@ -50,6 +52,7 @@ snapshots["goose-list looks like the latest snapshot with a document loaded"] =
       hasmeta=""
       mwc-list-item=""
       tabindex="-1"
+      value="IED1>>CircuitBreaker_CB1>GCB2"
     >
       <mwc-icon slot="graphic">
       </mwc-icon>
@@ -68,6 +71,7 @@ snapshots["goose-list looks like the latest snapshot with a document loaded"] =
       graphic="icon"
       noninteractive=""
       tabindex="-1"
+      value="IED2>>CBSW>GCB"
     >
       <span>
         IED2
@@ -87,6 +91,7 @@ snapshots["goose-list looks like the latest snapshot with a document loaded"] =
       hasmeta=""
       mwc-list-item=""
       tabindex="-1"
+      value="IED2>>CBSW>GCB"
     >
       <mwc-icon slot="graphic">
       </mwc-icon>
@@ -105,6 +110,7 @@ snapshots["goose-list looks like the latest snapshot with a document loaded"] =
       graphic="icon"
       noninteractive=""
       tabindex="-1"
+      value=""
     >
       <span>
         IED3

--- a/test/unit/editors/subscription/sampledvalues/__snapshots__/smv-list.test.snap.js
+++ b/test/unit/editors/subscription/sampledvalues/__snapshots__/smv-list.test.snap.js
@@ -12,6 +12,7 @@ snapshots["smv-list looks like the latest snapshot with a document loaded"] =
       graphic="icon"
       noninteractive=""
       tabindex="-1"
+      value=""
     >
       <span>
         IED1
@@ -30,6 +31,7 @@ snapshots["smv-list looks like the latest snapshot with a document loaded"] =
       graphic="icon"
       noninteractive=""
       tabindex="-1"
+      value=""
     >
       <span>
         IED2
@@ -48,6 +50,7 @@ snapshots["smv-list looks like the latest snapshot with a document loaded"] =
       graphic="icon"
       noninteractive=""
       tabindex="-1"
+      value="IED3>>MU01>MSVCB01"
     >
       <span>
         IED3
@@ -67,6 +70,7 @@ snapshots["smv-list looks like the latest snapshot with a document loaded"] =
       hasmeta=""
       mwc-list-item=""
       tabindex="0"
+      value="IED3>>MU01>MSVCB01"
     >
       <mwc-icon slot="graphic">
       </mwc-icon>

--- a/test/unit/filtered-list.test.ts
+++ b/test/unit/filtered-list.test.ts
@@ -31,7 +31,7 @@ describe('filtered-list', () => {
           ><div>
             <mwc-radio-list-item><span>nestedItem6</span></mwc-radio-list-item>
           </div></abbr
-        ><mwc-list-item noninteractive><span>item7</span></mwc-list-item>
+        ><mwc-list-item value="valueItem7"></mwc-list-item>
       </filtered-list>`
     );
   });
@@ -149,7 +149,7 @@ describe('filtered-list', () => {
       expect(element.children[3].classList.contains('hidden')).to.be.true;
       expect(element.children[4].classList.contains('hidden')).to.be.true;
       expect(element.children[5].classList.contains('hidden')).to.be.true;
-      expect(element.children[6].classList.contains('hidden')).to.be.false;
+      expect(element.children[6].classList.contains('hidden')).to.be.true;
     });
 
     it('uses space as logic AND ', async () => {
@@ -163,7 +163,7 @@ describe('filtered-list', () => {
       expect(element.children[3].classList.contains('hidden')).to.be.true;
       expect(element.children[4].classList.contains('hidden')).to.be.true;
       expect(element.children[5].classList.contains('hidden')).to.be.true;
-      expect(element.children[6].classList.contains('hidden')).to.be.false;
+      expect(element.children[6].classList.contains('hidden')).to.be.true;
     });
 
     it('nested mwc-list-item elements', async () => {
@@ -177,7 +177,7 @@ describe('filtered-list', () => {
       expect(element.children[3].classList.contains('hidden')).to.be.true;
       expect(element.children[4].classList.contains('hidden')).to.be.false;
       expect(element.children[5].classList.contains('hidden')).to.be.true;
-      expect(element.children[6].classList.contains('hidden')).to.be.false;
+      expect(element.children[6].classList.contains('hidden')).to.be.true;
     });
 
     it('nested mwc-radio-list-item elements', async () => {
@@ -191,10 +191,10 @@ describe('filtered-list', () => {
       expect(element.children[3].classList.contains('hidden')).to.be.true;
       expect(element.children[4].classList.contains('hidden')).to.be.true;
       expect(element.children[5].classList.contains('hidden')).to.be.false;
-      expect(element.children[6].classList.contains('hidden')).to.be.false;
+      expect(element.children[6].classList.contains('hidden')).to.be.true;
     });
 
-    it('onyl on noninteractive list itmes', async () => {
+    it('items value attribute', async () => {
       element.searchField.value = 'item7';
       element.onFilterInput();
       element.requestUpdate();


### PR DESCRIPTION
After two prototypes and some discussion, I decided to change the filter behavior of filtered-list. What has changed is that not only the list item's primary and secondary span is taken into account, but also its value attribute. This has in my opinion the advantage to be simple in design and very flexible for the user to use. As value is not visible, everybody can decide himself what the value can be and therefor also what the user can filter for. 

Best to test is the publisher plugin or both the subscriber plugins :)