### PR TITLE
feat(foundation/components): add pure UI oscd-dialog

### DIFF
--- a/src/foundation/components/oscd-dialog.ts
+++ b/src/foundation/components/oscd-dialog.ts
@@ -1,0 +1,140 @@
+import {
+  css,
+  customElement,
+  html,
+  LitElement,
+  property,
+  query,
+  TemplateResult,
+} from 'lit-element';
+import { translate } from 'lit-translate';
+
+import '@material/mwc-dialog';
+import '@material/mwc-button';
+import '@material/mwc-icon-button-toggle';
+import { Dialog } from '@material/mwc-dialog';
+
+import 'ace-custom-element';
+
+@customElement('oscd-dialog')
+export class OscdDialog extends LitElement {
+  /** Whether dialog is open */
+  @property({ type: Boolean })
+  open = false;
+
+  /** dialogs header content*/
+  @property({ type: String })
+  heading = '';
+
+  /** callback on primary action button click */
+  @property({ attribute: false })
+  primaryAction?: () => void;
+  /** Label of primary action button */
+  @property({ type: String })
+  primaryLabel?: string;
+  /** Icon of primary action icon */
+  @property({ type: String })
+  primaryIcon?: string;
+
+  /** SCL element to be edited in the code editor */
+  @property({ attribute: false })
+  element?: Element;
+  @property({ attribute: false })
+  codeAction?: () => void;
+
+  @query('mwc-dialog') dialog!: Dialog;
+
+  onClosed(ae: CustomEvent<{ action: string } | null>): void {
+    if (!(ae.target instanceof Dialog && ae.detail?.action)) return;
+    if (ae.detail.action === 'close') this.open = false;
+  }
+
+  render(): TemplateResult {
+    return html`<mwc-dialog
+      heading=${this.heading}
+      ?open=${this.open}
+      @closed=${this.onClosed}
+    >
+      ${this.element
+        ? html`<mwc-icon-button-toggle
+            class="code"
+            onicon="code"
+            officon="code_off"
+            @click=${() => this.requestUpdate()}
+          ></mwc-icon-button-toggle>`
+        : html``}
+      ${this.element
+        ? html`<ace-editor
+            class="code"
+            base-path="/public/ace"
+            wrap
+            soft-tabs
+            style="width: 80vw; height: calc(100vh - 240px);"
+            theme="ace/theme/solarized_${localStorage.getItem('theme')}"
+            mode="ace/mode/xml"
+            value="${new XMLSerializer().serializeToString(this.element)}"
+          ></ace-editor>`
+        : html``}
+      <slot></slot>
+      <mwc-button
+        slot="secondaryAction"
+        dialogAction="close"
+        label="${translate('close')}"
+        style="--mdc-theme-primary: var(--mdc-theme-error)"
+      ></mwc-button
+      >${this.primaryAction && this.primaryLabel
+        ? html`<mwc-button
+            id="primaryActionButton"
+            slot="primaryAction"
+            @click=${this.primaryAction}
+            icon="${this.primaryIcon ?? ''}"
+            label="${this.primaryLabel}"
+            trailingIcon
+          ></mwc-button>`
+        : html``}
+      ${this.element && this.codeAction
+        ? html`<mwc-button
+            id="codeActionButton"
+            slot="primaryAction"
+            @click=${this.codeAction}
+            icon="code"
+            label="${translate('save')}"
+            trailingIcon
+          ></mwc-button>`
+        : html``}</mwc-dialog
+    >`;
+  }
+
+  static styles = css`
+    mwc-dialog {
+      --mdc-dialog-max-width: 92vw;
+    }
+
+    mwc-dialog > mwc-icon-button-toggle.code {
+      position: absolute;
+      top: 8px;
+      right: 14px;
+      color: var(--base00);
+    }
+
+    mwc-icon-button-toggle.code[on] {
+      color: var(--mdc-theme-primary);
+    }
+
+    mwc-icon-button-toggle:not([on]) ~ ace-editor {
+      display: none;
+    }
+
+    mwc-icon-button-toggle:not([on]) ~ #codeActionButton {
+      display: none;
+    }
+
+    mwc-icon-button-toggle[on] ~ ::slotted(*) {
+      display: none;
+    }
+
+    mwc-icon-button-toggle[on] ~ #primaryActionButton {
+      display: none;
+    }
+  `;
+}

