### PR TITLE
fix(validate-schema): cache validator workers

### DIFF
--- a/src/validators/ValidateSchema.ts
+++ b/src/validators/ValidateSchema.ts
@@ -44,6 +44,8 @@ export default class ValidateSchema extends LitElement {
       });
     }
 
+    validators[xsdName] = validate;
+
     return new Promise((resolve, reject) => {
       worker.addEventListener('message', (e: MessageEvent<WorkerMessage>) => {
         if (isLoadSchemaResult(e.data)) {

--- a/src/validators/ValidateSchema.ts
+++ b/src/validators/ValidateSchema.ts
@@ -110,7 +110,7 @@ export default class ValidateSchema extends LitElement {
           title: get('validator.schema.invalid', { name: result.file }),
         })
       );
-      throw new Error(get('validator.schema.invalid', { name: result.file }));
+      return;
     }
 
     this.dispatchEvent(

--- a/test/integration/validators/ValidateSchema.test.ts
+++ b/test/integration/validators/ValidateSchema.test.ts
@@ -6,27 +6,6 @@ import { MockEditorLogger } from '../../mock-editor-logger.js';
 import ValidateSchema from '../../../src/validators/ValidateSchema.js';
 import { IssueDetail, LogEntry } from '../../../src/foundation.js';
 
-import { officialPlugins } from '../../../public/js/plugins.js';
-
-const plugins = officialPlugins
-  .map(plugin => ({
-    ...plugin,
-    default: false,
-    installed: false,
-    official: true,
-  }))
-  .concat([
-    {
-      name: 'Substation',
-      src: '/src/editors/Substation.ts',
-      icon: 'margin',
-      default: true,
-      kind: 'editor',
-      installed: true,
-      official: false,
-    },
-  ]);
-
 describe('ValidateSchema plugin', () => {
   if (customElements.get('') === undefined)
     customElements.define('validate-schema', ValidateSchema);
@@ -37,89 +16,85 @@ describe('ValidateSchema plugin', () => {
   let valid2007B4: XMLDocument;
   let invalid2007B: XMLDocument;
 
+  before(async () => {
+    parent = await fixture(html`
+      <mock-editor-logger
+        ><validate-schema></validate-schema
+      ></mock-editor-logger>
+    `);
+
+    element = <ValidateSchema>parent.querySelector('validate-schema')!;
+    element.pluginId = '/src/validators/ValidateSchema.js';
+    await element.updateComplete;
+  });
+
   describe('for valid SCL files', () => {
-    beforeEach(async () => {
+    before(async () => {
       valid2007B4 = await fetch('/test/testfiles/valid2007B.scd')
         .then(response => response.text())
         .then(str => new DOMParser().parseFromString(str, 'application/xml'));
 
-      localStorage.setItem('plugins', JSON.stringify(plugins));
-
-      parent = await fixture(html`
-        <mock-editor-logger
-          ><validate-schema
-            .doc=${valid2007B4}
-            .docName=${'valid2007B4'}
-          ></validate-schema
-        ></mock-editor-logger>
-      `);
-      element = <ValidateSchema>parent.querySelector('validate-schema')!;
-      element.pluginId = '/src/validators/ValidateSchema.js';
-      await element.requestUpdate();
+      element.doc = valid2007B4;
+      element.docName = 'valid2007B';
     });
 
-    it('zeroissues indication looks like the latest snapshot', async () => {
-      await parent.requestUpdate();
-      await expect(parent.diagnosticUI).to.equalSnapshot();
+    beforeEach(async () => {
+      parent.diagnoses.clear();
+      await parent.updateComplete;
+
+      await element.validate();
+      await parent.updateComplete;
     });
+
+    it('zeroissues indication looks like the latest snapshot', async () =>
+      await expect(parent.diagnosticUI).to.equalSnapshot());
 
     it('indicates successful schema validation in the diagnoses pane', async () => {
-      await element.validate();
-
       const lastEntry = <IssueDetail[]>(
         parent.diagnoses.get('/src/validators/ValidateSchema.js')
       );
       expect(lastEntry.length).to.equal(1);
       expect(lastEntry[0].title).to.contain('[validator.schema.valid]');
-    }).timeout(15000);
+    });
 
     it('indicates successful schema validation in the log', async () => {
-      await element.validate();
       const lastEntry = <LogEntry>parent.history.pop();
       expect(lastEntry.kind).to.equal('info');
       expect(lastEntry.title).to.contain('[validator.schema.valid]');
-    }).timeout(15000);
+    });
   });
 
   describe('for invalid SCL files', () => {
-    beforeEach(async () => {
+    before(async () => {
       invalid2007B = await fetch('/test/testfiles/invalid2007B.scd')
         .then(response => response.text())
         .then(str => new DOMParser().parseFromString(str, 'application/xml'));
 
-      parent = await fixture(html`
-        <mock-editor-logger
-          ><validate-schema
-            .doc=${invalid2007B}
-            .docName=${'invalid2007B'}
-          ></validate-schema
-        ></mock-editor-logger>
-      `);
+      element.doc = invalid2007B;
+      element.docName = 'invalid2007B';
 
-      element = <ValidateSchema>parent.querySelector('validate-schema')!;
-      element.pluginId = '/src/validators/ValidateSchema.js';
       await element.requestUpdate();
-
-      try {
-        await element.validate();
-      } catch (e) {
-        e;
-      }
     });
-    it('create issues in diagnose', async () => {
-      const issues = parent.diagnoses.get('/src/validators/ValidateSchema.js');
-      expect(issues).to.not.be.undefined;
-    }).timeout(15000);
 
-    it('pushes issues to the diagnostics pane that look like the latest snapshot', async () => {
-      await parent.requestUpdate();
-      await expect(parent.diagnosticUI).to.equalSnapshot();
+    beforeEach(async () => {
+      parent.diagnoses.clear();
+      await parent.updateComplete;
+
+      await element.validate();
+      await parent.updateComplete;
     });
+
+    it('pushes issues to the diagnostics pane that look like the latest snapshot', async () =>
+      await expect(parent.diagnosticUI).to.equalSnapshot());
+
+    it('create issues in diagnose', async () =>
+      expect(parent.diagnoses.get('/src/validators/ValidateSchema.js')).to.not
+        .be.undefined);
 
     it('generates error messages in the log', async () => {
-      const lastEntry = <LogEntry>parent.history.pop();
-      expect(lastEntry.kind).to.equal('warning');
-      expect(lastEntry.title).to.contain('[validator.schema.invalid]');
-    }).timeout(5000);
+      const lastLogEntry = <LogEntry>parent.history.pop();
+      expect(lastLogEntry.kind).to.equal('warning');
+      expect(lastLogEntry.title).to.contain('[validator.schema.invalid]');
+    });
   });
 });

--- a/test/integration/validators/__snapshots__/ValidateSchema.test.snap.js
+++ b/test/integration/validators/__snapshots__/ValidateSchema.test.snap.js
@@ -11,19 +11,32 @@ snapshots["ValidateSchema plugin for valid SCL files zeroissues indication looks
     wrapfocus=""
   >
     <mwc-list-item
-      aria-disabled="true"
-      disabled=""
-      graphic="icon"
-      mwc-list-item=""
-      tabindex="0"
+      aria-disabled="false"
+      noninteractive=""
+      tabindex="-1"
     >
-      <span>
-        [diag.placeholder]
-      </span>
-      <mwc-icon slot="graphic">
-        info
-      </mwc-icon>
+      Validate Schema
     </mwc-list-item>
+    <li
+      divider=""
+      padded=""
+      role="separator"
+    >
+    </li>
+    <abbr title="[validator.schema.valid]
+undefined">
+      <mwc-list-item
+        aria-disabled="false"
+        mwc-list-item=""
+        tabindex="-1"
+      >
+        <span>
+          [validator.schema.valid]
+        </span>
+        <span slot="secondary">
+        </span>
+      </mwc-list-item>
+    </abbr>
   </filtered-list>
   <mwc-button
     dialogaction="close"
@@ -75,12 +88,7 @@ invalid2007B:7 Substation name (Element '{http://www.iec.ch/61850/2003/SCL}Subst
     </abbr>
     <abbr title="Not all fields of key identity-constraint '{http://www.iec.ch/61850/2003/SCL}SubstationKey' evaluate to a node.
 invalid2007B:7 Substation key identity-constraint '{http://www.iec.ch/61850/2003/SCL}SubstationKey' (Element '{http://www.iec.ch/61850/2003/SCL}Substation')">
-      <mwc-list-item
-        aria-disabled="false"
-        mwc-list-item=""
-        tabindex="-1"
-        twoline=""
-      >
+      <mwc-list-item twoline="">
         <span>
           Not all fields of key identity-constraint '{http://www.iec.ch/61850/2003/SCL}SubstationKey' evaluate to a node.
         </span>


### PR DESCRIPTION
Due to a simple oversight we are currently not actually caching schema validator workers at all, meaning we instantiate a new worker on each validation, leaking memory and wasting time. This fixes that issue.

This pull request should result in a noticeable performance increase for repeat validations and in less memory usage.