### PR TITLE
feat(plugin): add read-only report-control-element-editor

### DIFF
--- a/src/editors/Publisher.ts
+++ b/src/editors/Publisher.ts
@@ -21,6 +21,7 @@ export default class PublisherPlugin extends LitElement {
   /** The document being edited as provided to plugins by [[`OpenSCD`]]. */
   @property({ attribute: false })
   doc!: XMLDocument;
+
   @state()
   private publisherType: 'Report' | 'GOOSE' | 'SampledValue' | 'DataSet' =
     'GOOSE';

--- a/src/editors/publisher/data-set-editor.ts
+++ b/src/editors/publisher/data-set-editor.ts
@@ -113,5 +113,9 @@ export class DataSetEditor extends LitElement {
 
   static styles = css`
     ${styles}
+
+    data-set-element-editor {
+      flex: auto;
+    }
   `;
 }

--- a/src/editors/publisher/data-set-element-editor.ts
+++ b/src/editors/publisher/data-set-element-editor.ts
@@ -18,6 +18,10 @@ import { identity } from '../../foundation.js';
 
 @customElement('data-set-element-editor')
 export class DataSetElementEditor extends LitElement {
+  /** The document being edited as provided to plugins by [[`OpenSCD`]]. */
+  @property({ attribute: false })
+  doc!: XMLDocument;
+  /** The element being edited as provided to plugins by [[`OpenSCD`]]. */
   @property({ attribute: false })
   element!: Element | null;
 
@@ -47,17 +51,21 @@ export class DataSetElementEditor extends LitElement {
       </wizard-textfield>
       <filtered-list
         >${Array.from(this.element!.querySelectorAll('FCDA')).map(fcda => {
-          const [ldInst, prefix, lnClass, lnInst, doName, daName] = [
+          const [ldInst, prefix, lnClass, lnInst, doName, daName, fc] = [
             'ldInst',
             'prefix',
             'lnClass',
             'lnInst',
             'doName',
             'daName',
+            'fc',
           ].map(attributeName => fcda.getAttribute(attributeName) ?? '');
 
           return html`<mwc-list-item selected twoline value="${identity(fcda)}"
-            ><span>${doName + '.' + daName}</span
+            ><span
+              >${doName}${daName
+                ? '.' + daName + ' ' + '[' + fc + ']'
+                : ' ' + '[' + fc + ']'}</span
             ><span slot="secondary"
               >${ldInst + '/' + prefix + lnClass + lnInst}</span
             >
@@ -77,7 +85,10 @@ export class DataSetElementEditor extends LitElement {
       </div>`;
 
     return html`<div class="content">
-      <h2>${translate('publisher.nodataset')}</h2>
+      <h2>
+        <div>DataSet</div>
+        <div class="headersubtitle">${translate('publisher.nodataset')}</div>
+      </h2>
     </div>`;
   }
 

--- a/src/editors/publisher/data-set-element-editor.ts
+++ b/src/editors/publisher/data-set-element-editor.ts
@@ -30,6 +30,42 @@ export class DataSetElementEditor extends LitElement {
     return this.element ? this.element.getAttribute('desc') : 'UNDEFINED';
   }
 
+  private renderContent(): TemplateResult {
+    return html`<wizard-textfield
+        label="name"
+        .maybeValue=${this.name}
+        helper="${translate('scl.name')}"
+        required
+      >
+      </wizard-textfield>
+      <wizard-textfield
+        label="desc"
+        .maybeValue=${this.desc}
+        helper="${translate('scl.desc')}"
+        nullable
+      >
+      </wizard-textfield>
+      <filtered-list
+        >${Array.from(this.element!.querySelectorAll('FCDA')).map(fcda => {
+          const [ldInst, prefix, lnClass, lnInst, doName, daName] = [
+            'ldInst',
+            'prefix',
+            'lnClass',
+            'lnInst',
+            'doName',
+            'daName',
+          ].map(attributeName => fcda.getAttribute(attributeName) ?? '');
+
+          return html`<mwc-list-item selected twoline value="${identity(fcda)}"
+            ><span>${doName + '.' + daName}</span
+            ><span slot="secondary"
+              >${ldInst + '/' + prefix + lnClass + lnInst}</span
+            >
+          </mwc-list-item>`;
+        })}</filtered-list
+      >`;
+  }
+
   render(): TemplateResult {
     if (this.element)
       return html`<div class="content">
@@ -37,42 +73,7 @@ export class DataSetElementEditor extends LitElement {
           <div>DataSet</div>
           <div class="headersubtitle">${identity(this.element)}</div>
         </h2>
-        <wizard-textfield
-          label="name"
-          .maybeValue=${this.name}
-          helper="${translate('scl.name')}"
-          required
-        >
-        </wizard-textfield>
-        <wizard-textfield
-          label="desc"
-          .maybeValue=${this.desc}
-          helper="${translate('scl.desc')}"
-          nullable
-        >
-        </wizard-textfield>
-        <filtered-list
-          >${Array.from(this.element.querySelectorAll('FCDA')).map(fcda => {
-            const [ldInst, prefix, lnClass, lnInst, doName, daName] = [
-              'ldInst',
-              'prefix',
-              'lnClass',
-              'lnInst',
-              'doName',
-              'daName',
-            ].map(attributeName => fcda.getAttribute(attributeName) ?? '');
-
-            return html`<mwc-list-item
-              selected
-              twoline
-              value="${identity(fcda)}"
-              ><span>${doName + '.' + daName}</span
-              ><span slot="secondary"
-                >${ldInst + '/' + prefix + lnClass + lnInst}</span
-              >
-            </mwc-list-item>`;
-          })}</filtered-list
-        >
+        ${this.renderContent()}
       </div>`;
 
     return html`<div class="content">

--- a/src/editors/publisher/foundation.ts
+++ b/src/editors/publisher/foundation.ts
@@ -21,10 +21,6 @@ export const styles = css`
     display: flex;
   }
 
-  data-set-element-editor {
-    width: calc(100% - 6px);
-  }
-
   .listitem.header {
     font-weight: 500;
   }
@@ -35,6 +31,12 @@ export const styles = css`
 
   mwc-button {
     display: none;
+  }
+
+  @media (max-width: 950px) {
+    .elementeditorcontainer {
+      display: block;
+    }
   }
 
   @media (max-width: 599px) {
@@ -52,6 +54,10 @@ export const styles = css`
       z-index: 1;
       box-shadow: 0 8px 10px 1px rgba(0, 0, 0, 0.14),
         0 3px 14px 2px rgba(0, 0, 0, 0.12), 0 5px 5px -3px rgba(0, 0, 0, 0.2);
+    }
+
+    .elementeditorcontainer {
+      display: block;
     }
 
     data-set-element-editor {

--- a/src/editors/publisher/gse-control-editor.ts
+++ b/src/editors/publisher/gse-control-editor.ts
@@ -121,5 +121,9 @@ export class GseControlEditor extends LitElement {
 
   static styles = css`
     ${styles}
+
+    data-set-element-editor {
+      flex: auto;
+    }
   `;
 }

--- a/src/editors/publisher/report-control-editor.ts
+++ b/src/editors/publisher/report-control-editor.ts
@@ -58,12 +58,12 @@ export class ReportControlEditor extends LitElement {
   private renderElementEditorContainer(): TemplateResult {
     if (this.selectedReportControl !== undefined)
       return html`<div class="elementeditorcontainer">
-        <report-control-element-editor
-          .element=${this.selectedReportControl}
-        ></report-control-element-editor>
         <data-set-element-editor
           .element=${this.selectedDataSet!}
         ></data-set-element-editor>
+        <report-control-element-editor
+          .element=${this.selectedReportControl}
+        ></report-control-element-editor>
       </div>`;
 
     return html``;
@@ -142,20 +142,12 @@ export class ReportControlEditor extends LitElement {
       grid-template-columns: repeat(3, 1fr);
     }
 
+    data-set-element-editor {
+      grid-column: 1 / 2;
+    }
+
     report-control-element-editor {
-      grid-column: 1 / 3;
-    }
-
-    report-control-element-editor[filtered] {
-      grid-column: 1 / 4;
-    }
-
-    report-control-element-editor:not([filtered]) ~ data-set-element-editor {
-      grid-column: 3 / 4;
-    }
-
-    report-control-element-editor[filtered] ~ data-set-element-editor {
-      grid-column: 1 / 4;
+      grid-column: 2 / 4;
     }
 
     @media (max-width: 950px) {

--- a/src/editors/publisher/report-control-editor.ts
+++ b/src/editors/publisher/report-control-editor.ts
@@ -16,6 +16,7 @@ import { Button } from '@material/mwc-button';
 import { ListItem } from '@material/mwc-list/mwc-list-item';
 
 import './data-set-element-editor.js';
+import './report-control-element-editor.js';
 import '../../filtered-list.js';
 import { FilteredList } from '../../filtered-list.js';
 
@@ -30,7 +31,9 @@ export class ReportControlEditor extends LitElement {
   doc!: XMLDocument;
 
   @state()
-  selectedReportControl?: Element | null;
+  selectedReportControl?: Element;
+  @state()
+  selectedDataSet?: Element | null;
 
   @query('.selectionlist') selectionList!: FilteredList;
   @query('mwc-button') selectReportControlButton!: Button;
@@ -38,11 +41,15 @@ export class ReportControlEditor extends LitElement {
   private selectReportControl(evt: Event): void {
     const id = ((evt.target as FilteredList).selected as ListItem).value;
     const reportControl = this.doc.querySelector(selector('ReportControl', id));
+    if (!reportControl) return;
 
-    if (reportControl) {
-      this.selectedReportControl = reportControl.parentElement?.querySelector(
-        `DataSet[name="${reportControl.getAttribute('datSet')}"]`
-      );
+    this.selectedReportControl = reportControl;
+
+    if (this.selectedReportControl) {
+      this.selectedDataSet =
+        this.selectedReportControl.parentElement?.querySelector(
+          `DataSet[name="${this.selectedReportControl.getAttribute('datSet')}"]`
+        );
       (evt.target as FilteredList).classList.add('hidden');
       this.selectReportControlButton.classList.remove('hidden');
     }
@@ -51,8 +58,11 @@ export class ReportControlEditor extends LitElement {
   private renderElementEditorContainer(): TemplateResult {
     if (this.selectedReportControl !== undefined)
       return html`<div class="elementeditorcontainer">
-        <data-set-element-editor
+        <report-control-element-editor
           .element=${this.selectedReportControl}
+        ></report-control-element-editor>
+        <data-set-element-editor
+          .element=${this.selectedDataSet!}
         ></data-set-element-editor>
       </div>`;
 
@@ -120,5 +130,38 @@ export class ReportControlEditor extends LitElement {
 
   static styles = css`
     ${styles}
+
+    .elementeditorcontainer {
+      flex: 65%;
+      margin: 4px 8px 4px 4px;
+      background-color: var(--mdc-theme-surface);
+      overflow-y: scroll;
+      display: grid;
+      grid-gap: 12px;
+      padding: 8px 12px 16px;
+      grid-template-columns: repeat(3, 1fr);
+    }
+
+    report-control-element-editor {
+      grid-column: 1 / 3;
+    }
+
+    report-control-element-editor[filtered] {
+      grid-column: 1 / 4;
+    }
+
+    report-control-element-editor:not([filtered]) ~ data-set-element-editor {
+      grid-column: 3 / 4;
+    }
+
+    report-control-element-editor[filtered] ~ data-set-element-editor {
+      grid-column: 1 / 4;
+    }
+
+    @media (max-width: 950px) {
+      .elementeditorcontainer {
+        display: block;
+      }
+    }
   `;
 }

--- a/src/editors/publisher/report-control-editor.ts
+++ b/src/editors/publisher/report-control-editor.ts
@@ -28,7 +28,20 @@ import { styles } from './foundation.js';
 export class ReportControlEditor extends LitElement {
   /** The document being edited as provided to plugins by [[`OpenSCD`]]. */
   @property({ attribute: false })
-  doc!: XMLDocument;
+  set doc(newDoc: XMLDocument) {
+    if (this._doc === newDoc) return;
+
+    this.selectedDataSet = undefined;
+    this.selectedReportControl = undefined;
+
+    this._doc = newDoc;
+
+    this.requestUpdate();
+  }
+  get doc(): XMLDocument {
+    return this._doc;
+  }
+  private _doc!: XMLDocument;
 
   @state()
   selectedReportControl?: Element;
@@ -59,9 +72,11 @@ export class ReportControlEditor extends LitElement {
     if (this.selectedReportControl !== undefined)
       return html`<div class="elementeditorcontainer">
         <data-set-element-editor
+          .doc=${this.doc}
           .element=${this.selectedDataSet!}
         ></data-set-element-editor>
         <report-control-element-editor
+          .doc=${this.doc}
           .element=${this.selectedReportControl}
         ></report-control-element-editor>
       </div>`;

--- a/src/editors/publisher/report-control-element-editor.ts
+++ b/src/editors/publisher/report-control-element-editor.ts
@@ -19,8 +19,6 @@ export class ReportControlElementEditor extends LitElement {
   /** The document being edited as provided to plugins by [[`OpenSCD`]]. */
   @property({ attribute: false })
   element!: Element;
-  @property({ type: Boolean, reflect: true })
-  filtered = true;
 
   private renderOptFieldsContent(): TemplateResult {
     const [
@@ -91,16 +89,12 @@ export class ReportControlElementEditor extends LitElement {
   }
 
   private renderChildElements(): TemplateResult {
-    if (this.filtered) return html``;
-
     return html`<div class="content">
       ${this.renderTrgOpsContent()}${this.renderOptFieldsContent()}
     </div>`;
   }
 
   private renderReportControlContent(): TemplateResult {
-    if (this.filtered) return html``;
-
     const [name, desc, buffered, rptID, indexed, bufTime, intgPd] = [
       'name',
       'desc',
@@ -186,12 +180,6 @@ export class ReportControlElementEditor extends LitElement {
             <div>ReportControl</div>
             <div class="headersubtitle">${identity(this.element)}</div>
           </div>
-          <mwc-icon-button-toggle
-            id="toggleButton"
-            onIcon="keyboard_arrow_up"
-            offIcon="keyboard_arrow_down"
-            @click=${() => (this.filtered = !this.filtered)}
-          ></mwc-icon-button-toggle>
         </h2>
         <div class="parentcontent">
           ${this.renderReportControlContent()}${this.renderChildElements()}
@@ -210,13 +198,13 @@ export class ReportControlElementEditor extends LitElement {
       grid-template-columns: repeat(auto-fit, minmax(316px, auto));
     }
 
+    .content {
+      border-left: thick solid var(--mdc-theme-on-primary);
+    }
+
     .content > * {
       display: block;
       margin: 4px 8px 16px;
-    }
-
-    mwc-icon-button-toggle {
-      position: relative;
     }
 
     h2,

--- a/src/editors/publisher/report-control-element-editor.ts
+++ b/src/editors/publisher/report-control-element-editor.ts
@@ -1,0 +1,243 @@
+import {
+  css,
+  customElement,
+  html,
+  LitElement,
+  property,
+  TemplateResult,
+} from 'lit-element';
+import { translate } from 'lit-translate';
+
+import '../../wizard-textfield.js';
+import '../../wizard-checkbox.js';
+
+import { identity } from '../../foundation.js';
+import { maxLength, patterns } from '../../wizards/foundation/limits.js';
+
+@customElement('report-control-element-editor')
+export class ReportControlElementEditor extends LitElement {
+  /** The document being edited as provided to plugins by [[`OpenSCD`]]. */
+  @property({ attribute: false })
+  element!: Element;
+  @property({ type: Boolean, reflect: true })
+  filtered = true;
+
+  private renderOptFieldsContent(): TemplateResult {
+    const [
+      seqNum,
+      timeStamp,
+      dataSet,
+      reasonCode,
+      dataRef,
+      entryID,
+      configRef,
+      bufOvfl,
+    ] = [
+      'seqNum',
+      'timeStamp',
+      'dataSet',
+      'reasonCode',
+      'dataRef',
+      'entryID',
+      'configRef',
+      'bufOvfl',
+    ].map(
+      attr =>
+        this.element.querySelector('OptFields')?.getAttribute(attr) ?? null
+    );
+
+    return html`<h3>Optional Fields</h3>
+      ${Object.entries({
+        seqNum,
+        timeStamp,
+        dataSet,
+        reasonCode,
+        dataRef,
+        entryID,
+        configRef,
+        bufOvfl,
+      }).map(
+        ([key, value]) =>
+          html`<wizard-checkbox
+            label="${key}"
+            .maybeValue=${value}
+            nullable
+            helper="${translate(`scl.${key}`)}"
+          ></wizard-checkbox>`
+      )}`;
+  }
+
+  private renderTrgOpsContent(): TemplateResult {
+    const [dchg, qchg, dupd, period, gi] = [
+      'dchg',
+      'qchg',
+      'dupd',
+      'period',
+      'gi',
+    ].map(
+      attr => this.element.querySelector('TrgOps')?.getAttribute(attr) ?? null
+    );
+
+    return html` <h3>Trigger Options</h3>
+      ${Object.entries({ dchg, qchg, dupd, period, gi }).map(
+        ([key, value]) =>
+          html`<wizard-checkbox
+            label="${key}"
+            .maybeValue=${value}
+            nullable
+            helper="${translate(`scl.${key}`)}"
+          ></wizard-checkbox>`
+      )}`;
+  }
+
+  private renderChildElements(): TemplateResult {
+    if (this.filtered) return html``;
+
+    return html`<div class="content">
+      ${this.renderTrgOpsContent()}${this.renderOptFieldsContent()}
+    </div>`;
+  }
+
+  private renderReportControlContent(): TemplateResult {
+    if (this.filtered) return html``;
+
+    const [name, desc, buffered, rptID, indexed, bufTime, intgPd] = [
+      'name',
+      'desc',
+      'buffered',
+      'rptID',
+      'indexed',
+      'bufTime',
+      'intgPd',
+    ].map(attr => this.element?.getAttribute(attr));
+    const max =
+      this.element.querySelector('RptEnabled')?.getAttribute('max') ?? null;
+
+    return html`<div class="content">
+      <wizard-textfield
+        label="name"
+        .maybeValue=${name}
+        helper="${translate('scl.name')}"
+        required
+        validationMessage="${translate('textfield.required')}"
+        pattern="${patterns.asciName}"
+        maxLength="${maxLength.cbName}"
+        dialogInitialFocus
+      ></wizard-textfield
+      ><wizard-textfield
+        label="desc"
+        .maybeValue=${desc}
+        nullable
+        helper="${translate('scl.desc')}"
+      ></wizard-textfield
+      ><wizard-checkbox
+        label="buffered"
+        .maybeValue=${buffered}
+        helper="${translate('scl.buffered')}"
+      ></wizard-checkbox
+      ><wizard-textfield
+        label="rptID"
+        .maybeValue=${rptID}
+        nullable
+        required
+        helper="${translate('report.rptID')}"
+      ></wizard-textfield
+      ><wizard-checkbox
+        label="indexed"
+        .maybeValue=${indexed}
+        nullable
+        helper="${translate('scl.indexed')}"
+      ></wizard-checkbox
+      ><wizard-textfield
+        label="max Clients"
+        .maybeValue=${max}
+        helper="${translate('scl.maxReport')}"
+        nullable
+        type="number"
+        suffix="#"
+      ></wizard-textfield
+      ><wizard-textfield
+        label="bufTime"
+        .maybeValue=${bufTime}
+        helper="${translate('scl.bufTime')}"
+        nullable
+        required
+        type="number"
+        min="0"
+        suffix="ms"
+      ></wizard-textfield
+      ><wizard-textfield
+        label="intgPd"
+        .maybeValue=${intgPd}
+        helper="${translate('scl.intgPd')}"
+        nullable
+        required
+        type="number"
+        min="0"
+        suffix="ms"
+      ></wizard-textfield>
+    </div>`;
+  }
+
+  render(): TemplateResult {
+    if (this.element)
+      return html`<h2 style="display: flex;">
+          <div style="flex:auto">
+            <div>ReportControl</div>
+            <div class="headersubtitle">${identity(this.element)}</div>
+          </div>
+          <mwc-icon-button-toggle
+            id="toggleButton"
+            onIcon="keyboard_arrow_up"
+            offIcon="keyboard_arrow_down"
+            @click=${() => (this.filtered = !this.filtered)}
+          ></mwc-icon-button-toggle>
+        </h2>
+        <div class="parentcontent">
+          ${this.renderReportControlContent()}${this.renderChildElements()}
+        </div>`;
+
+    return html`<div class="content">
+      <h2>${translate('publisher.nodataset')}</h2>
+    </div>`;
+  }
+
+  static styles = css`
+    .parentcontent {
+      display: grid;
+      grid-gap: 12px;
+      box-sizing: border-box;
+      grid-template-columns: repeat(auto-fit, minmax(316px, auto));
+    }
+
+    .content > * {
+      display: block;
+      margin: 4px 8px 16px;
+    }
+
+    mwc-icon-button-toggle {
+      position: relative;
+    }
+
+    h2,
+    h3 {
+      color: var(--mdc-theme-on-surface);
+      font-family: 'Roboto', sans-serif;
+      font-weight: 300;
+      margin: 4px 8px 16px;
+      padding-left: 0.3em;
+    }
+
+    .headersubtitle {
+      font-size: 16px;
+      font-weight: 200;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+
+    *[iconTrailing='search'] {
+      --mdc-shape-small: 28px;
+    }
+  `;
+}

--- a/src/editors/publisher/report-control-element-editor.ts
+++ b/src/editors/publisher/report-control-element-editor.ts
@@ -18,6 +18,9 @@ import { maxLength, patterns } from '../../wizards/foundation/limits.js';
 export class ReportControlElementEditor extends LitElement {
   /** The document being edited as provided to plugins by [[`OpenSCD`]]. */
   @property({ attribute: false })
+  doc!: XMLDocument;
+  /** The element being edited as provided to plugins by [[`OpenSCD`]]. */
+  @property({ attribute: false })
   element!: Element;
 
   private renderOptFieldsContent(): TemplateResult {
@@ -226,6 +229,12 @@ export class ReportControlElementEditor extends LitElement {
 
     *[iconTrailing='search'] {
       --mdc-shape-small: 28px;
+    }
+
+    @media (max-width: 950px) {
+      .content {
+        border-left: 0px solid var(--mdc-theme-on-primary);
+      }
     }
   `;
 }

--- a/src/editors/publisher/sampled-value-control-editor.ts
+++ b/src/editors/publisher/sampled-value-control-editor.ts
@@ -125,5 +125,9 @@ export class SampledValueControlEditor extends LitElement {
 
   static styles = css`
     ${styles}
+
+    data-set-element-editor {
+      flex: auto;
+    }
   `;
 }

--- a/test/integration/wizards/reportcontrol-wizarding-editing.test.ts
+++ b/test/integration/wizards/reportcontrol-wizarding-editing.test.ts
@@ -487,7 +487,7 @@ describe('Wizards for SCL element ReportControl', () => {
           `IED[name="IED5"] DataSet[name="${rpControl.getAttribute('datSet')}"]`
         );
         expect(dataSet).to.exist;
-        expect(dataSet!.children).to.have.lengthOf(2);
+        expect(dataSet!.children).to.have.lengthOf(3);
       });
     });
 

--- a/test/testfiles/wizards/reportcontrol.scd
+++ b/test/testfiles/wizards/reportcontrol.scd
@@ -37,378 +37,379 @@
 							<FCDA ldInst="CBSW" prefix="" lnClass="XSWI" lnInst="2" doName="Pos" daName="stVal" fc="ST"/>
 							<FCDA ldInst="CBSW" prefix="" lnClass="XSWI" lnInst="2" doName="Pos" daName="q" fc="ST"/>
 							<FCDA ldInst="CBSW" prefix="" lnClass="XSWI" lnInst="2" doName="OpSlc.dsd" daName="sasd.ads.asd" fc="ST"/>
-						</DataSet>
-						<GSEControl type="GOOSE" appID="0002" fixedOffs="false" confRev="1" name="GCB" datSet="GooseDataSet1">
-						</GSEControl>
-						<ReportControl rptID="reportCb1" confRev="9" buffered="true" bufTime="100" indexed="true" name="ReportCb" datSet="GooseDataSet1">
-							<TrgOps dchg="true" qchg="true" dupd="false" period="false" gi="true"/>
-							<OptFields seqNum="true" timeStamp="true" dataSet="true" reasonCode="true" dataRef="false" entryID="false" configRef="true" bufOvfl="false"/>
-							<RptEnabled max="5">
-								<ClientLN apRef="P1" ldInst="CircuitBreaker_CB1" lnClass="XCBR" lnInst="1" iedName="IED1"/>
-							</RptEnabled>
-						</ReportControl>
-						<SampledValueControl smvID="asdfads" multicast="true" smpRate="80" nofASDU="1" confRev="1" name="MSVCB01" datSet="GooseDataSet1">
-							<SmvOpts/>
-						</SampledValueControl>
-					</LN0>
-					<LN lnClass="LPHD" inst="1" lnType="Dummy.LPHD1"/>
-					<LN lnClass="XCBR" inst="1" lnType="Dummy.XCBR1">
-						<DOI name="Pos">
-							<DAI name="ctlModel">
-								<Val>status-only</Val>
-							</DAI>
-						</DOI>
-					</LN>
-					<LN lnClass="XSWI" inst="1" lnType="Dummy.XSWI1">
-						<DataSet name="dataSet">
+							<FCDA ldInst="CBSW" prefix="" lnClass="XSWI" lnInst="2" doName="Pos" fc="ST"/>
+    					</DataSet>
+    					<GSEControl type="GOOSE" appID="0002" fixedOffs="false" confRev="1" name="GCB" datSet="GooseDataSet1">
+    					</GSEControl>
+    					<ReportControl rptID="reportCb1" confRev="9" buffered="true" bufTime="100" indexed="true" name="ReportCb" datSet="GooseDataSet1">
+    						<TrgOps dchg="true" qchg="true" dupd="false" period="false" gi="true"/>
+    						<OptFields seqNum="true" timeStamp="true" dataSet="true" reasonCode="true" dataRef="false" entryID="false" configRef="true" bufOvfl="false"/>
+    						<RptEnabled max="5">
+    							<ClientLN apRef="P1" ldInst="CircuitBreaker_CB1" lnClass="XCBR" lnInst="1" iedName="IED1"/>
+    						</RptEnabled>
+    					</ReportControl>
+    					<SampledValueControl smvID="asdfads" multicast="true" smpRate="80" nofASDU="1" confRev="1" name="MSVCB01" datSet="GooseDataSet1">
+    						<SmvOpts/>
+    					</SampledValueControl>
+    				</LN0>
+    				<LN lnClass="LPHD" inst="1" lnType="Dummy.LPHD1"/>
+    				<LN lnClass="XCBR" inst="1" lnType="Dummy.XCBR1">
+    					<DOI name="Pos">
+    						<DAI name="ctlModel">
+    							<Val>status-only</Val>
+    						</DAI>
+    					</DOI>
+    				</LN>
+    				<LN lnClass="XSWI" inst="1" lnType="Dummy.XSWI1">
+    					<DataSet name="dataSet">
                             <FCDA ldInst="CBSW" lnClass="XSWI" lnInst="1" doName="Pos" daName="stVal" fc="ST"/>
                             <FCDA ldInst="CBSW" lnClass="XSWI" lnInst="1" doName="Pos" daName="q" fc="ST"/>
                         </DataSet>
-						<ReportControl rptID="IED2/CBSW/XSWI/SwitchGearBRCB" confRev="9" buffered="true" bufTime="100" indexed="true" intgPd="0" name="ReportCb2" datSet="dataSet">
-							<TrgOps dchg="true" qchg="true" dupd="false" period="false" gi="true"/>
-							<OptFields seqNum="true" timeStamp="true" dataSet="true" reasonCode="true" dataRef="false" entryID="false" configRef="true" bufOvfl="false"/>
-						</ReportControl>
-						<DOI name="Pos">
-							<DAI name="ctlModel">
-								<Val>status-only</Val>
-							</DAI>
-						</DOI>
-						<Inputs>
-							<ExtRef iedName="IED1" ldInst="Disconnectors" prefix="DC" lnClass="XSWI" lnInst="1" doName="Pos" daName="stVal"/>
-							<ExtRef iedName="IED1" ldInst="Disconnectors" prefix="DC" lnClass="XSWI" lnInst="1" doName="Pos" daName="q"/>
-						</Inputs>
-					</LN>
-					<LN lnClass="XSWI" inst="2" lnType="Dummy.XSWI1">
-						<DataSet name="dataSet">
-							<FCDA ldInst="CBSW" lnClass="XSWI" lnInst="1" doName="Pos" daName="stVal" fc="ST"/>
-							<FCDA ldInst="CBSW" lnClass="XSWI" lnInst="1" doName="Pos" daName="q" fc="ST"/>
-						</DataSet>
-						<ReportControl rptID="IED2/CBSW/XSWI/SwitchGearBRCB" confRev="9" buffered="true" bufTime="100" indexed="true" intgPd="0" name="ReportCb3" datSet="dataSet">
-							<TrgOps dchg="true" qchg="true" dupd="false" period="false" gi="true"/>
-							<OptFields seqNum="true" timeStamp="true" dataSet="true" reasonCode="true" dataRef="false" entryID="false" configRef="true" bufOvfl="false"/>
-						</ReportControl>
-						<DOI name="Pos">
-							<DAI name="ctlModel">
-								<Val>status-only</Val>
-							</DAI>
-						</DOI>
-					</LN>
-					<LN lnClass="XSWI" inst="3" lnType="Dummy.XSWI1">
-						<DOI name="Pos">
-							<DAI name="ctlModel">
-								<Val>status-only</Val>
-							</DAI>
-						</DOI>
-					</LN>
-					<LN lnClass="GGIO" inst="1" lnType="Dummy.GGIO1"/>
-				</LDevice>
-				<LDevice inst="CircuitBreaker_CB1">
-					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
-					<LN lnClass="XCBR" inst="1" lnType="Dummy.XCBR1">
-						<DOI name="Pos">
-							<DAI name="ctlModel">
-								<Val>status-only</Val>
-							</DAI>
-						</DOI>
-					</LN>
-					<LN lnClass="CSWI" inst="1" lnType="Dummy.CSWIwithoutCtlModel">
-						<DOI name="Pos">
-							<DAI name="ctlModel">
-								<Val>direct-with-enhanced-security</Val>
-							</DAI>
-						</DOI>
-						<Inputs>
-							<ExtRef iedName="IED1" ldInst="CircuitBreaker_CB1" prefix="" lnClass="XCBR" lnInst="1" doName="Pos" daName="stVal"/>
-							<ExtRef iedName="IED1" ldInst="CircuitBreaker_CB1" prefix="" lnClass="XCBR" lnInst="1" doName="Pos" daName="q"/>
-						</Inputs>
-					</LN>
-				</LDevice>
-			</Server>
-		</AccessPoint>
-	</IED>
-	<IED name="IED3" type="DummyIED" manufacturer="DummyManufactorer" configVersion="1" originalSclVersion="2007" originalSclRevision="B" owner="DummyOwner">
-		<Services>
-			<DynAssociation />
-			<GetDirectory />
-			<GetDataObjectDefinition />
-			<DataObjectDirectory />
-			<GetDataSetValue />
-			<SetDataSetValue />
-			<DataSetDirectory />
-			<ConfDataSet modify="false" max="3" />
-			<DynDataSet max="42" />
-			<ReadWrite />
-			<ConfReportControl max="10" />
-			<GetCBValues />
-			<ReportSettings rptID="Dyn" optFields="Dyn" bufTime="Dyn" trgOps="Dyn" intgPd="Dyn" resvTms="true" owner="true" />
-			<GOOSE max="1" />
-			<GSSE max="0" />
-			<ConfLNs fixPrefix="true" fixLnInst="true" />
-		</Services>
-		<AccessPoint name="P1">
-			<Server>
-				<Authentication />
-				<LDevice inst="CBSW">
-					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0">
-						<Private type="dummyType">
-							<esld:FCDA xmlns:esld="http://www.dummyURL.com/dummyNS" ldInst="CBSW" prefix="" lnClass="XSWI" lnInst="2" doName="Pos" daName="stVal" fc="ST"/>
-						</Private>
-						<DataSet name="GooseDataSet1">
-							<FCDA ldInst="CBSW" prefix="" lnClass="XSWI" lnInst="2" doName="Pos" daName="stVal" fc="ST"/>
-							<FCDA ldInst="CBSW" prefix="" lnClass="XSWI" lnInst="2" doName="Pos" daName="q" fc="ST"/>
-							<FCDA ldInst="CBSW" prefix="" lnClass="XSWI" lnInst="2" doName="OpSlc.dsd" daName="sasd.ads.asd" fc="ST"/>
-						</DataSet>
-						<GSEControl type="GOOSE" appID="0002" fixedOffs="false" confRev="1" name="GCB" datSet="GooseDataSet1">
-						</GSEControl>
-						<ReportControl rptID="reportCb1" confRev="9" buffered="true" bufTime="100" indexed="true" name="ReportCb" datSet="GooseDataSet1">
-							<TrgOps dchg="true" qchg="true" dupd="false" period="false" gi="true"/>
-							<OptFields seqNum="true" timeStamp="true" dataSet="true" reasonCode="true" dataRef="false" entryID="false" configRef="true" bufOvfl="false"/>
-							<RptEnabled max="5">
-								<ClientLN apRef="P1" ldInst="CircuitBreaker_CB1" lnClass="XCBR" lnInst="1" iedName="IED1"/>
-							</RptEnabled>
-						</ReportControl>
-						<SampledValueControl smvID="asdfads" multicast="true" smpRate="80" nofASDU="1" confRev="1" name="MSVCB01" datSet="GooseDataSet1">
-							<SmvOpts/>
-						</SampledValueControl>
-					</LN0>
-					<LN lnClass="LPHD" inst="1" lnType="Dummy.LPHD1"/>
-					<LN lnClass="XCBR" inst="1" lnType="Dummy.XCBR1">
-						<DOI name="Pos">
-							<DAI name="ctlModel">
-								<Val>status-only</Val>
-							</DAI>
-						</DOI>
-					</LN>
-					<LN lnClass="XSWI" inst="1" lnType="Dummy.XSWI1">
-						<DataSet name="dataSet">
+    					<ReportControl rptID="IED2/CBSW/XSWI/SwitchGearBRCB" confRev="9" buffered="true" bufTime="100" indexed="true" intgPd="0" name="ReportCb2" datSet="dataSet">
+    						<TrgOps dchg="true" qchg="true" dupd="false" period="false" gi="true"/>
+    						<OptFields seqNum="true" timeStamp="true" dataSet="true" reasonCode="true" dataRef="false" entryID="false" configRef="true" bufOvfl="false"/>
+    					</ReportControl>
+    					<DOI name="Pos">
+    						<DAI name="ctlModel">
+    							<Val>status-only</Val>
+    						</DAI>
+    					</DOI>
+    					<Inputs>
+    						<ExtRef iedName="IED1" ldInst="Disconnectors" prefix="DC" lnClass="XSWI" lnInst="1" doName="Pos" daName="stVal"/>
+    						<ExtRef iedName="IED1" ldInst="Disconnectors" prefix="DC" lnClass="XSWI" lnInst="1" doName="Pos" daName="q"/>
+    					</Inputs>
+    				</LN>
+    				<LN lnClass="XSWI" inst="2" lnType="Dummy.XSWI1">
+    					<DataSet name="dataSet">
+    						<FCDA ldInst="CBSW" lnClass="XSWI" lnInst="1" doName="Pos" daName="stVal" fc="ST"/>
+    						<FCDA ldInst="CBSW" lnClass="XSWI" lnInst="1" doName="Pos" daName="q" fc="ST"/>
+    					</DataSet>
+    					<ReportControl rptID="IED2/CBSW/XSWI/SwitchGearBRCB" confRev="9" buffered="true" bufTime="100" indexed="true" intgPd="0" name="ReportCb3" datSet="dataSet">
+    						<TrgOps dchg="true" qchg="true" dupd="false" period="false" gi="true"/>
+    						<OptFields seqNum="true" timeStamp="true" dataSet="true" reasonCode="true" dataRef="false" entryID="false" configRef="true" bufOvfl="false"/>
+    					</ReportControl>
+    					<DOI name="Pos">
+    						<DAI name="ctlModel">
+    							<Val>status-only</Val>
+    						</DAI>
+    					</DOI>
+    				</LN>
+    				<LN lnClass="XSWI" inst="3" lnType="Dummy.XSWI1">
+    					<DOI name="Pos">
+    						<DAI name="ctlModel">
+    							<Val>status-only</Val>
+    						</DAI>
+    					</DOI>
+    				</LN>
+    				<LN lnClass="GGIO" inst="1" lnType="Dummy.GGIO1"/>
+    			</LDevice>
+    			<LDevice inst="CircuitBreaker_CB1">
+    				<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0"/>
+    				<LN lnClass="XCBR" inst="1" lnType="Dummy.XCBR1">
+    					<DOI name="Pos">
+    						<DAI name="ctlModel">
+    							<Val>status-only</Val>
+    						</DAI>
+    					</DOI>
+    				</LN>
+    				<LN lnClass="CSWI" inst="1" lnType="Dummy.CSWIwithoutCtlModel">
+    					<DOI name="Pos">
+    						<DAI name="ctlModel">
+    							<Val>direct-with-enhanced-security</Val>
+    						</DAI>
+    					</DOI>
+    					<Inputs>
+    						<ExtRef iedName="IED1" ldInst="CircuitBreaker_CB1" prefix="" lnClass="XCBR" lnInst="1" doName="Pos" daName="stVal"/>
+    						<ExtRef iedName="IED1" ldInst="CircuitBreaker_CB1" prefix="" lnClass="XCBR" lnInst="1" doName="Pos" daName="q"/>
+    					</Inputs>
+    				</LN>
+    			</LDevice>
+    		</Server>
+    	</AccessPoint>
+    </IED>
+    <IED name="IED3" type="DummyIED" manufacturer="DummyManufactorer" configVersion="1" originalSclVersion="2007" originalSclRevision="B" owner="DummyOwner">
+    	<Services>
+    		<DynAssociation />
+    		<GetDirectory />
+    		<GetDataObjectDefinition />
+    		<DataObjectDirectory />
+    		<GetDataSetValue />
+    		<SetDataSetValue />
+    		<DataSetDirectory />
+    		<ConfDataSet modify="false" max="3" />
+    		<DynDataSet max="42" />
+    		<ReadWrite />
+    		<ConfReportControl max="10" />
+    		<GetCBValues />
+    		<ReportSettings rptID="Dyn" optFields="Dyn" bufTime="Dyn" trgOps="Dyn" intgPd="Dyn" resvTms="true" owner="true" />
+    		<GOOSE max="1" />
+    		<GSSE max="0" />
+    		<ConfLNs fixPrefix="true" fixLnInst="true" />
+    	</Services>
+    	<AccessPoint name="P1">
+    		<Server>
+    			<Authentication />
+    			<LDevice inst="CBSW">
+    				<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0">
+    					<Private type="dummyType">
+    						<esld:FCDA xmlns:esld="http://www.dummyURL.com/dummyNS" ldInst="CBSW" prefix="" lnClass="XSWI" lnInst="2" doName="Pos" daName="stVal" fc="ST"/>
+    					</Private>
+    					<DataSet name="GooseDataSet1">
+    						<FCDA ldInst="CBSW" prefix="" lnClass="XSWI" lnInst="2" doName="Pos" daName="stVal" fc="ST"/>
+    						<FCDA ldInst="CBSW" prefix="" lnClass="XSWI" lnInst="2" doName="Pos" daName="q" fc="ST"/>
+    						<FCDA ldInst="CBSW" prefix="" lnClass="XSWI" lnInst="2" doName="OpSlc.dsd" daName="sasd.ads.asd" fc="ST"/>
+    					</DataSet>
+    					<GSEControl type="GOOSE" appID="0002" fixedOffs="false" confRev="1" name="GCB" datSet="GooseDataSet1">
+    					</GSEControl>
+    					<ReportControl rptID="reportCb1" confRev="9" buffered="true" bufTime="100" indexed="true" name="ReportCb" datSet="GooseDataSet1">
+    						<TrgOps dchg="true" qchg="true" dupd="false" period="false" gi="true"/>
+    						<OptFields seqNum="true" timeStamp="true" dataSet="true" reasonCode="true" dataRef="false" entryID="false" configRef="true" bufOvfl="false"/>
+    						<RptEnabled max="5">
+    							<ClientLN apRef="P1" ldInst="CircuitBreaker_CB1" lnClass="XCBR" lnInst="1" iedName="IED1"/>
+    						</RptEnabled>
+    					</ReportControl>
+    					<SampledValueControl smvID="asdfads" multicast="true" smpRate="80" nofASDU="1" confRev="1" name="MSVCB01" datSet="GooseDataSet1">
+    						<SmvOpts/>
+    					</SampledValueControl>
+    				</LN0>
+    				<LN lnClass="LPHD" inst="1" lnType="Dummy.LPHD1"/>
+    				<LN lnClass="XCBR" inst="1" lnType="Dummy.XCBR1">
+    					<DOI name="Pos">
+    						<DAI name="ctlModel">
+    							<Val>status-only</Val>
+    						</DAI>
+    					</DOI>
+    				</LN>
+    				<LN lnClass="XSWI" inst="1" lnType="Dummy.XSWI1">
+    					<DataSet name="dataSet">
                             <FCDA ldInst="CBSW" lnClass="XSWI" lnInst="1" doName="Pos" daName="stVal" fc="ST"/>
                             <FCDA ldInst="CBSW" lnClass="XSWI" lnInst="1" doName="Pos" daName="q" fc="ST"/>
                         </DataSet>
-						<ReportControl rptID="IED2/CBSW/XSWI/SwitchGearBRCB" confRev="9" buffered="true" bufTime="100" indexed="true" intgPd="0" name="ReportCb2" datSet="dataSet">
-							<TrgOps dchg="true" qchg="true" dupd="false" period="false" gi="true"/>
-							<OptFields seqNum="true" timeStamp="true" dataSet="true" reasonCode="true" dataRef="false" entryID="false" configRef="true" bufOvfl="false"/>
-						</ReportControl>
-						<DOI name="Pos">
-							<DAI name="ctlModel">
-								<Val>status-only</Val>
-							</DAI>
-						</DOI>
-						<Inputs>
-							<ExtRef iedName="IED1" ldInst="Disconnectors" prefix="DC" lnClass="XSWI" lnInst="1" doName="Pos" daName="stVal"/>
-							<ExtRef iedName="IED1" ldInst="Disconnectors" prefix="DC" lnClass="XSWI" lnInst="1" doName="Pos" daName="q"/>
-						</Inputs>
-					</LN>
-					<LN lnClass="XSWI" inst="3" lnType="Dummy.XSWI1">
-						<DOI name="Pos">
-							<DAI name="ctlModel">
-								<Val>status-only</Val>
-							</DAI>
-						</DOI>
-					</LN>
-					<LN lnClass="GGIO" inst="1" lnType="Dummy.GGIO1"/>
-				</LDevice>
-			</Server>
-		</AccessPoint>
-	</IED>
-	<IED name="IED4" type="DummyIED" manufacturer="DummyManufactorer" configVersion="1" originalSclVersion="2007" originalSclRevision="B" owner="DummyOwner">
-		<Services>
-			<DynAssociation />
-			<GetDirectory />
-			<GetDataObjectDefinition />
-			<DataObjectDirectory />
-			<GetDataSetValue />
-			<SetDataSetValue />
-			<DataSetDirectory />
-			<ConfDataSet modify="false" max="3" />
-			<DynDataSet max="42" />
-			<ReadWrite />
-			<ConfReportControl max="10" />
-			<GetCBValues />
-			<ReportSettings rptID="Dyn" optFields="Dyn" bufTime="Dyn" trgOps="Dyn" intgPd="Dyn" resvTms="true" owner="true" />
-			<GOOSE max="1" />
-			<GSSE max="0" />
-			<ConfLNs fixPrefix="true" fixLnInst="true" />
-		</Services>
-		<AccessPoint name="P1">
-			<Server>
-				<Authentication />
-				<LDevice inst="CBSW">
-					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0">
-						<Private type="dummyType">
-							<esld:FCDA xmlns:esld="http://www.dummyURL.com/dummyNS" ldInst="CBSW" prefix="" lnClass="XSWI" lnInst="2" doName="Pos" daName="stVal" fc="ST"/>
-						</Private>
-					</LN0>
-					<LN lnClass="LPHD" inst="1" lnType="Dummy.LPHD1"/>
-					<LN lnClass="XCBR" inst="1" lnType="Dummy.XCBR1">
-						<DOI name="Pos">
-							<DAI name="ctlModel">
-								<Val>status-only</Val>
-							</DAI>
-						</DOI>
-					</LN>
-					<LN lnClass="XSWI" inst="3" lnType="Dummy.XSWI1">
-						<DOI name="Pos">
-							<DAI name="ctlModel">
-								<Val>status-only</Val>
-							</DAI>
-						</DOI>
-					</LN>
-				</LDevice>
-			</Server>
-		</AccessPoint>
-	</IED>
-	<IED name="IED5" type="DummyIED" manufacturer="DummyManufactorer" configVersion="1" originalSclVersion="2007" originalSclRevision="B" owner="DummyOwner">
-		<Services>
-			<DynAssociation />
-			<GetDirectory />
-			<GetDataObjectDefinition />
-			<DataObjectDirectory />
-			<GetDataSetValue />
-			<SetDataSetValue />
-			<DataSetDirectory />
-			<ConfDataSet modify="false" max="3" />
-			<DynDataSet max="42" />
-			<ReadWrite />
-			<ConfReportControl max="10" />
-			<GetCBValues />
-			<ReportSettings rptID="Dyn" optFields="Dyn" bufTime="Dyn" trgOps="Dyn" intgPd="Dyn" resvTms="true" owner="true" />
-			<GOOSE max="1" />
-			<GSSE max="0" />
-			<ConfLNs fixPrefix="true" fixLnInst="true" />
-		</Services>
-		<AccessPoint name="P1">
-			<Server>
-				<Authentication />
-				<LDevice inst="CBSW">
-					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0">
-						<Private type="dummyType">
-							<esld:FCDA xmlns:esld="http://www.dummyURL.com/dummyNS" ldInst="CBSW" prefix="" lnClass="XSWI" lnInst="2" doName="Pos" daName="stVal" fc="ST"/>
-						</Private>
-					</LN0>
-					<LN lnClass="LPHD" inst="1" lnType="Dummy.LPHD1"/>
-					<LN lnClass="XCBR" inst="1" lnType="Dummy.XCBR1">
-						<DOI name="Pos">
-							<DAI name="ctlModel">
-								<Val>status-only</Val>
-							</DAI>
-						</DOI>
-					</LN>
-					<LN lnClass="XSWI" inst="2" lnType="Dummy.XSWI1">
-						<DOI name="Pos">
-							<DAI name="ctlModel">
-								<Val>status-only</Val>
-							</DAI>
-						</DOI>
-					</LN>
-				</LDevice>
-			</Server>
-		</AccessPoint>
-	</IED>
-	<IED name="IED6" type="DummyIED" manufacturer="DummyManufactorer" configVersion="1" originalSclVersion="2007" originalSclRevision="B" owner="DummyOwner">
-		<Services>
-			<DynAssociation />
-			<GetDirectory />
-			<GetDataObjectDefinition />
-			<DataObjectDirectory />
-			<GetDataSetValue />
-			<SetDataSetValue />
-			<DataSetDirectory />
-			<ConfDataSet modify="false" max="3" />
-			<DynDataSet max="42" />
-			<ReadWrite />
-			<ConfReportControl max="10" />
-			<GetCBValues />
-			<ReportSettings rptID="Dyn" optFields="Dyn" bufTime="Dyn" trgOps="Dyn" intgPd="Dyn" resvTms="true" owner="true" />
-			<GOOSE max="1" />
-			<GSSE max="0" />
-			<ConfLNs fixPrefix="true" fixLnInst="true" />
-		</Services>
-		<AccessPoint name="P1">
-			<Server>
-				<Authentication />
-				<LDevice inst="CBSW">
-					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0">
-						<Private type="dummyType">
-							<esld:FCDA xmlns:esld="http://www.dummyURL.com/dummyNS" ldInst="CBSW" prefix="" lnClass="XSWI" lnInst="2" doName="Pos" daName="stVal" fc="ST"/>
-						</Private>
-						<ReportControl rptID="reportCb1" confRev="9" buffered="true" bufTime="100" indexed="true" name="ReportCb" >
-							<TrgOps dchg="true" qchg="true" dupd="false" period="false" gi="true"/>
-							<OptFields seqNum="true" timeStamp="true" dataSet="true" reasonCode="true" dataRef="false" entryID="false" configRef="true" bufOvfl="false"/>
-						</ReportControl>
-					</LN0>
-					<LN lnClass="LPHD" inst="1" lnType="Dummy.LPHD1"/>
-					<LN lnClass="XCBR" inst="1" lnType="Dummy.XCBR1">
-						<DOI name="Pos">
-							<DAI name="ctlModel">
-								<Val>status-only</Val>
-							</DAI>
-						</DOI>
-					</LN>
-					<LN lnClass="XSWI" inst="2" lnType="Dummy.XSWI1">
-						<DOI name="Pos">
-							<DAI name="ctlModel">
-								<Val>status-only</Val>
-							</DAI>
-						</DOI>
-					</LN>
-				</LDevice>
-			</Server>
-		</AccessPoint>
-	</IED>
-	<IED name="IED7" type="DummyIED" manufacturer="DummyManufactorer" configVersion="1" originalSclVersion="2007" originalSclRevision="B" owner="DummyOwner">
-		<Services>
-			<DynAssociation />
-			<GetDirectory />
-			<GetDataObjectDefinition />
-			<DataObjectDirectory />
-			<GetDataSetValue />
-			<SetDataSetValue />
-			<DataSetDirectory />
-			<ConfDataSet modify="false" max="3" />
-			<DynDataSet max="42" />
-			<ReadWrite />
-			<ConfReportControl max="10" />
-			<GetCBValues />
-			<ReportSettings rptID="Dyn" optFields="Dyn" bufTime="Dyn" trgOps="Dyn" intgPd="Dyn" resvTms="true" owner="true" />
-			<GOOSE max="1" />
-			<GSSE max="0" />
-			<ConfLNs fixPrefix="true" fixLnInst="true" />
-		</Services>
-		<AccessPoint name="P1">
-			<Server>
-				<Authentication />
-				<LDevice inst="CBSW">
-					<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0">
-						<Private type="dummyType">
-							<esld:FCDA xmlns:esld="http://www.dummyURL.com/dummyNS" ldInst="CBSW" prefix="" lnClass="XSWI" lnInst="2" doName="Pos" daName="stVal" fc="ST"/>
-						</Private>
-						<DataSet name="GooseDataSet1">
-							<FCDA ldInst="CBSW" prefix="" lnClass="XSWI" lnInst="2" doName="Pos" daName="stVal" fc="ST"/>
-							<FCDA ldInst="CBSW" prefix="" lnClass="XSWI" lnInst="2" doName="Pos" daName="q" fc="ST"/>
-							<FCDA ldInst="CBSW" prefix="" lnClass="XSWI" lnInst="2" doName="OpSlc.dsd" daName="sasd.ads.asd" fc="ST"/>
-						</DataSet>
-					</LN0>
-					<LN lnClass="LPHD" inst="1" lnType="Dummy.LPHD1"/>
-					<LN lnClass="XCBR" inst="1" lnType="Dummy.XCBR1">
-						<DOI name="Pos">
-							<DAI name="ctlModel">
-								<Val>status-only</Val>
-							</DAI>
-						</DOI>
-					</LN>
-					<LN lnClass="XSWI" inst="2" lnType="Dummy.XSWI1">
-						<DOI name="Pos">
-							<DAI name="ctlModel">
-								<Val>status-only</Val>
-							</DAI>
-						</DOI>
-					</LN>
-				</LDevice>
-			</Server>
-		</AccessPoint>
-	</IED>
-	<DataTypeTemplates>
-		<LNodeType lnClass="LLN0" id="Dummy.LLN0">
+    					<ReportControl rptID="IED2/CBSW/XSWI/SwitchGearBRCB" confRev="9" buffered="true" bufTime="100" indexed="true" intgPd="0" name="ReportCb2" datSet="dataSet">
+    						<TrgOps dchg="true" qchg="true" dupd="false" period="false" gi="true"/>
+    						<OptFields seqNum="true" timeStamp="true" dataSet="true" reasonCode="true" dataRef="false" entryID="false" configRef="true" bufOvfl="false"/>
+    					</ReportControl>
+    					<DOI name="Pos">
+    						<DAI name="ctlModel">
+    							<Val>status-only</Val>
+    						</DAI>
+    					</DOI>
+    					<Inputs>
+    						<ExtRef iedName="IED1" ldInst="Disconnectors" prefix="DC" lnClass="XSWI" lnInst="1" doName="Pos" daName="stVal"/>
+    						<ExtRef iedName="IED1" ldInst="Disconnectors" prefix="DC" lnClass="XSWI" lnInst="1" doName="Pos" daName="q"/>
+    					</Inputs>
+    				</LN>
+    				<LN lnClass="XSWI" inst="3" lnType="Dummy.XSWI1">
+    					<DOI name="Pos">
+    						<DAI name="ctlModel">
+    							<Val>status-only</Val>
+    						</DAI>
+    					</DOI>
+    				</LN>
+    				<LN lnClass="GGIO" inst="1" lnType="Dummy.GGIO1"/>
+    			</LDevice>
+    		</Server>
+    	</AccessPoint>
+    </IED>
+    <IED name="IED4" type="DummyIED" manufacturer="DummyManufactorer" configVersion="1" originalSclVersion="2007" originalSclRevision="B" owner="DummyOwner">
+    	<Services>
+    		<DynAssociation />
+    		<GetDirectory />
+    		<GetDataObjectDefinition />
+    		<DataObjectDirectory />
+    		<GetDataSetValue />
+    		<SetDataSetValue />
+    		<DataSetDirectory />
+    		<ConfDataSet modify="false" max="3" />
+    		<DynDataSet max="42" />
+    		<ReadWrite />
+    		<ConfReportControl max="10" />
+    		<GetCBValues />
+    		<ReportSettings rptID="Dyn" optFields="Dyn" bufTime="Dyn" trgOps="Dyn" intgPd="Dyn" resvTms="true" owner="true" />
+    		<GOOSE max="1" />
+    		<GSSE max="0" />
+    		<ConfLNs fixPrefix="true" fixLnInst="true" />
+    	</Services>
+    	<AccessPoint name="P1">
+    		<Server>
+    			<Authentication />
+    			<LDevice inst="CBSW">
+    				<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0">
+    					<Private type="dummyType">
+    						<esld:FCDA xmlns:esld="http://www.dummyURL.com/dummyNS" ldInst="CBSW" prefix="" lnClass="XSWI" lnInst="2" doName="Pos" daName="stVal" fc="ST"/>
+    					</Private>
+    				</LN0>
+    				<LN lnClass="LPHD" inst="1" lnType="Dummy.LPHD1"/>
+    				<LN lnClass="XCBR" inst="1" lnType="Dummy.XCBR1">
+    					<DOI name="Pos">
+    						<DAI name="ctlModel">
+    							<Val>status-only</Val>
+    						</DAI>
+    					</DOI>
+    				</LN>
+    				<LN lnClass="XSWI" inst="3" lnType="Dummy.XSWI1">
+    					<DOI name="Pos">
+    						<DAI name="ctlModel">
+    							<Val>status-only</Val>
+    						</DAI>
+    					</DOI>
+    				</LN>
+    			</LDevice>
+    		</Server>
+    	</AccessPoint>
+    </IED>
+    <IED name="IED5" type="DummyIED" manufacturer="DummyManufactorer" configVersion="1" originalSclVersion="2007" originalSclRevision="B" owner="DummyOwner">
+    	<Services>
+    		<DynAssociation />
+    		<GetDirectory />
+    		<GetDataObjectDefinition />
+    		<DataObjectDirectory />
+    		<GetDataSetValue />
+    		<SetDataSetValue />
+    		<DataSetDirectory />
+    		<ConfDataSet modify="false" max="3" />
+    		<DynDataSet max="42" />
+    		<ReadWrite />
+    		<ConfReportControl max="10" />
+    		<GetCBValues />
+    		<ReportSettings rptID="Dyn" optFields="Dyn" bufTime="Dyn" trgOps="Dyn" intgPd="Dyn" resvTms="true" owner="true" />
+    		<GOOSE max="1" />
+    		<GSSE max="0" />
+    		<ConfLNs fixPrefix="true" fixLnInst="true" />
+    	</Services>
+    	<AccessPoint name="P1">
+    		<Server>
+    			<Authentication />
+    			<LDevice inst="CBSW">
+    				<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0">
+    					<Private type="dummyType">
+    						<esld:FCDA xmlns:esld="http://www.dummyURL.com/dummyNS" ldInst="CBSW" prefix="" lnClass="XSWI" lnInst="2" doName="Pos" daName="stVal" fc="ST"/>
+    					</Private>
+    				</LN0>
+    				<LN lnClass="LPHD" inst="1" lnType="Dummy.LPHD1"/>
+    				<LN lnClass="XCBR" inst="1" lnType="Dummy.XCBR1">
+    					<DOI name="Pos">
+    						<DAI name="ctlModel">
+    							<Val>status-only</Val>
+    						</DAI>
+    					</DOI>
+    				</LN>
+    				<LN lnClass="XSWI" inst="2" lnType="Dummy.XSWI1">
+    					<DOI name="Pos">
+    						<DAI name="ctlModel">
+    							<Val>status-only</Val>
+    						</DAI>
+    					</DOI>
+    				</LN>
+    			</LDevice>
+    		</Server>
+    	</AccessPoint>
+    </IED>
+    <IED name="IED6" type="DummyIED" manufacturer="DummyManufactorer" configVersion="1" originalSclVersion="2007" originalSclRevision="B" owner="DummyOwner">
+    	<Services>
+    		<DynAssociation />
+    		<GetDirectory />
+    		<GetDataObjectDefinition />
+    		<DataObjectDirectory />
+    		<GetDataSetValue />
+    		<SetDataSetValue />
+    		<DataSetDirectory />
+    		<ConfDataSet modify="false" max="3" />
+    		<DynDataSet max="42" />
+    		<ReadWrite />
+    		<ConfReportControl max="10" />
+    		<GetCBValues />
+    		<ReportSettings rptID="Dyn" optFields="Dyn" bufTime="Dyn" trgOps="Dyn" intgPd="Dyn" resvTms="true" owner="true" />
+    		<GOOSE max="1" />
+    		<GSSE max="0" />
+    		<ConfLNs fixPrefix="true" fixLnInst="true" />
+    	</Services>
+    	<AccessPoint name="P1">
+    		<Server>
+    			<Authentication />
+    			<LDevice inst="CBSW">
+    				<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0">
+    					<Private type="dummyType">
+    						<esld:FCDA xmlns:esld="http://www.dummyURL.com/dummyNS" ldInst="CBSW" prefix="" lnClass="XSWI" lnInst="2" doName="Pos" daName="stVal" fc="ST"/>
+    					</Private>
+    					<ReportControl rptID="reportCb1" confRev="9" buffered="true" bufTime="100" indexed="true" name="ReportCb" >
+    						<TrgOps dchg="true" qchg="true" dupd="false" period="false" gi="true"/>
+    						<OptFields seqNum="true" timeStamp="true" dataSet="true" reasonCode="true" dataRef="false" entryID="false" configRef="true" bufOvfl="false"/>
+    					</ReportControl>
+    				</LN0>
+    				<LN lnClass="LPHD" inst="1" lnType="Dummy.LPHD1"/>
+    				<LN lnClass="XCBR" inst="1" lnType="Dummy.XCBR1">
+    					<DOI name="Pos">
+    						<DAI name="ctlModel">
+    							<Val>status-only</Val>
+    						</DAI>
+    					</DOI>
+    				</LN>
+    				<LN lnClass="XSWI" inst="2" lnType="Dummy.XSWI1">
+    					<DOI name="Pos">
+    						<DAI name="ctlModel">
+    							<Val>status-only</Val>
+    						</DAI>
+    					</DOI>
+    				</LN>
+    			</LDevice>
+    		</Server>
+    	</AccessPoint>
+    </IED>
+    <IED name="IED7" type="DummyIED" manufacturer="DummyManufactorer" configVersion="1" originalSclVersion="2007" originalSclRevision="B" owner="DummyOwner">
+    	<Services>
+    		<DynAssociation />
+    		<GetDirectory />
+    		<GetDataObjectDefinition />
+    		<DataObjectDirectory />
+    		<GetDataSetValue />
+    		<SetDataSetValue />
+    		<DataSetDirectory />
+    		<ConfDataSet modify="false" max="3" />
+    		<DynDataSet max="42" />
+    		<ReadWrite />
+    		<ConfReportControl max="10" />
+    		<GetCBValues />
+    		<ReportSettings rptID="Dyn" optFields="Dyn" bufTime="Dyn" trgOps="Dyn" intgPd="Dyn" resvTms="true" owner="true" />
+    		<GOOSE max="1" />
+    		<GSSE max="0" />
+    		<ConfLNs fixPrefix="true" fixLnInst="true" />
+    	</Services>
+    	<AccessPoint name="P1">
+    		<Server>
+    			<Authentication />
+    			<LDevice inst="CBSW">
+    				<LN0 lnClass="LLN0" inst="" lnType="Dummy.LLN0">
+    					<Private type="dummyType">
+    						<esld:FCDA xmlns:esld="http://www.dummyURL.com/dummyNS" ldInst="CBSW" prefix="" lnClass="XSWI" lnInst="2" doName="Pos" daName="stVal" fc="ST"/>
+    					</Private>
+    					<DataSet name="GooseDataSet1">
+    						<FCDA ldInst="CBSW" prefix="" lnClass="XSWI" lnInst="2" doName="Pos" daName="stVal" fc="ST"/>
+    						<FCDA ldInst="CBSW" prefix="" lnClass="XSWI" lnInst="2" doName="Pos" daName="q" fc="ST"/>
+    						<FCDA ldInst="CBSW" prefix="" lnClass="XSWI" lnInst="2" doName="OpSlc.dsd" daName="sasd.ads.asd" fc="ST"/>
+    					</DataSet>
+    				</LN0>
+    				<LN lnClass="LPHD" inst="1" lnType="Dummy.LPHD1"/>
+    				<LN lnClass="XCBR" inst="1" lnType="Dummy.XCBR1">
+    					<DOI name="Pos">
+    						<DAI name="ctlModel">
+    							<Val>status-only</Val>
+    						</DAI>
+    					</DOI>
+    				</LN>
+    				<LN lnClass="XSWI" inst="2" lnType="Dummy.XSWI1">
+    					<DOI name="Pos">
+    						<DAI name="ctlModel">
+    							<Val>status-only</Val>
+    						</DAI>
+    					</DOI>
+    				</LN>
+    			</LDevice>
+    		</Server>
+    	</AccessPoint>
+    </IED>
+    <DataTypeTemplates>
+    	<LNodeType lnClass="LLN0" id="Dummy.LLN0">
     		<DO name="Mod" type="Dummy.LLN0.Mod" />
     		<DO name="Beh" type="Dummy.LLN0.Beh" />
     		<DO name="Health" type="Dummy.LLN0.Health" />
@@ -662,4 +663,5 @@
     		<EnumVal ord="8">process</EnumVal>
     	</EnumType>
     </DataTypeTemplates>
+
 </SCL>

--- a/test/unit/editors/publisher/__snapshots__/data-set-element-editor.test.snap.js
+++ b/test/unit/editors/publisher/__snapshots__/data-set-element-editor.test.snap.js
@@ -8,7 +8,7 @@ snapshots["Editor for DataSet element with valid DataSet looks like the latest s
       DataSet
     </div>
     <div class="headersubtitle">
-      IED1>>CircuitBreaker_CB1>GooseDataSet1
+      IED2>>CBSW>GooseDataSet1
     </div>
   </h2>
   <wizard-textfield
@@ -32,13 +32,13 @@ snapshots["Editor for DataSet element with valid DataSet looks like the latest s
       selected=""
       tabindex="0"
       twoline=""
-      value="IED1>>CircuitBreaker_CB1>GooseDataSet1>CircuitBreaker_CB1/ XCBR 1.Pos stVal (ST)"
+      value="IED2>>CBSW>GooseDataSet1>CBSW/ XSWI 2.Pos stVal (ST)"
     >
       <span>
-        Pos.stVal
+        Pos.stVal [ST]
       </span>
       <span slot="secondary">
-        CircuitBreaker_CB1/XCBR1
+        CBSW/XSWI2
       </span>
     </mwc-list-item>
     <mwc-list-item
@@ -47,13 +47,13 @@ snapshots["Editor for DataSet element with valid DataSet looks like the latest s
       selected=""
       tabindex="-1"
       twoline=""
-      value="IED1>>CircuitBreaker_CB1>GooseDataSet1>CircuitBreaker_CB1/ XCBR 1.Pos q (ST)"
+      value="IED2>>CBSW>GooseDataSet1>CBSW/ XSWI 2.Pos q (ST)"
     >
       <span>
-        Pos.q
+        Pos.q [ST]
       </span>
       <span slot="secondary">
-        CircuitBreaker_CB1/XCBR1
+        CBSW/XSWI2
       </span>
     </mwc-list-item>
     <mwc-list-item
@@ -62,13 +62,13 @@ snapshots["Editor for DataSet element with valid DataSet looks like the latest s
       selected=""
       tabindex="-1"
       twoline=""
-      value="IED1>>CircuitBreaker_CB1>GooseDataSet1>CircuitBreaker_CB1/ CSWI 1.Pos stVal (ST)"
+      value="IED2>>CBSW>GooseDataSet1>CBSW/ XSWI 2.OpSlc.dsd sasd.ads.asd (ST)"
     >
       <span>
-        Pos.stVal
+        OpSlc.dsd.sasd.ads.asd [ST]
       </span>
       <span slot="secondary">
-        CircuitBreaker_CB1/CSWI1
+        CBSW/XSWI2
       </span>
     </mwc-list-item>
     <mwc-list-item
@@ -77,28 +77,13 @@ snapshots["Editor for DataSet element with valid DataSet looks like the latest s
       selected=""
       tabindex="-1"
       twoline=""
-      value="IED1>>CircuitBreaker_CB1>GooseDataSet1>Disconnectors/DC XSWI 1.Pos stVal (ST)"
+      value="IED2>>CBSW>GooseDataSet1>CBSW/ XSWI 2.Pos  (ST)"
     >
       <span>
-        Pos.stVal
+        Pos [ST]
       </span>
       <span slot="secondary">
-        Disconnectors/DCXSWI1
-      </span>
-    </mwc-list-item>
-    <mwc-list-item
-      aria-disabled="false"
-      mwc-list-item=""
-      selected=""
-      tabindex="-1"
-      twoline=""
-      value="IED1>>CircuitBreaker_CB1>GooseDataSet1>Disconnectors/DC XSWI 1.Pos q (ST)"
-    >
-      <span>
-        Pos.q
-      </span>
-      <span slot="secondary">
-        Disconnectors/DCXSWI1
+        CBSW/XSWI2
       </span>
     </mwc-list-item>
   </filtered-list>
@@ -109,7 +94,12 @@ snapshots["Editor for DataSet element with valid DataSet looks like the latest s
 snapshots["Editor for DataSet element with nulled DataSet looks like the latest snapshot"] = 
 `<div class="content">
   <h2>
-    [publisher.nodataset]
+    <div>
+      DataSet
+    </div>
+    <div class="headersubtitle">
+      [publisher.nodataset]
+    </div>
   </h2>
 </div>
 `;

--- a/test/unit/editors/publisher/__snapshots__/report-control-editor.test.snap.js
+++ b/test/unit/editors/publisher/__snapshots__/report-control-editor.test.snap.js
@@ -221,6 +221,8 @@ snapshots["Editor for ReportControl element with a selected ReportControl looks 
     </li>
   </filtered-list>
   <div class="elementeditorcontainer">
+    <report-control-element-editor filtered="">
+    </report-control-element-editor>
     <data-set-element-editor>
     </data-set-element-editor>
   </div>

--- a/test/unit/editors/publisher/__snapshots__/report-control-editor.test.snap.js
+++ b/test/unit/editors/publisher/__snapshots__/report-control-editor.test.snap.js
@@ -221,10 +221,10 @@ snapshots["Editor for ReportControl element with a selected ReportControl looks 
     </li>
   </filtered-list>
   <div class="elementeditorcontainer">
-    <report-control-element-editor filtered="">
-    </report-control-element-editor>
     <data-set-element-editor>
     </data-set-element-editor>
+    <report-control-element-editor>
+    </report-control-element-editor>
   </div>
 </div>
 `;

--- a/test/unit/editors/publisher/__snapshots__/report-control-element-editor.test.snap.js
+++ b/test/unit/editors/publisher/__snapshots__/report-control-element-editor.test.snap.js
@@ -11,12 +11,6 @@ snapshots["Editor for ReportControl element and its direct children with valid R
       IED2>>CBSW> XSWI 1>ReportCb
     </div>
   </div>
-  <mwc-icon-button-toggle
-    id="toggleButton"
-    officon="keyboard_arrow_down"
-    onicon="keyboard_arrow_up"
-  >
-  </mwc-icon-button-toggle>
 </h2>
 <div class="parentcontent">
   <div class="content">
@@ -173,26 +167,4 @@ snapshots["Editor for ReportControl element and its direct children with valid R
 </div>
 `;
 /* end snapshot Editor for ReportControl element and its direct children with valid ReportControl looks like the latest snapshot */
-
-snapshots["Editor for ReportControl element and its direct children with filtered property set looks like the latest snapshot"] = 
-`<h2 style="display: flex;">
-  <div style="flex:auto">
-    <div>
-      ReportControl
-    </div>
-    <div class="headersubtitle">
-      IED2>>CBSW> XSWI 1>ReportCb
-    </div>
-  </div>
-  <mwc-icon-button-toggle
-    id="toggleButton"
-    officon="keyboard_arrow_down"
-    onicon="keyboard_arrow_up"
-  >
-  </mwc-icon-button-toggle>
-</h2>
-<div class="parentcontent">
-</div>
-`;
-/* end snapshot Editor for ReportControl element and its direct children with filtered property set looks like the latest snapshot */
 

--- a/test/unit/editors/publisher/__snapshots__/report-control-element-editor.test.snap.js
+++ b/test/unit/editors/publisher/__snapshots__/report-control-element-editor.test.snap.js
@@ -1,0 +1,198 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["Editor for ReportControl element and its direct children with valid ReportControl looks like the latest snapshot"] = 
+`<h2 style="display: flex;">
+  <div style="flex:auto">
+    <div>
+      ReportControl
+    </div>
+    <div class="headersubtitle">
+      IED2>>CBSW> XSWI 1>ReportCb
+    </div>
+  </div>
+  <mwc-icon-button-toggle
+    id="toggleButton"
+    officon="keyboard_arrow_down"
+    onicon="keyboard_arrow_up"
+  >
+  </mwc-icon-button-toggle>
+</h2>
+<div class="parentcontent">
+  <div class="content">
+    <wizard-textfield
+      dialoginitialfocus=""
+      helper="[scl.name]"
+      label="name"
+      maxlength="32"
+      pattern="[A-Za-z][0-9,A-Z,a-z_]*"
+      required=""
+      validationmessage="[textfield.required]"
+    >
+    </wizard-textfield>
+    <wizard-textfield
+      disabled=""
+      helper="[scl.desc]"
+      label="desc"
+      nullable=""
+    >
+    </wizard-textfield>
+    <wizard-checkbox
+      helper="[scl.buffered]"
+      label="buffered"
+    >
+    </wizard-checkbox>
+    <wizard-textfield
+      helper="[report.rptID]"
+      label="rptID"
+      nullable=""
+      required=""
+    >
+    </wizard-textfield>
+    <wizard-checkbox
+      helper="[scl.indexed]"
+      label="indexed"
+      nullable=""
+    >
+    </wizard-checkbox>
+    <wizard-textfield
+      helper="[scl.maxReport]"
+      label="max Clients"
+      nullable=""
+      suffix="#"
+      type="number"
+    >
+    </wizard-textfield>
+    <wizard-textfield
+      helper="[scl.bufTime]"
+      label="bufTime"
+      min="0"
+      nullable=""
+      required=""
+      suffix="ms"
+      type="number"
+    >
+    </wizard-textfield>
+    <wizard-textfield
+      helper="[scl.intgPd]"
+      label="intgPd"
+      min="0"
+      nullable=""
+      required=""
+      suffix="ms"
+      type="number"
+    >
+    </wizard-textfield>
+  </div>
+  <div class="content">
+    <h3>
+      Trigger Options
+    </h3>
+    <wizard-checkbox
+      helper="[scl.dchg]"
+      label="dchg"
+      nullable=""
+    >
+    </wizard-checkbox>
+    <wizard-checkbox
+      helper="[scl.qchg]"
+      label="qchg"
+      nullable=""
+    >
+    </wizard-checkbox>
+    <wizard-checkbox
+      helper="[scl.dupd]"
+      label="dupd"
+      nullable=""
+    >
+    </wizard-checkbox>
+    <wizard-checkbox
+      helper="[scl.period]"
+      label="period"
+      nullable=""
+    >
+    </wizard-checkbox>
+    <wizard-checkbox
+      helper="[scl.gi]"
+      label="gi"
+      nullable=""
+    >
+    </wizard-checkbox>
+    <h3>
+      Optional Fields
+    </h3>
+    <wizard-checkbox
+      helper="[scl.seqNum]"
+      label="seqNum"
+      nullable=""
+    >
+    </wizard-checkbox>
+    <wizard-checkbox
+      helper="[scl.timeStamp]"
+      label="timeStamp"
+      nullable=""
+    >
+    </wizard-checkbox>
+    <wizard-checkbox
+      helper="[scl.dataSet]"
+      label="dataSet"
+      nullable=""
+    >
+    </wizard-checkbox>
+    <wizard-checkbox
+      helper="[scl.reasonCode]"
+      label="reasonCode"
+      nullable=""
+    >
+    </wizard-checkbox>
+    <wizard-checkbox
+      helper="[scl.dataRef]"
+      label="dataRef"
+      nullable=""
+    >
+    </wizard-checkbox>
+    <wizard-checkbox
+      helper="[scl.entryID]"
+      label="entryID"
+      nullable=""
+    >
+    </wizard-checkbox>
+    <wizard-checkbox
+      helper="[scl.configRef]"
+      label="configRef"
+      nullable=""
+    >
+    </wizard-checkbox>
+    <wizard-checkbox
+      helper="[scl.bufOvfl]"
+      label="bufOvfl"
+      nullable=""
+    >
+    </wizard-checkbox>
+  </div>
+</div>
+`;
+/* end snapshot Editor for ReportControl element and its direct children with valid ReportControl looks like the latest snapshot */
+
+snapshots["Editor for ReportControl element and its direct children with filtered property set looks like the latest snapshot"] = 
+`<h2 style="display: flex;">
+  <div style="flex:auto">
+    <div>
+      ReportControl
+    </div>
+    <div class="headersubtitle">
+      IED2>>CBSW> XSWI 1>ReportCb
+    </div>
+  </div>
+  <mwc-icon-button-toggle
+    id="toggleButton"
+    officon="keyboard_arrow_down"
+    onicon="keyboard_arrow_up"
+  >
+  </mwc-icon-button-toggle>
+</h2>
+<div class="parentcontent">
+</div>
+`;
+/* end snapshot Editor for ReportControl element and its direct children with filtered property set looks like the latest snapshot */
+

--- a/test/unit/editors/publisher/data-set-element-editor.test.ts
+++ b/test/unit/editors/publisher/data-set-element-editor.test.ts
@@ -8,7 +8,7 @@ describe('Editor for DataSet element', () => {
   let element: DataSetElementEditor;
 
   beforeEach(async () => {
-    doc = await fetch('/test/testfiles/valid2007B4.scd')
+    doc = await fetch('/test/testfiles/wizards/reportcontrol.scd')
       .then(response => response.text())
       .then(str => new DOMParser().parseFromString(str, 'application/xml'));
   });

--- a/test/unit/editors/publisher/report-control-element-editor.test.ts
+++ b/test/unit/editors/publisher/report-control-element-editor.test.ts
@@ -22,25 +22,6 @@ describe('Editor for ReportControl element and its direct children', () => {
           .element=${reportControl}
         ></report-control-element-editor>`
       );
-
-      element.filtered = false;
-      await element.requestUpdate();
-    });
-
-    it('looks like the latest snapshot', async () =>
-      await expect(element).shadowDom.to.equalSnapshot());
-  });
-
-  describe('with filtered property set', () => {
-    beforeEach(async () => {
-      const reportControl = doc.querySelector('ReportControl')!;
-
-      element = await fixture(
-        html`<report-control-element-editor
-          .element=${reportControl}
-          ?filtered=${true}
-        ></report-control-element-editor>`
-      );
     });
 
     it('looks like the latest snapshot', async () =>

--- a/test/unit/editors/publisher/report-control-element-editor.test.ts
+++ b/test/unit/editors/publisher/report-control-element-editor.test.ts
@@ -1,0 +1,49 @@
+import { expect, fixture, html } from '@open-wc/testing';
+
+import '../../../../src/editors/publisher/report-control-element-editor.js';
+import { ReportControlElementEditor } from '../../../../src/editors/publisher/report-control-element-editor.js';
+
+describe('Editor for ReportControl element and its direct children', () => {
+  let doc: XMLDocument;
+  let element: ReportControlElementEditor;
+
+  beforeEach(async () => {
+    doc = await fetch('/test/testfiles/valid2007B4.scd')
+      .then(response => response.text())
+      .then(str => new DOMParser().parseFromString(str, 'application/xml'));
+  });
+
+  describe('with valid ReportControl', () => {
+    beforeEach(async () => {
+      const reportControl = doc.querySelector('ReportControl')!;
+
+      element = await fixture(
+        html`<report-control-element-editor
+          .element=${reportControl}
+        ></report-control-element-editor>`
+      );
+
+      element.filtered = false;
+      await element.requestUpdate();
+    });
+
+    it('looks like the latest snapshot', async () =>
+      await expect(element).shadowDom.to.equalSnapshot());
+  });
+
+  describe('with filtered property set', () => {
+    beforeEach(async () => {
+      const reportControl = doc.querySelector('ReportControl')!;
+
+      element = await fixture(
+        html`<report-control-element-editor
+          .element=${reportControl}
+          ?filtered=${true}
+        ></report-control-element-editor>`
+      );
+    });
+
+    it('looks like the latest snapshot', async () =>
+      await expect(element).shadowDom.to.equalSnapshot());
+  });
+});


### PR DESCRIPTION
This one is adding read-only field showing the settings of a `ReportControl` element and its child elements. Per default it is not displayed to save the room for the data set. I am curious on your take on it. 