--- a/test/unit/foundation/components/__snapshots__/oscd-dialog.test.snap.js
+++ b/test/unit/foundation/components/__snapshots__/oscd-dialog.test.snap.js
@@ -1,0 +1,227 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["user defined dialog web component without primary action defined looks like the latest snapshot"] = 
+`<mwc-dialog heading="">
+  <slot>
+  </slot>
+  <mwc-button
+    dialogaction="close"
+    label="[close]"
+    slot="secondaryAction"
+    style="--mdc-theme-primary: var(--mdc-theme-error)"
+  >
+  </mwc-button>
+</mwc-dialog>
+`;
+/* end snapshot user defined dialog web component without primary action defined looks like the latest snapshot */
+
+snapshots["user defined dialog web component with primary action defined looks like the latest snapshot"] = 
+`<mwc-dialog heading="">
+  <slot>
+  </slot>
+  <mwc-button
+    dialogaction="close"
+    label="[close]"
+    slot="secondaryAction"
+    style="--mdc-theme-primary: var(--mdc-theme-error)"
+  >
+  </mwc-button>
+  <mwc-button
+    icon="save"
+    id="primaryActionButton"
+    label="label"
+    slot="primaryAction"
+    trailingicon=""
+  >
+  </mwc-button>
+</mwc-dialog>
+`;
+/* end snapshot user defined dialog web component with primary action defined looks like the latest snapshot */
+
+snapshots["user defined dialog web component with element property set looks like the latest snapshot"] = 
+`<mwc-dialog heading="">
+  <mwc-icon-button-toggle
+    class="code"
+    officon="code_off"
+    onicon="code"
+  >
+  </mwc-icon-button-toggle>
+  <ace-editor
+    base-path="/public/ace"
+    class="code"
+    mode="ace/mode/xml"
+    soft-tabs=""
+    style="width: 80vw; height: calc(100vh - 240px);"
+    theme="ace/theme/solarized_null"
+    value="<testelement><parsererror xmlns=&quot;http://www.w3.org/1999/xhtml&quot; style=&quot;display: block; white-space: pre; border: 2px solid #c77; padding: 0 1em 0 1em; margin: 1em; background-color: #fdd; color: black&quot;><h3>This page contains the following errors:</h3><div style=&quot;font-family:monospace;font-size:12px&quot;>error on line 1 at column 50: Extra content at the end of the document
+</div><h3>Below is a rendering of the page up to the first error.</h3></parsererror><testchild/><testelement/></testelement>"
+    wrap=""
+  >
+  </ace-editor>
+  <slot>
+  </slot>
+  <mwc-button
+    dialogaction="close"
+    label="[close]"
+    slot="secondaryAction"
+    style="--mdc-theme-primary: var(--mdc-theme-error)"
+  >
+  </mwc-button>
+</mwc-dialog>
+`;
+/* end snapshot user defined dialog web component with element property set looks like the latest snapshot */
+
+snapshots["user defined dialog web component with code action set and element property set looks like the latest snapshot"] = 
+`<mwc-dialog heading="">
+  <mwc-icon-button-toggle
+    class="code"
+    officon="code_off"
+    onicon="code"
+  >
+  </mwc-icon-button-toggle>
+  <ace-editor
+    base-path="/public/ace"
+    class="code"
+    mode="ace/mode/xml"
+    soft-tabs=""
+    style="width: 80vw; height: calc(100vh - 240px);"
+    theme="ace/theme/solarized_null"
+    value="<testelement><parsererror xmlns=&quot;http://www.w3.org/1999/xhtml&quot; style=&quot;display: block; white-space: pre; border: 2px solid #c77; padding: 0 1em 0 1em; margin: 1em; background-color: #fdd; color: black&quot;><h3>This page contains the following errors:</h3><div style=&quot;font-family:monospace;font-size:12px&quot;>error on line 1 at column 50: Extra content at the end of the document
+</div><h3>Below is a rendering of the page up to the first error.</h3></parsererror><testchild/><testelement/></testelement>"
+    wrap=""
+  >
+  </ace-editor>
+  <slot>
+  </slot>
+  <mwc-button
+    dialogaction="close"
+    label="[close]"
+    slot="secondaryAction"
+    style="--mdc-theme-primary: var(--mdc-theme-error)"
+  >
+  </mwc-button>
+  <mwc-button
+    icon="code"
+    id="codeActionButton"
+    label="[save]"
+    slot="primaryAction"
+    trailingicon=""
+  >
+  </mwc-button>
+</mwc-dialog>
+`;
+/* end snapshot user defined dialog web component with code action set and element property set looks like the latest snapshot */
+
+snapshots["user definable dialog web component without primary action defined looks like the latest snapshot"] = 
+`<mwc-dialog heading="">
+  <slot>
+  </slot>
+  <mwc-button
+    dialogaction="close"
+    label="[close]"
+    slot="secondaryAction"
+    style="--mdc-theme-primary: var(--mdc-theme-error)"
+  >
+  </mwc-button>
+</mwc-dialog>
+`;
+/* end snapshot user definable dialog web component without primary action defined looks like the latest snapshot */
+
+snapshots["user definable dialog web component with primary action defined looks like the latest snapshot"] = 
+`<mwc-dialog heading="">
+  <slot>
+  </slot>
+  <mwc-button
+    dialogaction="close"
+    label="[close]"
+    slot="secondaryAction"
+    style="--mdc-theme-primary: var(--mdc-theme-error)"
+  >
+  </mwc-button>
+  <mwc-button
+    icon="save"
+    id="primaryActionButton"
+    label="label"
+    slot="primaryAction"
+    trailingicon=""
+  >
+  </mwc-button>
+</mwc-dialog>
+`;
+/* end snapshot user definable dialog web component with primary action defined looks like the latest snapshot */
+
+snapshots["user definable dialog web component with element property set looks like the latest snapshot"] = 
+`<mwc-dialog heading="">
+  <mwc-icon-button-toggle
+    class="code"
+    officon="code_off"
+    onicon="code"
+  >
+  </mwc-icon-button-toggle>
+  <ace-editor
+    base-path="/public/ace"
+    class="code"
+    mode="ace/mode/xml"
+    soft-tabs=""
+    style="width: 80vw; height: calc(100vh - 240px);"
+    theme="ace/theme/solarized_null"
+    value="<testelement><parsererror xmlns=&quot;http://www.w3.org/1999/xhtml&quot; style=&quot;display: block; white-space: pre; border: 2px solid #c77; padding: 0 1em 0 1em; margin: 1em; background-color: #fdd; color: black&quot;><h3>This page contains the following errors:</h3><div style=&quot;font-family:monospace;font-size:12px&quot;>error on line 1 at column 50: Extra content at the end of the document
+</div><h3>Below is a rendering of the page up to the first error.</h3></parsererror><testchild/><testelement/></testelement>"
+    wrap=""
+  >
+  </ace-editor>
+  <slot>
+  </slot>
+  <mwc-button
+    dialogaction="close"
+    label="[close]"
+    slot="secondaryAction"
+    style="--mdc-theme-primary: var(--mdc-theme-error)"
+  >
+  </mwc-button>
+</mwc-dialog>
+`;
+/* end snapshot user definable dialog web component with element property set looks like the latest snapshot */
+
+snapshots["user definable dialog web component with code action set and element property set looks like the latest snapshot"] = 
+`<mwc-dialog heading="">
+  <mwc-icon-button-toggle
+    class="code"
+    officon="code_off"
+    onicon="code"
+  >
+  </mwc-icon-button-toggle>
+  <ace-editor
+    base-path="/public/ace"
+    class="code"
+    mode="ace/mode/xml"
+    soft-tabs=""
+    style="width: 80vw; height: calc(100vh - 240px);"
+    theme="ace/theme/solarized_null"
+    value="<testelement><parsererror xmlns=&quot;http://www.w3.org/1999/xhtml&quot; style=&quot;display: block; white-space: pre; border: 2px solid #c77; padding: 0 1em 0 1em; margin: 1em; background-color: #fdd; color: black&quot;><h3>This page contains the following errors:</h3><div style=&quot;font-family:monospace;font-size:12px&quot;>error on line 1 at column 50: Extra content at the end of the document
+</div><h3>Below is a rendering of the page up to the first error.</h3></parsererror><testchild/><testelement/></testelement>"
+    wrap=""
+  >
+  </ace-editor>
+  <slot>
+  </slot>
+  <mwc-button
+    dialogaction="close"
+    label="[close]"
+    slot="secondaryAction"
+    style="--mdc-theme-primary: var(--mdc-theme-error)"
+  >
+  </mwc-button>
+  <mwc-button
+    icon="code"
+    id="codeActionButton"
+    label="[save]"
+    slot="primaryAction"
+    trailingicon=""
+  >
+  </mwc-button>
+</mwc-dialog>
+`;
+/* end snapshot user definable dialog web component with code action set and element property set looks like the latest snapshot */
+

