### PR TITLE
Add activatable to subscriber filtered lists

### DIFF
--- a/src/editors/subscription/goose/goose-list.ts
+++ b/src/editors/subscription/goose/goose-list.ts
@@ -90,7 +90,7 @@ export class GooseList extends LitElement {
   render(): TemplateResult {
     return html` <section tabindex="0">
       <h1>${translate('subscription.goose.publisherGoose.title')}</h1>
-      <filtered-list>
+      <filtered-list activatable>
         ${getOrderedIeds(this.doc).map(
           ied =>
             html`

--- a/src/editors/subscription/ied-list.ts
+++ b/src/editors/subscription/ied-list.ts
@@ -40,7 +40,7 @@ export class IedList extends LitElement {
   render(): TemplateResult {
     return html` <section tabindex="0">
       <h1>${translate('subscription.iedList.title')}</h1>
-      <filtered-list>
+      <filtered-list activatable>
         ${getOrderedIeds(this.doc).map(
           ied =>
             html`

--- a/src/editors/subscription/later-binding/fcda-later-binding-list.ts
+++ b/src/editors/subscription/later-binding/fcda-later-binding-list.ts
@@ -146,7 +146,7 @@ export class FCDALaterBindingList extends LitElement {
                 `subscription.laterBinding.${this.controlTag}.controlBlockList.title`
               )}
             </h1>
-            <filtered-list>
+            <filtered-list activatable>
               ${controlElements.map(controlElement => {
                 const fcdaElements = this.getFcdaElements(controlElement);
                 return html`

--- a/src/editors/subscription/sampledvalues/smv-list.ts
+++ b/src/editors/subscription/sampledvalues/smv-list.ts
@@ -86,7 +86,7 @@ export class SmvPublisherList extends LitElement {
   render(): TemplateResult {
     return html` <section tabindex="0">
       <h1>${translate('subscription.smv.publisherSmv.title')}</h1>
-      <filtered-list>
+      <filtered-list activatable>
         ${getOrderedIeds(this.doc).map(
           ied =>
             html`

--- a/test/integration/editors/__snapshots__/GooseControlSubscription.test.snap.js
+++ b/test/integration/editors/__snapshots__/GooseControlSubscription.test.snap.js
@@ -708,7 +708,7 @@ snapshots["GOOSE subscriber plugin in Subscriber view per default the right hand
   <h1>
     [subscription.iedList.title]
   </h1>
-  <filtered-list>
+  <filtered-list activatable="">
     <mwc-list-item
       aria-disabled="false"
       graphic="icon"
@@ -1209,7 +1209,7 @@ snapshots["GOOSE subscriber plugin in Publisher view per default the right hand 
   <h1>
     [subscription.goose.publisherGoose.title]
   </h1>
-  <filtered-list>
+  <filtered-list activatable="">
     <mwc-list-item
       aria-disabled="false"
       graphic="icon"

--- a/test/integration/editors/__snapshots__/SampledValuesSubscription.test.snap.js
+++ b/test/integration/editors/__snapshots__/SampledValuesSubscription.test.snap.js
@@ -37,7 +37,7 @@ snapshots["Sampled Values Plugin in Publisher view initially the Sampled Values 
   <h1>
     [subscription.smv.publisherSmv.title]
   </h1>
-  <filtered-list>
+  <filtered-list activatable="">
     <mwc-list-item
       aria-disabled="false"
       graphic="icon"
@@ -633,7 +633,7 @@ snapshots["Sampled Values Plugin in Subscriber view initially the IED list looks
   <h1>
     [subscription.iedList.title]
   </h1>
-  <filtered-list>
+  <filtered-list activatable="">
     <mwc-list-item
       aria-disabled="false"
       graphic="icon"

--- a/test/unit/editors/subscription/__snapshots__/ied-list.test.snap.js
+++ b/test/unit/editors/subscription/__snapshots__/ied-list.test.snap.js
@@ -6,7 +6,7 @@ snapshots["ied-list looks like the latest snapshot with a document loaded"] =
   <h1>
     [subscription.iedList.title]
   </h1>
-  <filtered-list>
+  <filtered-list activatable="">
     <mwc-list-item
       aria-disabled="false"
       graphic="icon"
@@ -56,7 +56,7 @@ snapshots["ied-list looks like the latest snapshot without a doc loaded"] =
   <h1>
     [subscription.iedList.title]
   </h1>
-  <filtered-list>
+  <filtered-list activatable="">
   </filtered-list>
 </section>
 `;

--- a/test/unit/editors/subscription/goose/__snapshots__/goose-list.test.snap.js
+++ b/test/unit/editors/subscription/goose/__snapshots__/goose-list.test.snap.js
@@ -6,7 +6,7 @@ snapshots["goose-list looks like the latest snapshot with a document loaded"] =
   <h1>
     [subscription.goose.publisherGoose.title]
   </h1>
-  <filtered-list>
+  <filtered-list activatable="">
     <mwc-list-item
       aria-disabled="false"
       graphic="icon"
@@ -134,7 +134,7 @@ snapshots["goose-list looks like the latest snapshot without a doc loaded"] =
   <h1>
     [subscription.goose.publisherGoose.title]
   </h1>
-  <filtered-list>
+  <filtered-list activatable="">
   </filtered-list>
 </section>
 `;

--- a/test/unit/editors/subscription/later-binding/__snapshots__/fcda-later-binding-list.test.snap.js
+++ b/test/unit/editors/subscription/later-binding/__snapshots__/fcda-later-binding-list.test.snap.js
@@ -15,7 +15,7 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
   <h1>
     [subscription.laterBinding.SampledValueControl.controlBlockList.title]
   </h1>
-  <filtered-list>
+  <filtered-list activatable="">
     <mwc-list-item
       aria-disabled="false"
       graphic="icon"
@@ -617,7 +617,7 @@ snapshots["fcda-list with a GSEControl doc loaded looks like the latest snapshot
   <h1>
     [subscription.laterBinding.GSEControl.controlBlockList.title]
   </h1>
-  <filtered-list>
+  <filtered-list activatable="">
     <mwc-list-item
       aria-disabled="false"
       graphic="icon"

--- a/test/unit/editors/subscription/sampledvalues/__snapshots__/smv-list.test.snap.js
+++ b/test/unit/editors/subscription/sampledvalues/__snapshots__/smv-list.test.snap.js
@@ -6,7 +6,7 @@ snapshots["smv-list looks like the latest snapshot with a document loaded"] =
   <h1>
     [subscription.smv.publisherSmv.title]
   </h1>
-  <filtered-list>
+  <filtered-list activatable="">
     <mwc-list-item
       aria-disabled="false"
       graphic="icon"
@@ -94,7 +94,7 @@ snapshots["smv-list looks like the latest snapshot without a doc loaded"] =
   <h1>
     [subscription.smv.publisherSmv.title]
   </h1>
-  <filtered-list>
+  <filtered-list activatable="">
   </filtered-list>
 </section>
 `;


### PR DESCRIPTION
This adds "activatable" to the filtered lists used in subscribers as suggested in #958. When we click on the RHS we should not lose the selection on the LHS.

However, this exacerbates the restoration of the RHS pane issue where if either opening a new file or going to a different editor and returning the RHS pane may be either incorrect (for a new file without the same element) or the selection on the left is not shown.

I think Jakob did something in the Publisher plugin for this and I must look at this more deeply. We cannot readily save state for each editor at the moment I think such that one can flick between editors without losing selections. Does that mean the RHS panel should be made "empty" i.e. deselected whenever entering the editors?


