### PR TITLE
feat(editors/publisher): add code-editor-dialog

### DIFF
--- a/src/editors/publisher/code-editor-dialog.ts
+++ b/src/editors/publisher/code-editor-dialog.ts
@@ -1,0 +1,103 @@
+import {
+  customElement,
+  css,
+  LitElement,
+  property,
+  TemplateResult,
+  html,
+  query,
+} from 'lit-element';
+import { get, translate } from 'lit-translate';
+
+import 'ace-custom-element';
+import '@material/mwc-dialog';
+import AceEditor from 'ace-custom-element';
+import { Dialog } from '@material/mwc-dialog';
+
+import { Create, Delete, identity, newActionEvent } from '../../foundation.js';
+
+/** A dialog showing editable XML code*/
+@customElement('code-editor-dialog')
+export class CodeEditorDialog extends LitElement {
+  /** The XML element to be edited */
+  @property({ attribute: false })
+  element!: Element;
+  /** Whether the dialog is open */
+  @property({ type: Boolean })
+  open = false;
+
+  @query('mwc-dialog') dialog!: Dialog;
+  @query('ace-editor') aceEditor!: AceEditor;
+
+  codeAction(): void {
+    const text = this.aceEditor.value!;
+    if (!text || !this.element.parentElement) return;
+
+    const desc = {
+      parent: this.element.parentElement,
+      element: this.element,
+      reference: this.element.nextSibling,
+    };
+
+    const del: Delete = {
+      old: desc,
+      checkValidity: () => true,
+    };
+    const cre: Create = {
+      new: {
+        ...desc,
+        element: new DOMParser().parseFromString(text, 'application/xml')
+          .documentElement,
+      },
+      checkValidity: () => true,
+    };
+
+    this.dispatchEvent(
+      newActionEvent({
+        actions: [del, cre],
+        title: get('code.log', {
+          id: identity(this.element),
+        }),
+      })
+    );
+
+    this.dialog.close();
+  }
+
+  render(): TemplateResult {
+    return html`<mwc-dialog
+      heading=${this.element.tagName}
+      ?open=${this.open}
+      @closed=${() => (this.open = false)}
+    >
+      <ace-editor
+        base-path="/public/ace"
+        wrap
+        soft-tabs
+        style="width: 80vw; height: calc(100vh - 240px);"
+        theme="ace/theme/solarized_${localStorage.getItem('theme')}"
+        mode="ace/mode/xml"
+        value="${new XMLSerializer().serializeToString(this.element)}"
+      ></ace-editor>
+      <mwc-button
+        slot="secondaryAction"
+        dialogAction="close"
+        label="${translate('close')}"
+        style="--mdc-theme-primary: var(--mdc-theme-error)"
+      ></mwc-button>
+      <mwc-button
+        slot="primaryAction"
+        @click=${() => this.codeAction()}
+        icon="code"
+        label="${translate('save')}"
+        trailingIcon
+      ></mwc-button>
+    </mwc-dialog>`;
+  }
+
+  static styles = css`
+    mwc-dialog {
+      --mdc-dialog-max-width: 92vw;
+    }
+  `;
+}