--- a/test/unit/foundation/components/oscd-dialog.test.ts
+++ b/test/unit/foundation/components/oscd-dialog.test.ts
@@ -1,0 +1,118 @@
+import { expect, fixture, html } from '@open-wc/testing';
+import { SinonSpy, spy } from 'sinon';
+
+import '../../../../src/foundation/components/oscd-dialog.js';
+import { OscdDialog } from '../../../../src/foundation/components/oscd-dialog.js';
+
+describe('user definable dialog web component', () => {
+  let element: OscdDialog;
+  let xmlElement: Element;
+
+  beforeEach(async () => {
+    element = await fixture(html`<oscd-dialog
+      ><wizard-textfield label="someLabel" value="someValue"></wizard-textfield
+    ></oscd-dialog>`);
+
+    xmlElement = new DOMParser().parseFromString(
+      '<testelement><testchild></testchild><testelement>',
+      'application/xml'
+    ).documentElement;
+  });
+
+  describe('without primary action defined', () => {
+    it('looks like the latest snapshot', async () =>
+      await expect(element).shadowDom.equalSnapshot());
+
+    it('has no primary action button', () =>
+      expect(
+        element.shadowRoot?.querySelector('mwc-button[slot="primaryAction"]')
+      ).to.not.exist);
+  });
+
+  describe('with primary action defined', () => {
+    let primaryActionSpy: SinonSpy;
+    let primaryAction: () => void;
+
+    beforeEach(async () => {
+      primaryAction = () => {
+        return;
+      };
+      primaryActionSpy = spy(primaryAction);
+
+      element.primaryAction = primaryActionSpy;
+      element.primaryLabel = 'label';
+      element.primaryIcon = 'save';
+    });
+
+    it('looks like the latest snapshot', async () =>
+      await expect(element).shadowDom.equalSnapshot());
+
+    describe('on primary action button click', () => {
+      beforeEach(() => {
+        (
+          element.shadowRoot?.querySelector(
+            'mwc-button[slot="primaryAction"]'
+          ) as HTMLElement
+        ).click();
+      });
+
+      it('triggers the primary action', () =>
+        expect(primaryActionSpy).to.have.been.calledOnce);
+    });
+  });
+
+  describe('with element property set', () => {
+    beforeEach(async () => {
+      element.element = xmlElement;
+      await element.requestUpdate();
+    });
+
+    it('looks like the latest snapshot', async () =>
+      await expect(element).shadowDom.equalSnapshot());
+  });
+
+  describe('with code action set', () => {
+    let codeActionSpy: SinonSpy;
+    let codeAction: () => void;
+
+    beforeEach(async () => {
+      codeAction = () => {
+        return;
+      };
+      codeActionSpy = spy(codeAction);
+      element.codeAction = codeActionSpy;
+
+      await element.requestUpdate();
+    });
+
+    describe('and element property set', () => {
+      beforeEach(async () => {
+        element.element = xmlElement;
+        await element.requestUpdate();
+      });
+
+      it('looks like the latest snapshot', async () =>
+        await expect(element).shadowDom.equalSnapshot());
+
+      describe('on code action button click', () => {
+        beforeEach(() => {
+          (
+            element.shadowRoot?.querySelector(
+              'mwc-button[slot="primaryAction"]'
+            ) as HTMLElement
+          ).click();
+        });
+
+        it('triggers the primary action', () =>
+          expect(codeActionSpy).to.have.been.calledOnce);
+      });
+    });
+
+    describe('with element property NOT set', () => {
+      it('does not render code action button', () =>
+        expect(
+          element.shadowRoot.querySelector('mwc-button[id="codeActionButton"]')
+        ).to.not.exist);
+    });
+  });
+});


