### PR TITLE
refactor(editors/publisher): reset selections with missing reference

### DIFF
--- a/src/editors/publisher/data-set-editor.ts
+++ b/src/editors/publisher/data-set-editor.ts
@@ -20,33 +20,33 @@ import '../../filtered-list.js';
 import { FilteredList } from '../../filtered-list.js';
 
 import { compareNames, identity, selector } from '../../foundation.js';
-import { styles } from './foundation.js';
+import { styles, updateElementReference } from './foundation.js';
 
 @customElement('data-set-editor')
 export class DataSetEditor extends LitElement {
   /** The document being edited as provided to plugins by [[`OpenSCD`]]. */
   @property({ attribute: false })
-  set doc(newDoc: XMLDocument) {
-    if (this._doc === newDoc) return;
-
-    this.selectedDataSet = undefined;
-    if (this.selectionList && this.selectionList.selected)
-      (this.selectionList.selected as ListItem).selected = false;
-
-    this._doc = newDoc;
-
-    this.requestUpdate();
-  }
-  get doc(): XMLDocument {
-    return this._doc;
-  }
-  private _doc!: XMLDocument;
+  doc!: XMLDocument;
 
   @state()
   selectedDataSet?: Element;
 
   @query('.selectionlist') selectionList!: FilteredList;
   @query('mwc-button') selectDataSetButton!: Button;
+
+  /** Resets selected GOOSE, if not existing in new doc */
+  update(props: Map<string | number | symbol, unknown>): void {
+    if (props.has('doc') && this.selectedDataSet) {
+      const newDataSet = updateElementReference(this.doc, this.selectedDataSet);
+
+      this.selectedDataSet = newDataSet ?? undefined;
+
+      if (!newDataSet && this.selectionList && this.selectionList.selected)
+        (this.selectionList.selected as ListItem).selected = false;
+    }
+
+    super.update(props);
+  }
 
   private selectDataSet(evt: Event): void {
     const id = ((evt.target as FilteredList).selected as ListItem).value;

--- a/src/editors/publisher/foundation.ts
+++ b/src/editors/publisher/foundation.ts
@@ -1,5 +1,19 @@
 import { css } from 'lit-element';
 
+import { identity, selector } from '../../foundation.js';
+
+export function updateElementReference(
+  newDoc: XMLDocument,
+  oldElement: Element
+): Element | null {
+  if (!oldElement || !oldElement.closest('SCL')) return null;
+
+  const id = identity(oldElement);
+  const newElement = newDoc.querySelector(selector(oldElement.tagName, id));
+
+  return newElement;
+}
+
 export const styles = css`
   .content {
     display: flex;

--- a/test/unit/editors/publisher/data-set-editor.test.ts
+++ b/test/unit/editors/publisher/data-set-editor.test.ts
@@ -2,13 +2,19 @@ import { expect, fixture, html } from '@open-wc/testing';
 
 import '../../../../src/editors/publisher/data-set-editor.js';
 import { DataSetEditor } from '../../../../src/editors/publisher/data-set-editor.js';
+import { cloneTestDoc } from './foundation.test.js';
 
 describe('Editor for DataSet element', () => {
   let doc: XMLDocument;
+  let otherDoc: XMLDocument;
   let element: DataSetEditor;
 
   beforeEach(async () => {
     doc = await fetch('/test/testfiles/valid2007B4.scd')
+      .then(response => response.text())
+      .then(str => new DOMParser().parseFromString(str, 'application/xml'));
+
+    otherDoc = await fetch('/test/testfiles/history.scd')
       .then(response => response.text())
       .then(str => new DOMParser().parseFromString(str, 'application/xml'));
 
@@ -21,6 +27,8 @@ describe('Editor for DataSet element', () => {
     await expect(element).shadowDom.to.equalSnapshot());
 
   describe('with a selected DataSet', () => {
+    let newDoc: XMLDocument;
+
     beforeEach(async () => {
       (
         element.shadowRoot?.querySelector(
@@ -33,5 +41,56 @@ describe('Editor for DataSet element', () => {
 
     it('looks like the latest snapshot', async () =>
       await expect(element).shadowDom.to.equalSnapshot());
+
+    describe('on selected element update', () => {
+      beforeEach(async () => {
+        newDoc = cloneTestDoc(doc);
+        element.doc = newDoc;
+        await element.updateComplete;
+
+        await element.selectionList.requestUpdate();
+      });
+
+      it('does not reset selected Element', async () =>
+        expect(element.selectedDataSet).to.equal(
+          newDoc.querySelector('DataSet')
+        ));
+
+      it('does not reset selection', async () =>
+        expect(element.selectionList.selected).to.not.be.null);
+    });
+
+    describe('on selected element remove', () => {
+      beforeEach(async () => {
+        element.selectedDataSet?.parentElement?.removeChild(
+          element.selectedDataSet
+        );
+        element.doc = cloneTestDoc(doc);
+        await element.updateComplete;
+
+        await element.selectionList.requestUpdate();
+      });
+
+      it('resets selected Element', async () =>
+        expect(element.selectedDataSet).to.be.undefined);
+
+      it('reset selection', async () =>
+        expect(element.selectionList.selected).to.be.null);
+    });
+
+    describe('on new doc loaded', () => {
+      beforeEach(async () => {
+        element.doc = otherDoc;
+        await element.updateComplete;
+
+        await element.selectionList.requestUpdate();
+      });
+
+      it('does not reset selected Element', async () =>
+        expect(element.selectedDataSet).to.be.undefined);
+
+      it('does not reset selection', async () =>
+        expect(element.selectionList.selected).to.be.null);
+    });
   });
 });

--- a/test/unit/editors/publisher/foundation.test.ts
+++ b/test/unit/editors/publisher/foundation.test.ts
@@ -1,0 +1,11 @@
+export function cloneTestDoc(doc: XMLDocument): XMLDocument {
+  const newDoc = document.implementation.createDocument(
+    doc.lookupNamespaceURI(''),
+    doc.documentElement.tagName,
+    doc.doctype
+  );
+
+  newDoc.documentElement.replaceWith(doc.documentElement);
+
+  return newDoc;
+}

--- a/test/unit/editors/publisher/gse-control-editor.test.ts
+++ b/test/unit/editors/publisher/gse-control-editor.test.ts
@@ -2,13 +2,19 @@ import { expect, fixture, html } from '@open-wc/testing';
 
 import '../../../../src/editors/publisher/gse-control-editor.js';
 import { GseControlEditor } from '../../../../src/editors/publisher/gse-control-editor.js';
+import { cloneTestDoc } from './foundation.test.js';
 
 describe('Editor for GSEControl element', () => {
   let doc: XMLDocument;
+  let otherDoc: XMLDocument;
   let element: GseControlEditor;
 
   beforeEach(async () => {
     doc = await fetch('/test/testfiles/valid2007B4.scd')
+      .then(response => response.text())
+      .then(str => new DOMParser().parseFromString(str, 'application/xml'));
+
+    otherDoc = await fetch('/test/testfiles/history.scd')
       .then(response => response.text())
       .then(str => new DOMParser().parseFromString(str, 'application/xml'));
 
@@ -21,6 +27,8 @@ describe('Editor for GSEControl element', () => {
     await expect(element).shadowDom.to.equalSnapshot());
 
   describe('with a selected GSEControl', () => {
+    let newDoc: XMLDocument;
+
     beforeEach(async () => {
       (
         element.shadowRoot?.querySelector(
@@ -33,5 +41,59 @@ describe('Editor for GSEControl element', () => {
 
     it('looks like the latest snapshot', async () =>
       await expect(element).shadowDom.to.equalSnapshot());
+
+    describe('on selected element update', () => {
+      beforeEach(async () => {
+        newDoc = cloneTestDoc(doc);
+        element.doc = newDoc;
+        await element.updateComplete;
+
+        await element.selectionList.requestUpdate();
+      });
+
+      it('does not reset selected Element', async () =>
+        expect(element.selectedGseControl).to.equal(
+          newDoc.querySelector('GSEControl')
+        ));
+
+      it('does not reset selection', async () =>
+        expect(element.selectionList.selected).to.not.be.null);
+    });
+
+    describe('on selected element remove', () => {
+      beforeEach(async () => {
+        element.selectedGseControl?.parentElement?.removeChild(
+          element.selectedGseControl
+        );
+        element.doc = cloneTestDoc(doc);
+        await element.updateComplete;
+
+        await element.selectionList.requestUpdate();
+      });
+
+      it('resets selected Element', async () =>
+        expect(element.selectedGseControl).to.be.undefined);
+
+      it('resets selected Elements DataSet', async () =>
+        expect(element.selectedDataSet).to.be.undefined);
+
+      it('reset selection', async () =>
+        expect(element.selectionList.selected).to.be.null);
+    });
+
+    describe('and other doc property update', () => {
+      beforeEach(async () => {
+        element.doc = otherDoc;
+        await element.requestUpdate();
+
+        await element.selectionList.requestUpdate();
+      });
+
+      it('does not reset selected Element', async () =>
+        expect(element.selectedGseControl).to.be.undefined);
+
+      it('does not reset selection', async () =>
+        expect(element.selectionList.selected).to.be.null);
+    });
   });
 });

--- a/test/unit/editors/publisher/report-control-editor.test.ts
+++ b/test/unit/editors/publisher/report-control-editor.test.ts
@@ -2,13 +2,19 @@ import { expect, fixture, html } from '@open-wc/testing';
 
 import '../../../../src/editors/publisher/report-control-editor.js';
 import { ReportControlEditor } from '../../../../src/editors/publisher/report-control-editor.js';
+import { cloneTestDoc } from './foundation.test.js';
 
 describe('Editor for ReportControl element', () => {
   let doc: XMLDocument;
+  let otherDoc: XMLDocument;
   let element: ReportControlEditor;
 
   beforeEach(async () => {
     doc = await fetch('/test/testfiles/valid2007B4.scd')
+      .then(response => response.text())
+      .then(str => new DOMParser().parseFromString(str, 'application/xml'));
+
+    otherDoc = await fetch('/test/testfiles/history.scd')
       .then(response => response.text())
       .then(str => new DOMParser().parseFromString(str, 'application/xml'));
 
@@ -21,6 +27,8 @@ describe('Editor for ReportControl element', () => {
     await expect(element).shadowDom.to.equalSnapshot());
 
   describe('with a selected ReportControl', () => {
+    let newDoc: XMLDocument;
+
     beforeEach(async () => {
       (
         element.shadowRoot?.querySelector(
@@ -33,5 +41,56 @@ describe('Editor for ReportControl element', () => {
 
     it('looks like the latest snapshot', async () =>
       await expect(element).shadowDom.to.equalSnapshot());
+
+    describe('on selected element update', () => {
+      beforeEach(async () => {
+        newDoc = cloneTestDoc(doc);
+        element.doc = newDoc;
+        await element.updateComplete;
+
+        await element.selectionList.requestUpdate();
+      });
+
+      it('does not reset selected Element', async () =>
+        expect(element.selectedReportControl).to.equal(
+          newDoc.querySelector('ReportControl')
+        ));
+
+      it('does not reset selection', async () =>
+        expect(element.selectionList.selected).to.not.be.null);
+    });
+
+    describe('on selected element remove', () => {
+      beforeEach(async () => {
+        element.selectedReportControl?.parentElement?.removeChild(
+          element.selectedReportControl
+        );
+        element.doc = cloneTestDoc(doc);
+        await element.updateComplete;
+
+        await element.selectionList.requestUpdate();
+      });
+
+      it('resets selected Element', async () =>
+        expect(element.selectedDataSet).to.be.undefined);
+
+      it('reset selection', async () =>
+        expect(element.selectionList.selected).to.be.null);
+    });
+
+    describe('and other doc property update', () => {
+      beforeEach(async () => {
+        element.doc = otherDoc;
+        await element.requestUpdate();
+
+        await element.selectionList.requestUpdate();
+      });
+
+      it('does not reset selected Element', async () =>
+        expect(element.selectedReportControl).to.be.undefined);
+
+      it('does not reset selection', async () =>
+        expect(element.selectionList.selected).to.be.null);
+    });
   });
 });

--- a/test/unit/editors/publisher/sampled-value-control-editor.test.ts
+++ b/test/unit/editors/publisher/sampled-value-control-editor.test.ts
@@ -2,13 +2,19 @@ import { expect, fixture, html } from '@open-wc/testing';
 
 import '../../../../src/editors/publisher/sampled-value-control-editor.js';
 import { SampledValueControlEditor } from '../../../../src/editors/publisher/sampled-value-control-editor.js';
+import { cloneTestDoc } from './foundation.test.js';
 
 describe('Editor for SampledValueControl element', () => {
   let doc: XMLDocument;
+  let otherDoc: XMLDocument;
   let element: SampledValueControlEditor;
 
   beforeEach(async () => {
     doc = await fetch('/test/testfiles/valid2007B4.scd')
+      .then(response => response.text())
+      .then(str => new DOMParser().parseFromString(str, 'application/xml'));
+
+    otherDoc = await fetch('/test/testfiles/history.scd')
       .then(response => response.text())
       .then(str => new DOMParser().parseFromString(str, 'application/xml'));
 
@@ -23,6 +29,8 @@ describe('Editor for SampledValueControl element', () => {
     await expect(element).shadowDom.to.equalSnapshot());
 
   describe('with a selected SampledValueControl', () => {
+    let newDoc: XMLDocument;
+
     beforeEach(async () => {
       (
         element.shadowRoot?.querySelector(
@@ -35,5 +43,56 @@ describe('Editor for SampledValueControl element', () => {
 
     it('looks like the latest snapshot', async () =>
       await expect(element).shadowDom.to.equalSnapshot());
+
+    describe('on selected element update', () => {
+      beforeEach(async () => {
+        newDoc = cloneTestDoc(doc);
+        element.doc = newDoc;
+        await element.updateComplete;
+
+        await element.selectionList.requestUpdate();
+      });
+
+      it('does not reset selected Element', async () =>
+        expect(element.selectedSampledValueControl).to.equal(
+          newDoc.querySelector('SampledValueControl')
+        ));
+
+      it('does not reset selection', async () =>
+        expect(element.selectionList.selected).to.not.be.null);
+    });
+
+    describe('on selected element remove', () => {
+      beforeEach(async () => {
+        element.selectedSampledValueControl?.parentElement?.removeChild(
+          element.selectedSampledValueControl
+        );
+        element.doc = cloneTestDoc(doc);
+        await element.updateComplete;
+
+        await element.selectionList.requestUpdate();
+      });
+
+      it('resets selected Element', async () =>
+        expect(element.selectedSampledValueControl).to.be.undefined);
+
+      it('reset selection', async () =>
+        expect(element.selectionList.selected).to.be.null);
+    });
+
+    describe('and other doc property update', () => {
+      beforeEach(async () => {
+        element.doc = otherDoc;
+        await element.requestUpdate();
+
+        await element.selectionList.requestUpdate();
+      });
+
+      it('does not reset selected Element', async () =>
+        expect(element.selectedSampledValueControl).to.be.undefined);
+
+      it('does not reset selection', async () =>
+        expect(element.selectionList.selected).to.be.null);
+    });
   });
 });


### PR DESCRIPTION
Reset selection on loading doc with missing selected element. E.g. new doc does not have a specific `ReportControl` because doc is a completely new file lead to a reset of the selection in the `report-control-editor`. This also means when loading another doc that contains the same element, the selection is not reset.

@ca-d `hasChanged` cannot be used because within this function this.selected... cannot be set/reset. I decided to us update as this is run through before re-render.