### PR TITLE
fix(editing): failing auto-validation after editor actions

### DIFF
--- a/src/Editing.ts
+++ b/src/Editing.ts
@@ -1,4 +1,4 @@
-import { LitElement, property } from 'lit-element';
+import { property } from 'lit-element';
 import { get } from 'lit-translate';
 
 import {
@@ -421,8 +421,6 @@ export function Editing<TBase extends LitElementConstructor>(Base: TBase) {
         );
       }
 
-      this.dispatchEvent(newValidateEvent());
-
       if (!this.doc) return;
 
       const newDoc = document.implementation.createDocument(
@@ -434,6 +432,8 @@ export function Editing<TBase extends LitElementConstructor>(Base: TBase) {
       // change the document object reference to enable reactive updates
       newDoc.documentElement.replaceWith(this.doc.documentElement);
       this.doc = newDoc;
+
+      this.dispatchEvent(newValidateEvent());
     }
 
     private async onOpenDoc(event: OpenDocEvent) {


### PR DESCRIPTION
This fixes a recently introduced bug in `Editing` where after committing an editor action the auto validation fails because the doc is empty at the point where the validation starts.

Resolves #880 .