### PR TITLE
fix(editing): don't validate after no-op action

### DIFF
--- a/src/Editing.ts
+++ b/src/Editing.ts
@@ -419,7 +419,7 @@ export function Editing<TBase extends LitElementConstructor>(Base: TBase) {
             action: event.detail.action,
           })
         );
-      }
+      } else return;
 
       if (!this.doc) return;
 


### PR DESCRIPTION
After committing an empty complex action (e.g. clicking "merge" in a
merge wizard without any additions or deletions selected) the `Editing`
mixin needlessly dispatches a ValidateEvent causing lengthy validation
of an already validated document. This fixes that issue.