### PR TITLE
feat(editors/publisher): add read only data set element editor

### DIFF
--- a/src/editors/Publisher.ts
+++ b/src/editors/Publisher.ts
@@ -85,7 +85,7 @@ export default class PublisherPlugin extends LitElement {
     }
 
     .publishertypeselector {
-      margin: 4px 8px 16px;
+      margin: 4px 8px 8px;
       background-color: var(--mdc-theme-surface);
       width: calc(100% - 16px);
       justify-content: space-around;

--- a/src/editors/publisher/data-set-element-editor.ts
+++ b/src/editors/publisher/data-set-element-editor.ts
@@ -33,7 +33,10 @@ export class DataSetElementEditor extends LitElement {
   render(): TemplateResult {
     if (this.element)
       return html`<div class="content">
-        <h2>${identity(this.element)}</h2>
+        <h2>
+          <div>DataSet</div>
+          <div class="headersubtitle">${identity(this.element)}</div>
+        </h2>
         <wizard-textfield
           label="name"
           .maybeValue=${this.name}
@@ -49,12 +52,26 @@ export class DataSetElementEditor extends LitElement {
         >
         </wizard-textfield>
         <filtered-list
-          >${Array.from(this.element.querySelectorAll('FCDA')).map(
-            fcda =>
-              html`<mwc-list-item selected value="${identity(fcda)}"
-                >${(<string>identity(fcda)).split('>').pop()}</mwc-list-item
-              >`
-          )}</filtered-list
+          >${Array.from(this.element.querySelectorAll('FCDA')).map(fcda => {
+            const [ldInst, prefix, lnClass, lnInst, doName, daName] = [
+              'ldInst',
+              'prefix',
+              'lnClass',
+              'lnInst',
+              'doName',
+              'daName',
+            ].map(attributeName => fcda.getAttribute(attributeName) ?? '');
+
+            return html`<mwc-list-item
+              selected
+              twoline
+              value="${identity(fcda)}"
+              ><span>${doName + '.' + daName}</span
+              ><span slot="secondary"
+                >${ldInst + '/' + prefix + lnClass + lnInst}</span
+              >
+            </mwc-list-item>`;
+          })}</filtered-list
         >
       </div>`;
 
@@ -79,13 +96,18 @@ export class DataSetElementEditor extends LitElement {
       color: var(--mdc-theme-on-surface);
       font-family: 'Roboto', sans-serif;
       font-weight: 300;
+
+      margin: 0px;
+      padding-left: 0.3em;
+      transition: background-color 150ms linear;
+    }
+
+    .headersubtitle {
+      font-size: 16px;
+      font-weight: 200;
       overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;
-      margin: 0px;
-      line-height: 48px;
-      padding-left: 0.3em;
-      transition: background-color 150ms linear;
     }
 
     *[iconTrailing='search'] {

--- a/src/editors/publisher/data-set-element-editor.ts
+++ b/src/editors/publisher/data-set-element-editor.ts
@@ -1,0 +1,95 @@
+import {
+  css,
+  customElement,
+  html,
+  LitElement,
+  property,
+  state,
+  TemplateResult,
+} from 'lit-element';
+import { translate } from 'lit-translate';
+
+import '@material/mwc-list/mwc-list-item';
+
+import '../../wizard-textfield.js';
+import '../../filtered-list.js';
+
+import { identity } from '../../foundation.js';
+
+@customElement('data-set-element-editor')
+export class DataSetElementEditor extends LitElement {
+  @property({ attribute: false })
+  element!: Element | null;
+
+  @state()
+  private get name(): string | null {
+    return this.element ? this.element.getAttribute('name') : 'UNDEFINED';
+  }
+  @state()
+  private get desc(): string | null {
+    return this.element ? this.element.getAttribute('desc') : 'UNDEFINED';
+  }
+
+  render(): TemplateResult {
+    if (this.element)
+      return html`<div class="content">
+        <h2>${identity(this.element)}</h2>
+        <wizard-textfield
+          label="name"
+          .maybeValue=${this.name}
+          helper="${translate('scl.name')}"
+          required
+        >
+        </wizard-textfield>
+        <wizard-textfield
+          label="desc"
+          .maybeValue=${this.desc}
+          helper="${translate('scl.desc')}"
+          nullable
+        >
+        </wizard-textfield>
+        <filtered-list
+          >${Array.from(this.element.querySelectorAll('FCDA')).map(
+            fcda =>
+              html`<mwc-list-item selected value="${identity(fcda)}"
+                >${(<string>identity(fcda)).split('>').pop()}</mwc-list-item
+              >`
+          )}</filtered-list
+        >
+      </div>`;
+
+    return html`<div class="content">
+      <h2>${translate('publisher.nodataset')}</h2>
+    </div>`;
+  }
+
+  static styles = css`
+    .content {
+      display: flex;
+      flex-direction: column;
+      background-color: var(--mdc-theme-surface);
+    }
+
+    .content > * {
+      display: block;
+      margin: 4px 8px 16px;
+    }
+
+    h2 {
+      color: var(--mdc-theme-on-surface);
+      font-family: 'Roboto', sans-serif;
+      font-weight: 300;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      margin: 0px;
+      line-height: 48px;
+      padding-left: 0.3em;
+      transition: background-color 150ms linear;
+    }
+
+    *[iconTrailing='search'] {
+      --mdc-shape-small: 28px;
+    }
+  `;
+}

--- a/src/editors/publisher/foundation.ts
+++ b/src/editors/publisher/foundation.ts
@@ -1,0 +1,70 @@
+import { css } from 'lit-element';
+
+export const styles = css`
+  .content {
+    display: flex;
+    height: calc(100vh - 184px);
+  }
+
+  .selectionlist {
+    flex: 35%;
+    margin: 4px 4px 4px 8px;
+    background-color: var(--mdc-theme-surface);
+    overflow-y: scroll;
+  }
+
+  .elementeditorcontainer {
+    flex: 65%;
+    margin: 4px 8px 4px 4px;
+    background-color: var(--mdc-theme-surface);
+    overflow-y: scroll;
+    display: flex;
+  }
+
+  data-set-element-editor {
+    width: calc(100% - 6px);
+  }
+
+  .listitem.header {
+    font-weight: 500;
+  }
+
+  mwc-list-item.hidden[noninteractive] + li[divider] {
+    display: none;
+  }
+
+  mwc-button {
+    display: none;
+  }
+
+  @media (max-width: 599px) {
+    .content {
+      height: 100%;
+    }
+
+    .selectionlist {
+      position: absolute;
+      width: calc(100% - 32px);
+      height: auto;
+      top: 110px;
+      left: 8px;
+      background-color: var(--mdc-theme-surface);
+      z-index: 1;
+      box-shadow: 0 8px 10px 1px rgba(0, 0, 0, 0.14),
+        0 3px 14px 2px rgba(0, 0, 0, 0.12), 0 5px 5px -3px rgba(0, 0, 0, 0.2);
+    }
+
+    data-set-element-editor {
+      width: calc(100% - 16px);
+    }
+
+    .selectionlist.hidden {
+      display: none;
+    }
+
+    mwc-button {
+      display: flex;
+      margin: 4px 8px 8px;
+    }
+  }
+`;

--- a/src/editors/publisher/gse-control-editor.ts
+++ b/src/editors/publisher/gse-control-editor.ts
@@ -3,25 +3,66 @@ import {
   customElement,
   html,
   LitElement,
-  property,
+  property as state,
+  query,
   TemplateResult,
 } from 'lit-element';
+import { translate } from 'lit-translate';
 
+import '@material/mwc-button';
 import '@material/mwc-list/mwc-list-item';
-import '@material/mwc-icon';
+import { Button } from '@material/mwc-button';
+import { ListItem } from '@material/mwc-list/mwc-list-item';
 
+import './data-set-element-editor.js';
 import '../../filtered-list.js';
-import { compareNames, identity } from '../../foundation.js';
+import { FilteredList } from '../../filtered-list.js';
+
 import { gooseIcon } from '../../icons/icons.js';
+import { compareNames, identity, selector } from '../../foundation.js';
+import { styles } from './foundation.js';
 
 @customElement('gse-control-editor')
 export class GseControlEditor extends LitElement {
   /** The document being edited as provided to plugins by [[`OpenSCD`]]. */
-  @property({ attribute: false })
+  @state({ attribute: false })
   doc!: XMLDocument;
 
-  renderList(): TemplateResult {
+  @state()
+  selectedGseControl?: Element | null;
+
+  @query('.selectionlist') selectionList!: FilteredList;
+  @query('mwc-button') selectGSEControlButton!: Button;
+
+  private selectGSEControl(evt: Event): void {
+    const id = ((evt.target as FilteredList).selected as ListItem).value;
+    const gseControl = this.doc.querySelector(selector('GSEControl', id));
+
+    if (gseControl) {
+      this.selectedGseControl = gseControl.parentElement?.querySelector(
+        `DataSet[name="${gseControl.getAttribute('datSet')}"]`
+      );
+      (evt.target as FilteredList).classList.add('hidden');
+      this.selectGSEControlButton.classList.remove('hidden');
+    }
+  }
+
+  private renderElementEditorContainer(): TemplateResult {
+    if (this.selectedGseControl !== undefined)
+      return html`<div class="elementeditorcontainer">
+        <data-set-element-editor
+          .element=${this.selectedGseControl}
+        ></data-set-element-editor>
+      </div>`;
+
+    return html``;
+  }
+
+  renderSelectionList(): TemplateResult {
     return html`<filtered-list
+      activatable
+      @action=${this.selectGSEControl}
+      class="selectionlist"
       >${Array.from(this.doc.querySelectorAll('IED'))
         .sort(compareNames)
         .flatMap(ied => {
@@ -60,22 +101,25 @@ export class GseControlEditor extends LitElement {
     >`;
   }
 
+  private renderToggleButton(): TemplateResult {
+    return html`<mwc-button
+      outlined
+      label="${translate('publisher.selectbutton', { type: 'GOOSE' })}"
+      @click=${() => {
+        this.selectionList.classList.remove('hidden');
+        this.selectGSEControlButton.classList.add('hidden');
+      }}
+    ></mwc-button>`;
+  }
+
   render(): TemplateResult {
-    return html`${this.renderList()}`;
+    return html`${this.renderToggleButton()}
+      <div class="content">
+        ${this.renderSelectionList()}${this.renderElementEditorContainer()}
+      </div>`;
   }
 
   static styles = css`
-    filtered-list {
-      margin: 4px 8px 16px;
-      background-color: var(--mdc-theme-surface);
-    }
-
-    .listitem.header {
-      font-weight: 500;
-    }
-
-    mwc-list-item.hidden[noninteractive] + li[divider] {
-      display: none;
-    }
+    ${styles}
   `;
 }

--- a/src/editors/publisher/report-control-editor.ts
+++ b/src/editors/publisher/report-control-editor.ts
@@ -4,15 +4,24 @@ import {
   html,
   LitElement,
   property,
+  query,
+  state,
   TemplateResult,
 } from 'lit-element';
+import { translate } from 'lit-translate';
 
+import '@material/mwc-button';
 import '@material/mwc-list/mwc-list-item';
-import '@material/mwc-icon';
+import { Button } from '@material/mwc-button';
+import { ListItem } from '@material/mwc-list/mwc-list-item';
 
+import './data-set-element-editor.js';
 import '../../filtered-list.js';
-import { compareNames, identity } from '../../foundation.js';
+import { FilteredList } from '../../filtered-list.js';
+
+import { compareNames, identity, selector } from '../../foundation.js';
 import { reportIcon } from '../../icons/icons.js';
+import { styles } from './foundation.js';
 
 @customElement('report-control-editor')
 export class ReportControlEditor extends LitElement {
@@ -20,8 +29,41 @@ export class ReportControlEditor extends LitElement {
   @property({ attribute: false })
   doc!: XMLDocument;
 
-  renderList(): TemplateResult {
+  @state()
+  selectedReportControl?: Element | null;
+
+  @query('.selectionlist') selectionList!: FilteredList;
+  @query('mwc-button') selectReportControlButton!: Button;
+
+  private selectReportControl(evt: Event): void {
+    const id = ((evt.target as FilteredList).selected as ListItem).value;
+    const reportControl = this.doc.querySelector(selector('ReportControl', id));
+
+    if (reportControl) {
+      this.selectedReportControl = reportControl.parentElement?.querySelector(
+        `DataSet[name="${reportControl.getAttribute('datSet')}"]`
+      );
+      (evt.target as FilteredList).classList.add('hidden');
+      this.selectReportControlButton.classList.remove('hidden');
+    }
+  }
+
+  private renderElementEditorContainer(): TemplateResult {
+    if (this.selectedReportControl !== undefined)
+      return html`<div class="elementeditorcontainer">
+        <data-set-element-editor
+          .element=${this.selectedReportControl}
+        ></data-set-element-editor>
+      </div>`;
+
+    return html``;
+  }
+
+  private renderSelectionList(): TemplateResult {
     return html`<filtered-list
+      activatable
+      class="selectionlist"
+      @action=${this.selectReportControl}
       >${Array.from(this.doc.querySelectorAll('IED'))
         .sort(compareNames)
         .flatMap(ied => {
@@ -58,22 +100,25 @@ export class ReportControlEditor extends LitElement {
     >`;
   }
 
+  private renderToggleButton(): TemplateResult {
+    return html`<mwc-button
+      outlined
+      label="${translate('publisher.selectbutton', { type: 'Report' })}"
+      @click=${() => {
+        this.selectionList.classList.remove('hidden');
+        this.selectReportControlButton.classList.add('hidden');
+      }}
+    ></mwc-button>`;
+  }
+
   render(): TemplateResult {
-    return html`${this.renderList()}`;
+    return html`${this.renderToggleButton()}
+      <div class="content">
+        ${this.renderSelectionList()}${this.renderElementEditorContainer()}
+      </div>`;
   }
 
   static styles = css`
-    filtered-list {
-      margin: 4px 8px 16px;
-      background-color: var(--mdc-theme-surface);
-    }
-
-    .listitem.header {
-      font-weight: 500;
-    }
-
-    mwc-list-item.hidden[noninteractive] + li[divider] {
-      display: none;
-    }
+    ${styles}
   `;
 }

--- a/src/editors/publisher/sampled-value-control-editor.ts
+++ b/src/editors/publisher/sampled-value-control-editor.ts
@@ -4,15 +4,24 @@ import {
   html,
   LitElement,
   property,
+  query,
+  state,
   TemplateResult,
 } from 'lit-element';
+import { translate } from 'lit-translate';
 
+import '@material/mwc-button';
 import '@material/mwc-list/mwc-list-item';
-import '@material/mwc-icon';
+import { Button } from '@material/mwc-button';
+import { ListItem } from '@material/mwc-list/mwc-list-item';
 
+import './data-set-element-editor.js';
 import '../../filtered-list.js';
-import { compareNames, identity } from '../../foundation.js';
+import { FilteredList } from '../../filtered-list.js';
+
+import { compareNames, identity, selector } from '../../foundation.js';
 import { smvIcon } from '../../icons/icons.js';
+import { styles } from './foundation.js';
 
 @customElement('sampled-value-control-editor')
 export class SampledValueControlEditor extends LitElement {
@@ -20,8 +29,44 @@ export class SampledValueControlEditor extends LitElement {
   @property({ attribute: false })
   doc!: XMLDocument;
 
-  renderList(): TemplateResult {
+  @state()
+  selectedSampledValueControl?: Element | null;
+
+  @query('.selectionlist') selectionList!: FilteredList;
+  @query('mwc-button') selectSampledValueControlButton!: Button;
+
+  private selectSMVControl(evt: Event): void {
+    const id = ((evt.target as FilteredList).selected as ListItem).value;
+    const smvControl = this.doc.querySelector(
+      selector('SampledValueControl', id)
+    );
+
+    if (smvControl) {
+      this.selectedSampledValueControl =
+        smvControl.parentElement?.querySelector(
+          `DataSet[name="${smvControl.getAttribute('datSet')}"]`
+        );
+      (evt.target as FilteredList).classList.add('hidden');
+      this.selectSampledValueControlButton.classList.remove('hidden');
+    }
+  }
+
+  private renderElementEditorContainer(): TemplateResult {
+    if (this.selectedSampledValueControl !== undefined)
+      return html`<div class="elementeditorcontainer">
+        <data-set-element-editor
+          .element=${this.selectedSampledValueControl}
+        ></data-set-element-editor>
+      </div>`;
+
+    return html``;
+  }
+
+  private renderSelectionList(): TemplateResult {
     return html`<filtered-list
+      activatable
+      @action=${this.selectSMVControl}
+      class="selectionlist"
       >${Array.from(this.doc.querySelectorAll('IED'))
         .sort(compareNames)
         .flatMap(ied => {
@@ -60,22 +105,25 @@ export class SampledValueControlEditor extends LitElement {
     >`;
   }
 
+  private renderToggleButton(): TemplateResult {
+    return html`<mwc-button
+      outlined
+      label="${translate('publisher.selectbutton', { type: 'SMV' })}"
+      @click=${() => {
+        this.selectionList.classList.remove('hidden');
+        this.selectSampledValueControlButton.classList.add('hidden');
+      }}
+    ></mwc-button>`;
+  }
+
   render(): TemplateResult {
-    return html`${this.renderList()}`;
+    return html`${this.renderToggleButton()}
+      <div class="content">
+        ${this.renderSelectionList()}${this.renderElementEditorContainer()}
+      </div>`;
   }
 
   static styles = css`
-    filtered-list {
-      margin: 4px 8px 16px;
-      background-color: var(--mdc-theme-surface);
-    }
-
-    .listitem.header {
-      font-weight: 500;
-    }
-
-    mwc-list-item.hidden[noninteractive] + li[divider] {
-      display: none;
-    }
+    ${styles}
   `;
 }

--- a/src/translations/de.ts
+++ b/src/translations/de.ts
@@ -740,6 +740,10 @@ export const de: Translations = {
       location: 'Ablageort des Select Sampled Value Control Block wählen',
     },
   },
+  publisher: {
+    selectbutton: '{{type}} auswählen',
+    nodataset: 'Kein verbundener Datensatz',
+  },
   add: 'Hinzufügen',
   new: 'Neu',
   remove: 'Entfernen',

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -734,6 +734,10 @@ export const en = {
   samvpledvaluecontrol: {
     wizard: { location: 'Select Sampled Value Control Block Location' },
   },
+  publisher: {
+    selectbutton: 'Select other {{type}}',
+    nodataset: 'No DataSet referenced',
+  },
   add: 'Add',
   new: 'New',
   remove: 'Remove',

--- a/test/unit/editors/publisher/__snapshots__/data-set-editor.test.snap.js
+++ b/test/unit/editors/publisher/__snapshots__/data-set-editor.test.snap.js
@@ -1,7 +1,7 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["Editor for DataSet element initialy looks like the latest snapshot"] = 
+snapshots["Editor for DataSet element initially looks like the latest snapshot"] = 
 `<mwc-button
   label="[publisher.selectbutton]"
   outlined=""
@@ -145,7 +145,7 @@ snapshots["Editor for DataSet element initialy looks like the latest snapshot"] 
   </filtered-list>
 </div>
 `;
-/* end snapshot Editor for DataSet element initialy looks like the latest snapshot */
+/* end snapshot Editor for DataSet element initially looks like the latest snapshot */
 
 snapshots["Editor for DataSet element with a selected DataSet looks like the latest snapshot"] = 
 `<mwc-button

--- a/test/unit/editors/publisher/__snapshots__/data-set-editor.test.snap.js
+++ b/test/unit/editors/publisher/__snapshots__/data-set-editor.test.snap.js
@@ -1,139 +1,302 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["Editor for DataSet element looks like the latest snapshot"] = 
-`<filtered-list>
-  <mwc-list-item
-    aria-disabled="false"
-    class="header listitem"
-    graphic="icon"
-    noninteractive=""
-    tabindex="-1"
-    value="IED1>>CircuitBreaker_CB1>GooseDataSet1"
+snapshots["Editor for DataSet element initialy looks like the latest snapshot"] = 
+`<mwc-button
+  label="[publisher.selectbutton]"
+  outlined=""
+>
+</mwc-button>
+<div class="content">
+  <filtered-list
+    activatable=""
+    class="selectionlist"
   >
-    <span>
-      IED1
-    </span>
-    <mwc-icon slot="graphic">
-      developer_board
-    </mwc-icon>
-  </mwc-list-item>
-  <li
-    divider=""
-    role="separator"
-  >
-  </li>
-  <mwc-list-item
-    aria-disabled="false"
-    mwc-list-item=""
-    tabindex="-1"
-    twoline=""
-    value="IED1>>CircuitBreaker_CB1>GooseDataSet1"
-  >
-    <span>
-      GooseDataSet1
-    </span>
-    <span slot="secondary">
-      IED1>>CircuitBreaker_CB1>GooseDataSet1
-    </span>
-  </mwc-list-item>
-  <mwc-list-item
-    aria-disabled="false"
-    class="header listitem"
-    graphic="icon"
-    noninteractive=""
-    tabindex="-1"
-    value="IED2>>CBSW>GooseDataSet1 IED2>>CBSW> XSWI 1>dataSet IED2>>CBSW> XSWI 2>dataSet"
-  >
-    <span>
-      IED2
-    </span>
-    <mwc-icon slot="graphic">
-      developer_board
-    </mwc-icon>
-  </mwc-list-item>
-  <li
-    divider=""
-    role="separator"
-  >
-  </li>
-  <mwc-list-item
-    aria-disabled="false"
-    mwc-list-item=""
-    tabindex="-1"
-    twoline=""
-    value="IED2>>CBSW>GooseDataSet1"
-  >
-    <span>
-      GooseDataSet1
-    </span>
-    <span slot="secondary">
-      IED2>>CBSW>GooseDataSet1
-    </span>
-  </mwc-list-item>
-  <mwc-list-item
-    aria-disabled="false"
-    mwc-list-item=""
-    tabindex="-1"
-    twoline=""
-    value="IED2>>CBSW> XSWI 1>dataSet"
-  >
-    <span>
-      dataSet
-    </span>
-    <span slot="secondary">
-      IED2>>CBSW> XSWI 1>dataSet
-    </span>
-  </mwc-list-item>
-  <mwc-list-item
-    aria-disabled="false"
-    mwc-list-item=""
-    tabindex="-1"
-    twoline=""
-    value="IED2>>CBSW> XSWI 2>dataSet"
-  >
-    <span>
-      dataSet
-    </span>
-    <span slot="secondary">
-      IED2>>CBSW> XSWI 2>dataSet
-    </span>
-  </mwc-list-item>
-  <mwc-list-item
-    aria-disabled="false"
-    class="header listitem"
-    graphic="icon"
-    noninteractive=""
-    tabindex="-1"
-    value="IED3>>MU01>PhsMeas1"
-  >
-    <span>
-      IED3
-    </span>
-    <mwc-icon slot="graphic">
-      developer_board
-    </mwc-icon>
-  </mwc-list-item>
-  <li
-    divider=""
-    role="separator"
-  >
-  </li>
-  <mwc-list-item
-    aria-disabled="false"
-    mwc-list-item=""
-    tabindex="-1"
-    twoline=""
-    value="IED3>>MU01>PhsMeas1"
-  >
-    <span>
-      PhsMeas1
-    </span>
-    <span slot="secondary">
-      IED3>>MU01>PhsMeas1
-    </span>
-  </mwc-list-item>
-</filtered-list>
+    <mwc-list-item
+      aria-disabled="false"
+      class="header listitem"
+      graphic="icon"
+      noninteractive=""
+      tabindex="-1"
+      value="IED1>>CircuitBreaker_CB1>GooseDataSet1"
+    >
+      <span>
+        IED1
+      </span>
+      <mwc-icon slot="graphic">
+        developer_board
+      </mwc-icon>
+    </mwc-list-item>
+    <li
+      divider=""
+      role="separator"
+    >
+    </li>
+    <mwc-list-item
+      aria-disabled="false"
+      mwc-list-item=""
+      tabindex="0"
+      twoline=""
+      value="IED1>>CircuitBreaker_CB1>GooseDataSet1"
+    >
+      <span>
+        GooseDataSet1
+      </span>
+      <span slot="secondary">
+        IED1>>CircuitBreaker_CB1>GooseDataSet1
+      </span>
+    </mwc-list-item>
+    <mwc-list-item
+      aria-disabled="false"
+      class="header listitem"
+      graphic="icon"
+      noninteractive=""
+      tabindex="-1"
+      value="IED2>>CBSW>GooseDataSet1 IED2>>CBSW> XSWI 1>dataSet IED2>>CBSW> XSWI 2>dataSet"
+    >
+      <span>
+        IED2
+      </span>
+      <mwc-icon slot="graphic">
+        developer_board
+      </mwc-icon>
+    </mwc-list-item>
+    <li
+      divider=""
+      role="separator"
+    >
+    </li>
+    <mwc-list-item
+      aria-disabled="false"
+      mwc-list-item=""
+      tabindex="-1"
+      twoline=""
+      value="IED2>>CBSW>GooseDataSet1"
+    >
+      <span>
+        GooseDataSet1
+      </span>
+      <span slot="secondary">
+        IED2>>CBSW>GooseDataSet1
+      </span>
+    </mwc-list-item>
+    <mwc-list-item
+      aria-disabled="false"
+      mwc-list-item=""
+      tabindex="-1"
+      twoline=""
+      value="IED2>>CBSW> XSWI 1>dataSet"
+    >
+      <span>
+        dataSet
+      </span>
+      <span slot="secondary">
+        IED2>>CBSW> XSWI 1>dataSet
+      </span>
+    </mwc-list-item>
+    <mwc-list-item
+      aria-disabled="false"
+      mwc-list-item=""
+      tabindex="-1"
+      twoline=""
+      value="IED2>>CBSW> XSWI 2>dataSet"
+    >
+      <span>
+        dataSet
+      </span>
+      <span slot="secondary">
+        IED2>>CBSW> XSWI 2>dataSet
+      </span>
+    </mwc-list-item>
+    <mwc-list-item
+      aria-disabled="false"
+      class="header listitem"
+      graphic="icon"
+      noninteractive=""
+      tabindex="-1"
+      value="IED3>>MU01>PhsMeas1"
+    >
+      <span>
+        IED3
+      </span>
+      <mwc-icon slot="graphic">
+        developer_board
+      </mwc-icon>
+    </mwc-list-item>
+    <li
+      divider=""
+      role="separator"
+    >
+    </li>
+    <mwc-list-item
+      aria-disabled="false"
+      mwc-list-item=""
+      tabindex="-1"
+      twoline=""
+      value="IED3>>MU01>PhsMeas1"
+    >
+      <span>
+        PhsMeas1
+      </span>
+      <span slot="secondary">
+        IED3>>MU01>PhsMeas1
+      </span>
+    </mwc-list-item>
+  </filtered-list>
+</div>
 `;
-/* end snapshot Editor for DataSet element looks like the latest snapshot */
+/* end snapshot Editor for DataSet element initialy looks like the latest snapshot */
+
+snapshots["Editor for DataSet element with a selected DataSet looks like the latest snapshot"] = 
+`<mwc-button
+  label="[publisher.selectbutton]"
+  outlined=""
+>
+</mwc-button>
+<div class="content">
+  <filtered-list
+    activatable=""
+    class="hidden selectionlist"
+  >
+    <mwc-list-item
+      aria-disabled="false"
+      class="header listitem"
+      graphic="icon"
+      noninteractive=""
+      tabindex="-1"
+      value="IED1>>CircuitBreaker_CB1>GooseDataSet1"
+    >
+      <span>
+        IED1
+      </span>
+      <mwc-icon slot="graphic">
+        developer_board
+      </mwc-icon>
+    </mwc-list-item>
+    <li
+      divider=""
+      role="separator"
+    >
+    </li>
+    <mwc-list-item
+      activated=""
+      aria-disabled="false"
+      aria-selected="true"
+      mwc-list-item=""
+      selected=""
+      tabindex="0"
+      twoline=""
+      value="IED1>>CircuitBreaker_CB1>GooseDataSet1"
+    >
+      <span>
+        GooseDataSet1
+      </span>
+      <span slot="secondary">
+        IED1>>CircuitBreaker_CB1>GooseDataSet1
+      </span>
+    </mwc-list-item>
+    <mwc-list-item
+      aria-disabled="false"
+      class="header listitem"
+      graphic="icon"
+      noninteractive=""
+      tabindex="-1"
+      value="IED2>>CBSW>GooseDataSet1 IED2>>CBSW> XSWI 1>dataSet IED2>>CBSW> XSWI 2>dataSet"
+    >
+      <span>
+        IED2
+      </span>
+      <mwc-icon slot="graphic">
+        developer_board
+      </mwc-icon>
+    </mwc-list-item>
+    <li
+      divider=""
+      role="separator"
+    >
+    </li>
+    <mwc-list-item
+      aria-disabled="false"
+      mwc-list-item=""
+      tabindex="-1"
+      twoline=""
+      value="IED2>>CBSW>GooseDataSet1"
+    >
+      <span>
+        GooseDataSet1
+      </span>
+      <span slot="secondary">
+        IED2>>CBSW>GooseDataSet1
+      </span>
+    </mwc-list-item>
+    <mwc-list-item
+      aria-disabled="false"
+      mwc-list-item=""
+      tabindex="-1"
+      twoline=""
+      value="IED2>>CBSW> XSWI 1>dataSet"
+    >
+      <span>
+        dataSet
+      </span>
+      <span slot="secondary">
+        IED2>>CBSW> XSWI 1>dataSet
+      </span>
+    </mwc-list-item>
+    <mwc-list-item
+      aria-disabled="false"
+      mwc-list-item=""
+      tabindex="-1"
+      twoline=""
+      value="IED2>>CBSW> XSWI 2>dataSet"
+    >
+      <span>
+        dataSet
+      </span>
+      <span slot="secondary">
+        IED2>>CBSW> XSWI 2>dataSet
+      </span>
+    </mwc-list-item>
+    <mwc-list-item
+      aria-disabled="false"
+      class="header listitem"
+      graphic="icon"
+      noninteractive=""
+      tabindex="-1"
+      value="IED3>>MU01>PhsMeas1"
+    >
+      <span>
+        IED3
+      </span>
+      <mwc-icon slot="graphic">
+        developer_board
+      </mwc-icon>
+    </mwc-list-item>
+    <li
+      divider=""
+      role="separator"
+    >
+    </li>
+    <mwc-list-item
+      aria-disabled="false"
+      mwc-list-item=""
+      tabindex="-1"
+      twoline=""
+      value="IED3>>MU01>PhsMeas1"
+    >
+      <span>
+        PhsMeas1
+      </span>
+      <span slot="secondary">
+        IED3>>MU01>PhsMeas1
+      </span>
+    </mwc-list-item>
+  </filtered-list>
+  <div class="elementeditorcontainer">
+    <data-set-element-editor>
+    </data-set-element-editor>
+  </div>
+</div>
+`;
+/* end snapshot Editor for DataSet element with a selected DataSet looks like the latest snapshot */
 

--- a/test/unit/editors/publisher/__snapshots__/data-set-element-editor.test.snap.js
+++ b/test/unit/editors/publisher/__snapshots__/data-set-element-editor.test.snap.js
@@ -4,7 +4,12 @@ export const snapshots = {};
 snapshots["Editor for DataSet element with valid DataSet looks like the latest snapshot"] = 
 `<div class="content">
   <h2>
-    IED1>>CircuitBreaker_CB1>GooseDataSet1
+    <div>
+      DataSet
+    </div>
+    <div class="headersubtitle">
+      IED1>>CircuitBreaker_CB1>GooseDataSet1
+    </div>
   </h2>
   <wizard-textfield
     helper="[scl.name]"
@@ -26,45 +31,75 @@ snapshots["Editor for DataSet element with valid DataSet looks like the latest s
       mwc-list-item=""
       selected=""
       tabindex="0"
+      twoline=""
       value="IED1>>CircuitBreaker_CB1>GooseDataSet1>CircuitBreaker_CB1/ XCBR 1.Pos stVal (ST)"
     >
-      CircuitBreaker_CB1/ XCBR 1.Pos stVal (ST)
+      <span>
+        Pos.stVal
+      </span>
+      <span slot="secondary">
+        CircuitBreaker_CB1/XCBR1
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       mwc-list-item=""
       selected=""
       tabindex="-1"
+      twoline=""
       value="IED1>>CircuitBreaker_CB1>GooseDataSet1>CircuitBreaker_CB1/ XCBR 1.Pos q (ST)"
     >
-      CircuitBreaker_CB1/ XCBR 1.Pos q (ST)
+      <span>
+        Pos.q
+      </span>
+      <span slot="secondary">
+        CircuitBreaker_CB1/XCBR1
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       mwc-list-item=""
       selected=""
       tabindex="-1"
+      twoline=""
       value="IED1>>CircuitBreaker_CB1>GooseDataSet1>CircuitBreaker_CB1/ CSWI 1.Pos stVal (ST)"
     >
-      CircuitBreaker_CB1/ CSWI 1.Pos stVal (ST)
+      <span>
+        Pos.stVal
+      </span>
+      <span slot="secondary">
+        CircuitBreaker_CB1/CSWI1
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       mwc-list-item=""
       selected=""
       tabindex="-1"
+      twoline=""
       value="IED1>>CircuitBreaker_CB1>GooseDataSet1>Disconnectors/DC XSWI 1.Pos stVal (ST)"
     >
-      Disconnectors/DC XSWI 1.Pos stVal (ST)
+      <span>
+        Pos.stVal
+      </span>
+      <span slot="secondary">
+        Disconnectors/DCXSWI1
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       mwc-list-item=""
       selected=""
       tabindex="-1"
+      twoline=""
       value="IED1>>CircuitBreaker_CB1>GooseDataSet1>Disconnectors/DC XSWI 1.Pos q (ST)"
     >
-      Disconnectors/DC XSWI 1.Pos q (ST)
+      <span>
+        Pos.q
+      </span>
+      <span slot="secondary">
+        Disconnectors/DCXSWI1
+      </span>
     </mwc-list-item>
   </filtered-list>
 </div>

--- a/test/unit/editors/publisher/__snapshots__/data-set-element-editor.test.snap.js
+++ b/test/unit/editors/publisher/__snapshots__/data-set-element-editor.test.snap.js
@@ -1,0 +1,82 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["Editor for DataSet element with valid DataSet looks like the latest snapshot"] = 
+`<div class="content">
+  <h2>
+    IED1>>CircuitBreaker_CB1>GooseDataSet1
+  </h2>
+  <wizard-textfield
+    helper="[scl.name]"
+    label="name"
+    required=""
+  >
+  </wizard-textfield>
+  <wizard-textfield
+    disabled=""
+    helper="[scl.desc]"
+    label="desc"
+    nullable=""
+  >
+  </wizard-textfield>
+  <filtered-list>
+    <mwc-list-item
+      aria-disabled="false"
+      aria-selected="true"
+      mwc-list-item=""
+      selected=""
+      tabindex="0"
+      value="IED1>>CircuitBreaker_CB1>GooseDataSet1>CircuitBreaker_CB1/ XCBR 1.Pos stVal (ST)"
+    >
+      CircuitBreaker_CB1/ XCBR 1.Pos stVal (ST)
+    </mwc-list-item>
+    <mwc-list-item
+      aria-disabled="false"
+      mwc-list-item=""
+      selected=""
+      tabindex="-1"
+      value="IED1>>CircuitBreaker_CB1>GooseDataSet1>CircuitBreaker_CB1/ XCBR 1.Pos q (ST)"
+    >
+      CircuitBreaker_CB1/ XCBR 1.Pos q (ST)
+    </mwc-list-item>
+    <mwc-list-item
+      aria-disabled="false"
+      mwc-list-item=""
+      selected=""
+      tabindex="-1"
+      value="IED1>>CircuitBreaker_CB1>GooseDataSet1>CircuitBreaker_CB1/ CSWI 1.Pos stVal (ST)"
+    >
+      CircuitBreaker_CB1/ CSWI 1.Pos stVal (ST)
+    </mwc-list-item>
+    <mwc-list-item
+      aria-disabled="false"
+      mwc-list-item=""
+      selected=""
+      tabindex="-1"
+      value="IED1>>CircuitBreaker_CB1>GooseDataSet1>Disconnectors/DC XSWI 1.Pos stVal (ST)"
+    >
+      Disconnectors/DC XSWI 1.Pos stVal (ST)
+    </mwc-list-item>
+    <mwc-list-item
+      aria-disabled="false"
+      mwc-list-item=""
+      selected=""
+      tabindex="-1"
+      value="IED1>>CircuitBreaker_CB1>GooseDataSet1>Disconnectors/DC XSWI 1.Pos q (ST)"
+    >
+      Disconnectors/DC XSWI 1.Pos q (ST)
+    </mwc-list-item>
+  </filtered-list>
+</div>
+`;
+/* end snapshot Editor for DataSet element with valid DataSet looks like the latest snapshot */
+
+snapshots["Editor for DataSet element with nulled DataSet looks like the latest snapshot"] = 
+`<div class="content">
+  <h2>
+    [publisher.nodataset]
+  </h2>
+</div>
+`;
+/* end snapshot Editor for DataSet element with nulled DataSet looks like the latest snapshot */
+

--- a/test/unit/editors/publisher/__snapshots__/gse-control-editor.test.snap.js
+++ b/test/unit/editors/publisher/__snapshots__/gse-control-editor.test.snap.js
@@ -1,120 +1,264 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["Editor for GSEControl element looks like the latest snapshot"] = 
-`<filtered-list>
-  <mwc-list-item
-    aria-disabled="false"
-    class="header listitem"
-    graphic="icon"
-    noninteractive=""
-    tabindex="-1"
-    value="IED1>>CircuitBreaker_CB1>GCB IED1>>CircuitBreaker_CB1>GCB2"
+snapshots["Editor for GSEControl element initialy looks like the latest snapshot"] = 
+`<mwc-button
+  label="[publisher.selectbutton]"
+  outlined=""
+>
+</mwc-button>
+<div class="content">
+  <filtered-list
+    activatable=""
+    class="selectionlist"
   >
-    <span>
-      IED1
-    </span>
-    <mwc-icon slot="graphic">
-      developer_board
-    </mwc-icon>
-  </mwc-list-item>
-  <li
-    divider=""
-    role="separator"
-  >
-  </li>
-  <mwc-list-item
-    aria-disabled="false"
-    graphic="icon"
-    mwc-list-item=""
-    tabindex="0"
-    twoline=""
-    value="IED1>>CircuitBreaker_CB1>GCB"
-  >
-    <span>
-      GCB
-    </span>
-    <span slot="secondary">
-      IED1>>CircuitBreaker_CB1>GCB
-    </span>
-    <mwc-icon slot="graphic">
-    </mwc-icon>
-  </mwc-list-item>
-  <mwc-list-item
-    aria-disabled="false"
-    graphic="icon"
-    mwc-list-item=""
-    tabindex="-1"
-    twoline=""
-    value="IED1>>CircuitBreaker_CB1>GCB2"
-  >
-    <span>
-      GCB2
-    </span>
-    <span slot="secondary">
-      IED1>>CircuitBreaker_CB1>GCB2
-    </span>
-    <mwc-icon slot="graphic">
-    </mwc-icon>
-  </mwc-list-item>
-  <mwc-list-item
-    aria-disabled="false"
-    class="header listitem"
-    graphic="icon"
-    noninteractive=""
-    tabindex="-1"
-    value="IED2>>CBSW>GCB"
-  >
-    <span>
-      IED2
-    </span>
-    <mwc-icon slot="graphic">
-      developer_board
-    </mwc-icon>
-  </mwc-list-item>
-  <li
-    divider=""
-    role="separator"
-  >
-  </li>
-  <mwc-list-item
-    aria-disabled="false"
-    graphic="icon"
-    mwc-list-item=""
-    tabindex="-1"
-    twoline=""
-    value="IED2>>CBSW>GCB"
-  >
-    <span>
-      GCB
-    </span>
-    <span slot="secondary">
-      IED2>>CBSW>GCB
-    </span>
-    <mwc-icon slot="graphic">
-    </mwc-icon>
-  </mwc-list-item>
-  <mwc-list-item
-    aria-disabled="false"
-    class="header listitem"
-    graphic="icon"
-    noninteractive=""
-    tabindex="-1"
-    value=""
-  >
-    <span>
-      IED3
-    </span>
-    <mwc-icon slot="graphic">
-      developer_board
-    </mwc-icon>
-  </mwc-list-item>
-  <li
-    divider=""
-    role="separator"
-  >
-  </li>
-</filtered-list>
+    <mwc-list-item
+      aria-disabled="false"
+      class="header listitem"
+      graphic="icon"
+      noninteractive=""
+      tabindex="-1"
+      value="IED1>>CircuitBreaker_CB1>GCB IED1>>CircuitBreaker_CB1>GCB2"
+    >
+      <span>
+        IED1
+      </span>
+      <mwc-icon slot="graphic">
+        developer_board
+      </mwc-icon>
+    </mwc-list-item>
+    <li
+      divider=""
+      role="separator"
+    >
+    </li>
+    <mwc-list-item
+      aria-disabled="false"
+      graphic="icon"
+      mwc-list-item=""
+      tabindex="0"
+      twoline=""
+      value="IED1>>CircuitBreaker_CB1>GCB"
+    >
+      <span>
+        GCB
+      </span>
+      <span slot="secondary">
+        IED1>>CircuitBreaker_CB1>GCB
+      </span>
+      <mwc-icon slot="graphic">
+      </mwc-icon>
+    </mwc-list-item>
+    <mwc-list-item
+      aria-disabled="false"
+      graphic="icon"
+      mwc-list-item=""
+      tabindex="-1"
+      twoline=""
+      value="IED1>>CircuitBreaker_CB1>GCB2"
+    >
+      <span>
+        GCB2
+      </span>
+      <span slot="secondary">
+        IED1>>CircuitBreaker_CB1>GCB2
+      </span>
+      <mwc-icon slot="graphic">
+      </mwc-icon>
+    </mwc-list-item>
+    <mwc-list-item
+      aria-disabled="false"
+      class="header listitem"
+      graphic="icon"
+      noninteractive=""
+      tabindex="-1"
+      value="IED2>>CBSW>GCB"
+    >
+      <span>
+        IED2
+      </span>
+      <mwc-icon slot="graphic">
+        developer_board
+      </mwc-icon>
+    </mwc-list-item>
+    <li
+      divider=""
+      role="separator"
+    >
+    </li>
+    <mwc-list-item
+      aria-disabled="false"
+      graphic="icon"
+      mwc-list-item=""
+      tabindex="-1"
+      twoline=""
+      value="IED2>>CBSW>GCB"
+    >
+      <span>
+        GCB
+      </span>
+      <span slot="secondary">
+        IED2>>CBSW>GCB
+      </span>
+      <mwc-icon slot="graphic">
+      </mwc-icon>
+    </mwc-list-item>
+    <mwc-list-item
+      aria-disabled="false"
+      class="header listitem"
+      graphic="icon"
+      noninteractive=""
+      tabindex="-1"
+      value=""
+    >
+      <span>
+        IED3
+      </span>
+      <mwc-icon slot="graphic">
+        developer_board
+      </mwc-icon>
+    </mwc-list-item>
+    <li
+      divider=""
+      role="separator"
+    >
+    </li>
+  </filtered-list>
+</div>
 `;
-/* end snapshot Editor for GSEControl element looks like the latest snapshot */
+/* end snapshot Editor for GSEControl element initialy looks like the latest snapshot */
+
+snapshots["Editor for GSEControl element with a selected GSEControl looks like the latest snapshot"] = 
+`<mwc-button
+  label="[publisher.selectbutton]"
+  outlined=""
+>
+</mwc-button>
+<div class="content">
+  <filtered-list
+    activatable=""
+    class="hidden selectionlist"
+  >
+    <mwc-list-item
+      aria-disabled="false"
+      class="header listitem"
+      graphic="icon"
+      noninteractive=""
+      tabindex="-1"
+      value="IED1>>CircuitBreaker_CB1>GCB IED1>>CircuitBreaker_CB1>GCB2"
+    >
+      <span>
+        IED1
+      </span>
+      <mwc-icon slot="graphic">
+        developer_board
+      </mwc-icon>
+    </mwc-list-item>
+    <li
+      divider=""
+      role="separator"
+    >
+    </li>
+    <mwc-list-item
+      activated=""
+      aria-disabled="false"
+      aria-selected="true"
+      graphic="icon"
+      mwc-list-item=""
+      selected=""
+      tabindex="0"
+      twoline=""
+      value="IED1>>CircuitBreaker_CB1>GCB"
+    >
+      <span>
+        GCB
+      </span>
+      <span slot="secondary">
+        IED1>>CircuitBreaker_CB1>GCB
+      </span>
+      <mwc-icon slot="graphic">
+      </mwc-icon>
+    </mwc-list-item>
+    <mwc-list-item
+      aria-disabled="false"
+      graphic="icon"
+      mwc-list-item=""
+      tabindex="-1"
+      twoline=""
+      value="IED1>>CircuitBreaker_CB1>GCB2"
+    >
+      <span>
+        GCB2
+      </span>
+      <span slot="secondary">
+        IED1>>CircuitBreaker_CB1>GCB2
+      </span>
+      <mwc-icon slot="graphic">
+      </mwc-icon>
+    </mwc-list-item>
+    <mwc-list-item
+      aria-disabled="false"
+      class="header listitem"
+      graphic="icon"
+      noninteractive=""
+      tabindex="-1"
+      value="IED2>>CBSW>GCB"
+    >
+      <span>
+        IED2
+      </span>
+      <mwc-icon slot="graphic">
+        developer_board
+      </mwc-icon>
+    </mwc-list-item>
+    <li
+      divider=""
+      role="separator"
+    >
+    </li>
+    <mwc-list-item
+      aria-disabled="false"
+      graphic="icon"
+      mwc-list-item=""
+      tabindex="-1"
+      twoline=""
+      value="IED2>>CBSW>GCB"
+    >
+      <span>
+        GCB
+      </span>
+      <span slot="secondary">
+        IED2>>CBSW>GCB
+      </span>
+      <mwc-icon slot="graphic">
+      </mwc-icon>
+    </mwc-list-item>
+    <mwc-list-item
+      aria-disabled="false"
+      class="header listitem"
+      graphic="icon"
+      noninteractive=""
+      tabindex="-1"
+      value=""
+    >
+      <span>
+        IED3
+      </span>
+      <mwc-icon slot="graphic">
+        developer_board
+      </mwc-icon>
+    </mwc-list-item>
+    <li
+      divider=""
+      role="separator"
+    >
+    </li>
+  </filtered-list>
+  <div class="elementeditorcontainer">
+    <data-set-element-editor>
+    </data-set-element-editor>
+  </div>
+</div>
+`;
+/* end snapshot Editor for GSEControl element with a selected GSEControl looks like the latest snapshot */
 

--- a/test/unit/editors/publisher/__snapshots__/gse-control-editor.test.snap.js
+++ b/test/unit/editors/publisher/__snapshots__/gse-control-editor.test.snap.js
@@ -1,7 +1,7 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["Editor for GSEControl element initialy looks like the latest snapshot"] = 
+snapshots["Editor for GSEControl element initially looks like the latest snapshot"] = 
 `<mwc-button
   label="[publisher.selectbutton]"
   outlined=""
@@ -126,7 +126,7 @@ snapshots["Editor for GSEControl element initialy looks like the latest snapshot
   </filtered-list>
 </div>
 `;
-/* end snapshot Editor for GSEControl element initialy looks like the latest snapshot */
+/* end snapshot Editor for GSEControl element initially looks like the latest snapshot */
 
 snapshots["Editor for GSEControl element with a selected GSEControl looks like the latest snapshot"] = 
 `<mwc-button

--- a/test/unit/editors/publisher/__snapshots__/report-control-editor.test.snap.js
+++ b/test/unit/editors/publisher/__snapshots__/report-control-editor.test.snap.js
@@ -1,7 +1,7 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["Editor for ReportControl element initialy looks like the latest snapshot"] = 
+snapshots["Editor for ReportControl element initially looks like the latest snapshot"] = 
 `<mwc-button
   label="[publisher.selectbutton]"
   outlined=""
@@ -109,7 +109,7 @@ snapshots["Editor for ReportControl element initialy looks like the latest snaps
   </filtered-list>
 </div>
 `;
-/* end snapshot Editor for ReportControl element initialy looks like the latest snapshot */
+/* end snapshot Editor for ReportControl element initially looks like the latest snapshot */
 
 snapshots["Editor for ReportControl element with a selected ReportControl looks like the latest snapshot"] = 
 `<mwc-button

--- a/test/unit/editors/publisher/__snapshots__/report-control-editor.test.snap.js
+++ b/test/unit/editors/publisher/__snapshots__/report-control-editor.test.snap.js
@@ -1,103 +1,230 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["Editor for ReportControl element looks like the latest snapshot"] = 
-`<filtered-list>
-  <mwc-list-item
-    aria-disabled="false"
-    class="header listitem"
-    graphic="icon"
-    noninteractive=""
-    tabindex="-1"
-    value=""
+snapshots["Editor for ReportControl element initialy looks like the latest snapshot"] = 
+`<mwc-button
+  label="[publisher.selectbutton]"
+  outlined=""
+>
+</mwc-button>
+<div class="content">
+  <filtered-list
+    activatable=""
+    class="selectionlist"
   >
-    <span>
-      IED1
-    </span>
-    <mwc-icon slot="graphic">
-      developer_board
-    </mwc-icon>
-  </mwc-list-item>
-  <li
-    divider=""
-    role="separator"
-  >
-  </li>
-  <mwc-list-item
-    aria-disabled="false"
-    class="header listitem"
-    graphic="icon"
-    noninteractive=""
-    tabindex="-1"
-    value="IED2>>CBSW> XSWI 1>ReportCb IED2>>CBSW> XSWI 2>ReportCb"
-  >
-    <span>
-      IED2
-    </span>
-    <mwc-icon slot="graphic">
-      developer_board
-    </mwc-icon>
-  </mwc-list-item>
-  <li
-    divider=""
-    role="separator"
-  >
-  </li>
-  <mwc-list-item
-    aria-disabled="false"
-    graphic="icon"
-    mwc-list-item=""
-    tabindex="0"
-    twoline=""
-    value="IED2>>CBSW> XSWI 1>ReportCb"
-  >
-    <span>
-      ReportCb
-    </span>
-    <span slot="secondary">
-      IED2>>CBSW> XSWI 1>ReportCb
-    </span>
-    <mwc-icon slot="graphic">
-    </mwc-icon>
-  </mwc-list-item>
-  <mwc-list-item
-    aria-disabled="false"
-    graphic="icon"
-    mwc-list-item=""
-    tabindex="-1"
-    twoline=""
-    value="IED2>>CBSW> XSWI 2>ReportCb"
-  >
-    <span>
-      ReportCb
-    </span>
-    <span slot="secondary">
-      IED2>>CBSW> XSWI 2>ReportCb
-    </span>
-    <mwc-icon slot="graphic">
-    </mwc-icon>
-  </mwc-list-item>
-  <mwc-list-item
-    aria-disabled="false"
-    class="header listitem"
-    graphic="icon"
-    noninteractive=""
-    tabindex="-1"
-    value=""
-  >
-    <span>
-      IED3
-    </span>
-    <mwc-icon slot="graphic">
-      developer_board
-    </mwc-icon>
-  </mwc-list-item>
-  <li
-    divider=""
-    role="separator"
-  >
-  </li>
-</filtered-list>
+    <mwc-list-item
+      aria-disabled="false"
+      class="header listitem"
+      graphic="icon"
+      noninteractive=""
+      tabindex="-1"
+      value=""
+    >
+      <span>
+        IED1
+      </span>
+      <mwc-icon slot="graphic">
+        developer_board
+      </mwc-icon>
+    </mwc-list-item>
+    <li
+      divider=""
+      role="separator"
+    >
+    </li>
+    <mwc-list-item
+      aria-disabled="false"
+      class="header listitem"
+      graphic="icon"
+      noninteractive=""
+      tabindex="-1"
+      value="IED2>>CBSW> XSWI 1>ReportCb IED2>>CBSW> XSWI 2>ReportCb"
+    >
+      <span>
+        IED2
+      </span>
+      <mwc-icon slot="graphic">
+        developer_board
+      </mwc-icon>
+    </mwc-list-item>
+    <li
+      divider=""
+      role="separator"
+    >
+    </li>
+    <mwc-list-item
+      aria-disabled="false"
+      graphic="icon"
+      mwc-list-item=""
+      tabindex="0"
+      twoline=""
+      value="IED2>>CBSW> XSWI 1>ReportCb"
+    >
+      <span>
+        ReportCb
+      </span>
+      <span slot="secondary">
+        IED2>>CBSW> XSWI 1>ReportCb
+      </span>
+      <mwc-icon slot="graphic">
+      </mwc-icon>
+    </mwc-list-item>
+    <mwc-list-item
+      aria-disabled="false"
+      graphic="icon"
+      mwc-list-item=""
+      tabindex="-1"
+      twoline=""
+      value="IED2>>CBSW> XSWI 2>ReportCb"
+    >
+      <span>
+        ReportCb
+      </span>
+      <span slot="secondary">
+        IED2>>CBSW> XSWI 2>ReportCb
+      </span>
+      <mwc-icon slot="graphic">
+      </mwc-icon>
+    </mwc-list-item>
+    <mwc-list-item
+      aria-disabled="false"
+      class="header listitem"
+      graphic="icon"
+      noninteractive=""
+      tabindex="-1"
+      value=""
+    >
+      <span>
+        IED3
+      </span>
+      <mwc-icon slot="graphic">
+        developer_board
+      </mwc-icon>
+    </mwc-list-item>
+    <li
+      divider=""
+      role="separator"
+    >
+    </li>
+  </filtered-list>
+</div>
 `;
-/* end snapshot Editor for ReportControl element looks like the latest snapshot */
+/* end snapshot Editor for ReportControl element initialy looks like the latest snapshot */
+
+snapshots["Editor for ReportControl element with a selected ReportControl looks like the latest snapshot"] = 
+`<mwc-button
+  label="[publisher.selectbutton]"
+  outlined=""
+>
+</mwc-button>
+<div class="content">
+  <filtered-list
+    activatable=""
+    class="hidden selectionlist"
+  >
+    <mwc-list-item
+      aria-disabled="false"
+      class="header listitem"
+      graphic="icon"
+      noninteractive=""
+      tabindex="-1"
+      value=""
+    >
+      <span>
+        IED1
+      </span>
+      <mwc-icon slot="graphic">
+        developer_board
+      </mwc-icon>
+    </mwc-list-item>
+    <li
+      divider=""
+      role="separator"
+    >
+    </li>
+    <mwc-list-item
+      aria-disabled="false"
+      class="header listitem"
+      graphic="icon"
+      noninteractive=""
+      tabindex="-1"
+      value="IED2>>CBSW> XSWI 1>ReportCb IED2>>CBSW> XSWI 2>ReportCb"
+    >
+      <span>
+        IED2
+      </span>
+      <mwc-icon slot="graphic">
+        developer_board
+      </mwc-icon>
+    </mwc-list-item>
+    <li
+      divider=""
+      role="separator"
+    >
+    </li>
+    <mwc-list-item
+      activated=""
+      aria-disabled="false"
+      aria-selected="true"
+      graphic="icon"
+      mwc-list-item=""
+      selected=""
+      tabindex="0"
+      twoline=""
+      value="IED2>>CBSW> XSWI 1>ReportCb"
+    >
+      <span>
+        ReportCb
+      </span>
+      <span slot="secondary">
+        IED2>>CBSW> XSWI 1>ReportCb
+      </span>
+      <mwc-icon slot="graphic">
+      </mwc-icon>
+    </mwc-list-item>
+    <mwc-list-item
+      aria-disabled="false"
+      graphic="icon"
+      mwc-list-item=""
+      tabindex="-1"
+      twoline=""
+      value="IED2>>CBSW> XSWI 2>ReportCb"
+    >
+      <span>
+        ReportCb
+      </span>
+      <span slot="secondary">
+        IED2>>CBSW> XSWI 2>ReportCb
+      </span>
+      <mwc-icon slot="graphic">
+      </mwc-icon>
+    </mwc-list-item>
+    <mwc-list-item
+      aria-disabled="false"
+      class="header listitem"
+      graphic="icon"
+      noninteractive=""
+      tabindex="-1"
+      value=""
+    >
+      <span>
+        IED3
+      </span>
+      <mwc-icon slot="graphic">
+        developer_board
+      </mwc-icon>
+    </mwc-list-item>
+    <li
+      divider=""
+      role="separator"
+    >
+    </li>
+  </filtered-list>
+  <div class="elementeditorcontainer">
+    <data-set-element-editor>
+    </data-set-element-editor>
+  </div>
+</div>
+`;
+/* end snapshot Editor for ReportControl element with a selected ReportControl looks like the latest snapshot */
 

--- a/test/unit/editors/publisher/__snapshots__/sampled-value-control-editor.test.snap.js
+++ b/test/unit/editors/publisher/__snapshots__/sampled-value-control-editor.test.snap.js
@@ -1,7 +1,7 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["Editor for SampledValueControl element initialy looks like the latest snapshot"] = 
+snapshots["Editor for SampledValueControl element initially looks like the latest snapshot"] = 
 `<mwc-button
   label="[publisher.selectbutton]"
   outlined=""
@@ -92,7 +92,7 @@ snapshots["Editor for SampledValueControl element initialy looks like the latest
   </filtered-list>
 </div>
 `;
-/* end snapshot Editor for SampledValueControl element initialy looks like the latest snapshot */
+/* end snapshot Editor for SampledValueControl element initially looks like the latest snapshot */
 
 snapshots["Editor for SampledValueControl element with a selected SampledValueControl looks like the latest snapshot"] = 
 `<mwc-button

--- a/test/unit/editors/publisher/__snapshots__/sampled-value-control-editor.test.snap.js
+++ b/test/unit/editors/publisher/__snapshots__/sampled-value-control-editor.test.snap.js
@@ -1,86 +1,196 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["Editor for SampledValueControl element looks like the latest snapshot"] = 
-`<filtered-list>
-  <mwc-list-item
-    aria-disabled="false"
-    class="header listitem"
-    graphic="icon"
-    noninteractive=""
-    tabindex="-1"
-    value=""
+snapshots["Editor for SampledValueControl element initialy looks like the latest snapshot"] = 
+`<mwc-button
+  label="[publisher.selectbutton]"
+  outlined=""
+>
+</mwc-button>
+<div class="content">
+  <filtered-list
+    activatable=""
+    class="selectionlist"
   >
-    <span>
-      IED1
-    </span>
-    <mwc-icon slot="graphic">
-      developer_board
-    </mwc-icon>
-  </mwc-list-item>
-  <li
-    divider=""
-    role="separator"
-  >
-  </li>
-  <mwc-list-item
-    aria-disabled="false"
-    class="header listitem"
-    graphic="icon"
-    noninteractive=""
-    tabindex="-1"
-    value=""
-  >
-    <span>
-      IED2
-    </span>
-    <mwc-icon slot="graphic">
-      developer_board
-    </mwc-icon>
-  </mwc-list-item>
-  <li
-    divider=""
-    role="separator"
-  >
-  </li>
-  <mwc-list-item
-    aria-disabled="false"
-    class="header listitem"
-    graphic="icon"
-    noninteractive=""
-    tabindex="-1"
-    value="IED3>>MU01>MSVCB01"
-  >
-    <span>
-      IED3
-    </span>
-    <mwc-icon slot="graphic">
-      developer_board
-    </mwc-icon>
-  </mwc-list-item>
-  <li
-    divider=""
-    role="separator"
-  >
-  </li>
-  <mwc-list-item
-    aria-disabled="false"
-    graphic="icon"
-    mwc-list-item=""
-    tabindex="0"
-    twoline=""
-    value="IED3>>MU01>MSVCB01"
-  >
-    <span>
-      MSVCB01
-    </span>
-    <span slot="secondary">
-      IED3>>MU01>MSVCB01
-    </span>
-    <mwc-icon slot="graphic">
-    </mwc-icon>
-  </mwc-list-item>
-</filtered-list>
+    <mwc-list-item
+      aria-disabled="false"
+      class="header listitem"
+      graphic="icon"
+      noninteractive=""
+      tabindex="-1"
+      value=""
+    >
+      <span>
+        IED1
+      </span>
+      <mwc-icon slot="graphic">
+        developer_board
+      </mwc-icon>
+    </mwc-list-item>
+    <li
+      divider=""
+      role="separator"
+    >
+    </li>
+    <mwc-list-item
+      aria-disabled="false"
+      class="header listitem"
+      graphic="icon"
+      noninteractive=""
+      tabindex="-1"
+      value=""
+    >
+      <span>
+        IED2
+      </span>
+      <mwc-icon slot="graphic">
+        developer_board
+      </mwc-icon>
+    </mwc-list-item>
+    <li
+      divider=""
+      role="separator"
+    >
+    </li>
+    <mwc-list-item
+      aria-disabled="false"
+      class="header listitem"
+      graphic="icon"
+      noninteractive=""
+      tabindex="-1"
+      value="IED3>>MU01>MSVCB01"
+    >
+      <span>
+        IED3
+      </span>
+      <mwc-icon slot="graphic">
+        developer_board
+      </mwc-icon>
+    </mwc-list-item>
+    <li
+      divider=""
+      role="separator"
+    >
+    </li>
+    <mwc-list-item
+      aria-disabled="false"
+      graphic="icon"
+      mwc-list-item=""
+      tabindex="0"
+      twoline=""
+      value="IED3>>MU01>MSVCB01"
+    >
+      <span>
+        MSVCB01
+      </span>
+      <span slot="secondary">
+        IED3>>MU01>MSVCB01
+      </span>
+      <mwc-icon slot="graphic">
+      </mwc-icon>
+    </mwc-list-item>
+  </filtered-list>
+</div>
 `;
-/* end snapshot Editor for SampledValueControl element looks like the latest snapshot */
+/* end snapshot Editor for SampledValueControl element initialy looks like the latest snapshot */
+
+snapshots["Editor for SampledValueControl element with a selected SampledValueControl looks like the latest snapshot"] = 
+`<mwc-button
+  label="[publisher.selectbutton]"
+  outlined=""
+>
+</mwc-button>
+<div class="content">
+  <filtered-list
+    activatable=""
+    class="hidden selectionlist"
+  >
+    <mwc-list-item
+      aria-disabled="false"
+      class="header listitem"
+      graphic="icon"
+      noninteractive=""
+      tabindex="-1"
+      value=""
+    >
+      <span>
+        IED1
+      </span>
+      <mwc-icon slot="graphic">
+        developer_board
+      </mwc-icon>
+    </mwc-list-item>
+    <li
+      divider=""
+      role="separator"
+    >
+    </li>
+    <mwc-list-item
+      aria-disabled="false"
+      class="header listitem"
+      graphic="icon"
+      noninteractive=""
+      tabindex="-1"
+      value=""
+    >
+      <span>
+        IED2
+      </span>
+      <mwc-icon slot="graphic">
+        developer_board
+      </mwc-icon>
+    </mwc-list-item>
+    <li
+      divider=""
+      role="separator"
+    >
+    </li>
+    <mwc-list-item
+      aria-disabled="false"
+      class="header listitem"
+      graphic="icon"
+      noninteractive=""
+      tabindex="-1"
+      value="IED3>>MU01>MSVCB01"
+    >
+      <span>
+        IED3
+      </span>
+      <mwc-icon slot="graphic">
+        developer_board
+      </mwc-icon>
+    </mwc-list-item>
+    <li
+      divider=""
+      role="separator"
+    >
+    </li>
+    <mwc-list-item
+      activated=""
+      aria-disabled="false"
+      aria-selected="true"
+      graphic="icon"
+      mwc-list-item=""
+      selected=""
+      tabindex="0"
+      twoline=""
+      value="IED3>>MU01>MSVCB01"
+    >
+      <span>
+        MSVCB01
+      </span>
+      <span slot="secondary">
+        IED3>>MU01>MSVCB01
+      </span>
+      <mwc-icon slot="graphic">
+      </mwc-icon>
+    </mwc-list-item>
+  </filtered-list>
+  <div class="elementeditorcontainer">
+    <data-set-element-editor>
+    </data-set-element-editor>
+  </div>
+</div>
+`;
+/* end snapshot Editor for SampledValueControl element with a selected SampledValueControl looks like the latest snapshot */
 

--- a/test/unit/editors/publisher/data-set-editor.test.ts
+++ b/test/unit/editors/publisher/data-set-editor.test.ts
@@ -17,6 +17,21 @@ describe('Editor for DataSet element', () => {
     );
   });
 
-  it('looks like the latest snapshot', async () =>
+  it('initialy looks like the latest snapshot', async () =>
     await expect(element).shadowDom.to.equalSnapshot());
+
+  describe('with a selected DataSet', () => {
+    beforeEach(async () => {
+      (
+        element.shadowRoot?.querySelector(
+          '.selectionlist > mwc-list-item:not([noninteractive])'
+        ) as HTMLElement
+      ).click();
+
+      await element.updateComplete;
+    });
+
+    it('looks like the latest snapshot', async () =>
+      await expect(element).shadowDom.to.equalSnapshot());
+  });
 });

--- a/test/unit/editors/publisher/data-set-editor.test.ts
+++ b/test/unit/editors/publisher/data-set-editor.test.ts
@@ -17,7 +17,7 @@ describe('Editor for DataSet element', () => {
     );
   });
 
-  it('initialy looks like the latest snapshot', async () =>
+  it('initially looks like the latest snapshot', async () =>
     await expect(element).shadowDom.to.equalSnapshot());
 
   describe('with a selected DataSet', () => {

--- a/test/unit/editors/publisher/data-set-element-editor.test.ts
+++ b/test/unit/editors/publisher/data-set-element-editor.test.ts
@@ -1,0 +1,45 @@
+import { expect, fixture, html } from '@open-wc/testing';
+
+import '../../../../src/editors/publisher/data-set-element-editor.js';
+import { DataSetElementEditor } from '../../../../src/editors/publisher/data-set-element-editor.js';
+
+describe('Editor for DataSet element', () => {
+  let doc: XMLDocument;
+  let element: DataSetElementEditor;
+
+  beforeEach(async () => {
+    doc = await fetch('/test/testfiles/valid2007B4.scd')
+      .then(response => response.text())
+      .then(str => new DOMParser().parseFromString(str, 'application/xml'));
+  });
+
+  describe('with valid DataSet', () => {
+    beforeEach(async () => {
+      const dataSet = doc.querySelector('DataSet')!;
+
+      element = await fixture(
+        html`<data-set-element-editor
+          .element=${dataSet}
+        ></data-set-element-editor>`
+      );
+    });
+
+    it('looks like the latest snapshot', async () =>
+      await expect(element).shadowDom.to.equalSnapshot());
+  });
+
+  describe('with nulled DataSet', () => {
+    beforeEach(async () => {
+      const dataSet = null;
+
+      element = await fixture(
+        html`<data-set-element-editor
+          .element=${dataSet}
+        ></data-set-element-editor>`
+      );
+    });
+
+    it('looks like the latest snapshot', async () =>
+      await expect(element).shadowDom.to.equalSnapshot());
+  });
+});

--- a/test/unit/editors/publisher/gse-control-editor.test.ts
+++ b/test/unit/editors/publisher/gse-control-editor.test.ts
@@ -17,6 +17,21 @@ describe('Editor for GSEControl element', () => {
     );
   });
 
-  it('looks like the latest snapshot', async () =>
+  it('initialy looks like the latest snapshot', async () =>
     await expect(element).shadowDom.to.equalSnapshot());
+
+  describe('with a selected GSEControl', () => {
+    beforeEach(async () => {
+      (
+        element.shadowRoot?.querySelector(
+          '.selectionlist > mwc-list-item:not([noninteractive])'
+        ) as HTMLElement
+      ).click();
+
+      await element.updateComplete;
+    });
+
+    it('looks like the latest snapshot', async () =>
+      await expect(element).shadowDom.to.equalSnapshot());
+  });
 });

--- a/test/unit/editors/publisher/gse-control-editor.test.ts
+++ b/test/unit/editors/publisher/gse-control-editor.test.ts
@@ -17,7 +17,7 @@ describe('Editor for GSEControl element', () => {
     );
   });
 
-  it('initialy looks like the latest snapshot', async () =>
+  it('initially looks like the latest snapshot', async () =>
     await expect(element).shadowDom.to.equalSnapshot());
 
   describe('with a selected GSEControl', () => {

--- a/test/unit/editors/publisher/report-control-editor.test.ts
+++ b/test/unit/editors/publisher/report-control-editor.test.ts
@@ -17,6 +17,21 @@ describe('Editor for ReportControl element', () => {
     );
   });
 
-  it('looks like the latest snapshot', async () =>
+  it('initialy looks like the latest snapshot', async () =>
     await expect(element).shadowDom.to.equalSnapshot());
+
+  describe('with a selected ReportControl', () => {
+    beforeEach(async () => {
+      (
+        element.shadowRoot?.querySelector(
+          '.selectionlist > mwc-list-item:not([noninteractive])'
+        ) as HTMLElement
+      ).click();
+
+      await element.updateComplete;
+    });
+
+    it('looks like the latest snapshot', async () =>
+      await expect(element).shadowDom.to.equalSnapshot());
+  });
 });

--- a/test/unit/editors/publisher/report-control-editor.test.ts
+++ b/test/unit/editors/publisher/report-control-editor.test.ts
@@ -17,7 +17,7 @@ describe('Editor for ReportControl element', () => {
     );
   });
 
-  it('initialy looks like the latest snapshot', async () =>
+  it('initially looks like the latest snapshot', async () =>
     await expect(element).shadowDom.to.equalSnapshot());
 
   describe('with a selected ReportControl', () => {

--- a/test/unit/editors/publisher/sampled-value-control-editor.test.ts
+++ b/test/unit/editors/publisher/sampled-value-control-editor.test.ts
@@ -19,7 +19,7 @@ describe('Editor for SampledValueControl element', () => {
     );
   });
 
-  it('initialy looks like the latest snapshot', async () =>
+  it('initially looks like the latest snapshot', async () =>
     await expect(element).shadowDom.to.equalSnapshot());
 
   describe('with a selected SampledValueControl', () => {

--- a/test/unit/editors/publisher/sampled-value-control-editor.test.ts
+++ b/test/unit/editors/publisher/sampled-value-control-editor.test.ts
@@ -19,6 +19,21 @@ describe('Editor for SampledValueControl element', () => {
     );
   });
 
-  it('looks like the latest snapshot', async () =>
+  it('initialy looks like the latest snapshot', async () =>
     await expect(element).shadowDom.to.equalSnapshot());
+
+  describe('with a selected SampledValueControl', () => {
+    beforeEach(async () => {
+      (
+        element.shadowRoot?.querySelector(
+          '.selectionlist > mwc-list-item:not([noninteractive])'
+        ) as HTMLElement
+      ).click();
+
+      await element.updateComplete;
+    });
+
+    it('looks like the latest snapshot', async () =>
+      await expect(element).shadowDom.to.equalSnapshot());
+  });
 });


### PR DESCRIPTION
This PR adds a read only DataSet element editor that shows referenced DataSets for `ReportControl`, `GSEControl`, `SampledValueControl` as well as `DataSet`s itself.

I have not bothered to create issues for this one. I did test a lot of CSS in the PR and therefore no Mock was present.