### PR TITLE
docs: include reference to TypeDoc documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ npm start
 
 This will start a local development server and open a browser window which will automatically be reloaded as soon as you save any changes to your local source code files.
 
+### TypeDoc
+This project uses [TypeDoc](https://typedoc.org/) to transform documentation comments in the source code into a rendered HTML document that can be queried and navigated through. If you want to consult the generated documentation for the TypeScript components, mixins, modules and other relevant artifacts of this project, you can [do it here](https://openscd.github.io/doc/).
+
 ### Linting & Formatting
 
 If you use VSCode to develop, we recommend you install and use the [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) and [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) extensions in order to automatically lint and format your code as you edit it. There are similar plugins available for using [ESLint](https://eslint.org/) and [Prettier](https://prettier.io/) from within other IDEs and text editors.


### PR DESCRIPTION
As discussed during the Praatje CoMPAS today. Here's an update to the README.md with a link to the TypeDoc documentation under the Contributing section.

Please let me know your thoughts regarding the text I suggest here.