--- a/src/editors/publisher/data-set-editor.ts
+++ b/src/editors/publisher/data-set-editor.ts
@@ -29,8 +29,14 @@ export class DataSetEditor extends LitElement {
   set doc(newDoc: XMLDocument) {
     if (this._doc === newDoc) return;
 
-    this.selectedDataSet = undefined;
-    if (this.selectionList && this.selectionList.selected)
+    const newDataSet = this._selectedDataSetId
+      ? newDoc.querySelector(selector('DataSet', this._selectedDataSetId))
+      : null;
+
+    if (newDataSet) this.selectedDataSet = newDataSet;
+    else this.selectedDataSet = undefined;
+
+    if (!newDataSet && this.selectionList && this.selectionList.selected)
       (this.selectionList.selected as ListItem).selected = false;
 
     this._doc = newDoc;
@@ -43,7 +49,17 @@ export class DataSetEditor extends LitElement {
   private _doc!: XMLDocument;
 
   @state()
-  selectedDataSet?: Element;
+  set selectedDataSet(newSelection: Element | undefined) {
+    this._selectedDataSet = newSelection;
+    this._selectedDataSetId = identity(this._selectedDataSet ?? null);
+
+    this.requestUpdate();
+  }
+  get selectedDataSet(): Element | undefined {
+    return this._selectedDataSet;
+  }
+  private _selectedDataSet?: Element;
+  private _selectedDataSetId?: string | number;
 
   @query('.selectionlist') selectionList!: FilteredList;
   @query('mwc-button') selectDataSetButton!: Button;

--- a/src/editors/publisher/data-set-element-editor.ts
+++ b/src/editors/publisher/data-set-element-editor.ts
@@ -4,6 +4,7 @@ import {
   html,
   LitElement,
   property,
+  query,
   state,
   TemplateResult,
 } from 'lit-element';
@@ -13,6 +14,8 @@ import '@material/mwc-list/mwc-list-item';
 
 import '../../wizard-textfield.js';
 import '../../filtered-list.js';
+import './code-editor-dialog.js';
+import { CodeEditorDialog } from './code-editor-dialog.js';
 
 import { identity } from '../../foundation.js';
 
@@ -33,6 +36,8 @@ export class DataSetElementEditor extends LitElement {
   private get desc(): string | null {
     return this.element ? this.element.getAttribute('desc') : 'UNDEFINED';
   }
+
+  @query('code-editor-dialog') codeEditor!: CodeEditorDialog;
 
   private renderContent(): TemplateResult {
     return html`<wizard-textfield
@@ -77,10 +82,18 @@ export class DataSetElementEditor extends LitElement {
   render(): TemplateResult {
     if (this.element)
       return html`<div class="content">
-        <h2>
-          <div>DataSet</div>
-          <div class="headersubtitle">${identity(this.element)}</div>
+        <h2 style="display: flex; flex-direction: row">
+          <div style="flex:auto">
+            <div>DataSet</div>
+            <div class="headersubtitle">${identity(this.element)}</div>
+          </div>
+          <mwc-icon-button
+            style="float:right"
+            icon="code"
+            @click=${() => (this.codeEditor.open = true)}
+          ></mwc-icon-button>
         </h2>
+        <code-editor-dialog .element=${this.element}></code-editor-dialog>
         ${this.renderContent()}
       </div>`;
 

--- a/test/unit/editors/publisher/__snapshots__/data-set-element-editor.test.snap.js
+++ b/test/unit/editors/publisher/__snapshots__/data-set-element-editor.test.snap.js
@@ -3,14 +3,23 @@ export const snapshots = {};
 
 snapshots["Editor for DataSet element with valid DataSet looks like the latest snapshot"] = 
 `<div class="content">
-  <h2>
-    <div>
-      DataSet
+  <h2 style="display: flex; flex-direction: row">
+    <div style="flex:auto">
+      <div>
+        DataSet
+      </div>
+      <div class="headersubtitle">
+        IED2>>CBSW>GooseDataSet1
+      </div>
     </div>
-    <div class="headersubtitle">
-      IED2>>CBSW>GooseDataSet1
-    </div>
+    <mwc-icon-button
+      icon="code"
+      style="float:right"
+    >
+    </mwc-icon-button>
   </h2>
+  <code-editor-dialog>
+  </code-editor-dialog>
   <wizard-textfield
     helper="[scl.name]"
     label="name"


### PR DESCRIPTION
@danyill I was thinking to add a code editor to the publisher on every element as you suggested. That would be a very fast way to allow editing of the elements and would make the editor already quite usable. 

The tricky part here was to re-render properly. There is no clean way to distinguish between doc change on open project or doc change due to an editor action at the moment because in both cases we exchange the doc. So I had to do an assumption:
>When the new doc has an element at the same location in the file, I assume there was a change due an editor action. That means also that when you load an older version of a file that has also the same element (same identity string) then the element stays selected, and the values are updated.

I would love to have your review for this PR a code review as well. Maybe there is a smarter way to implement the pure code editor. 

Tests are still missing. I would do those as soon as I know the principal solution is good enough