### PR TITLE
fix(mergeWizard): insert element at valid position

### DIFF
--- a/src/wizards.ts
+++ b/src/wizards.ts
@@ -73,7 +73,7 @@ function mergeWizardAction(
       for (const diff of selectedChildDiffs)
         if (!diff.ours)
           actions.push({
-            new: { parent, element: diff.theirs, reference: null },
+            new: { parent, element: diff.theirs },
           });
         else if (!diff.theirs)
           actions.push({


### PR DESCRIPTION
The merge wizard was implemented before our "choose a valid position
automatically" feature was implemented for insert and move actions in
Editing (`reference: undefined`).

Therefore, all insert actions fired by the merge wizard insert the
element at as the parent's last child, resulting in schema invalid files
in many cases (e.g. insert a Substation section in a file with an IED or
DataTypeTemplates). This fixes that issue, making our Merge and
UpdateSubstation plugins schema compliant.