### PR DESCRIPTION
For the merge with `open-scd-core` the API that opens a `wiazrd-dialog` will be available for standard SCL elements are defined in IEC 61850-6. We have however a lot of case where `wizard-dialog` is used for other purposes as well. I therefore invested some time to create a web component that copies some `wizard-dialog` behavior to allow a quicker refactor in the future. 

This is what the component can do for you:
1. Automatically renders primary action button when primary action is defined
2. Always renders secondary action `Close` button
3. Allow to define an element to show in a code editor. Allow to toggle between code editor and the dialog.
4. You can define your own code action. I do not want mix this pure UI element with any functionality. But we can of course define the function used in `wizard-dialog` somewhere in the foundations and reuse it.
5. Allows to slot any elements into the dialog you want. 

This is what it cannot to compared to `wizard-dialog`
1. Closing and opening of the dialog is the user's obligation now. There is no mechanism to watch when which dialog is opened. So if you want to have multiple dialogs to opened in a sequence, you have to add as many `oscd-dialog`s you need and open/close those in a specific order you need.
2. `oscd-dialog` other than `wizard-dialog` consist only of one page only. You cannot define a multi pages dialog, where the dialog handles the jumps to the next and/or the previous page. 
3. There is not checking of validity of the inputs. So when clicking in primary action, the dialog will be closed even on invalid inputs. 


The component is not ready to use yet!! I wanted to have your opinion on the feature set it has to have before proceeding.
 - Point 1:  I cannot think of a way to add 1 with the way `oscd-dailog` is implemented as a pure UI component. Do you?
 - Point 2: Do we really need that. From looking through the code I have not seen it be used other than `LNode`, `GSEControl`, `Report` and `SampledValuesControl` and those are going to be covered by `open-scd-core` wizard library
 - Point 3: Do we need that? I think yes, but am not sure at all here.


Please have a look at the tests, if you want to see how the web.component can be used.
