### PR TITLE
Add count of FCDA used in ExtRefs, part of #958

### DIFF
--- a/src/editors/subscription/later-binding/ext-ref-later-binding-list.ts
+++ b/src/editors/subscription/later-binding/ext-ref-later-binding-list.ts
@@ -12,16 +12,18 @@ import { translate } from 'lit-translate';
 
 import {
   cloneElement,
-  compareNames,
   getDescriptionAttribute,
   identity,
   newActionEvent,
   Replace,
-  getSclSchemaVersion,
 } from '../../../foundation.js';
 
-import { serviceTypes, styles, updateExtRefElement } from '../foundation.js';
-import { FcdaSelectEvent } from './foundation.js';
+import { styles, updateExtRefElement } from '../foundation.js';
+import {
+  FcdaSelectEvent,
+  getExtRefElements,
+  getSubscribedExtRefElements
+} from './foundation.js';
 
 /**
  * A sub element for showing all Ext Refs from a FCDA Element.
@@ -51,31 +53,8 @@ export class ExtRefLaterBindingList extends LitElement {
     }
   }
 
-  private getExtRefElements(): Element[] {
-    if (this.doc) {
-      return Array.from(this.doc.querySelectorAll('ExtRef'))
-        .filter(element => element.hasAttribute('intAddr'))
-        .filter(element => element.closest('IED') !== this.currentIedElement)
-        .sort((a, b) =>
-          compareNames(
-            `${a.getAttribute('intAddr')}`,
-            `${b.getAttribute('intAddr')}`
-          )
-        );
-    }
-    return [];
-  }
-
-  private getSubscribedExtRefElements(): Element[] {
-    return this.getExtRefElements().filter(element =>
-      this.isSubscribedTo(element)
-    );
-  }
-
   private getAvailableExtRefElements(): Element[] {
-    return this.getExtRefElements().filter(
-      element => !this.isSubscribed(element)
-    );
+    return getExtRefElements(this.doc, this.currentIedElement!).filter(element => !this.isSubscribed(element));
   }
 
   private async onFcdaSelectEvent(event: FcdaSelectEvent) {
@@ -87,64 +66,6 @@ export class ExtRefLaterBindingList extends LitElement {
     this.currentIedElement = this.currentSelectedFcdaElement
       ? this.currentSelectedFcdaElement.closest('IED') ?? undefined
       : undefined;
-  }
-
-  private sameAttributeValue(
-    extRefElement: Element,
-    attributeName: string
-  ): boolean {
-    return (
-      (extRefElement.getAttribute(attributeName) ?? '') ===
-        (this.currentSelectedFcdaElement?.getAttribute(attributeName) ?? '')
-    );
-  }
-
-  private checkEditionSpecificRequirements(extRefElement: Element): boolean {
-    if (getSclSchemaVersion(extRefElement.ownerDocument) === '2003')
-      return true;
-    return (
-      extRefElement.getAttribute('serviceType') ===
-        serviceTypes[this.controlTag] &&
-      extRefElement.getAttribute('srcLDInst') ===
-        this.currentSelectedControlElement
-          ?.closest('LDevice')
-          ?.getAttribute('inst') &&
-      (extRefElement.getAttribute('srcPrefix') || '') ===
-        (this.currentSelectedControlElement
-          ?.closest('LN0')
-          ?.getAttribute('prefix') || '') &&
-      extRefElement.getAttribute('srcLNClass') ===
-        this.currentSelectedControlElement
-          ?.closest('LN0')
-          ?.getAttribute('lnClass') &&
-      (extRefElement.getAttribute('srcLNInst') || '') ===
-        this.currentSelectedControlElement
-          ?.closest('LN0')
-          ?.getAttribute('inst') &&
-      extRefElement.getAttribute('srcCBName') ===
-        this.currentSelectedControlElement?.getAttribute('name')
-    );
-  }
-
-  /**
-   * Check if specific attributes from the ExtRef Element are the same as the ones from the FCDA Element
-   * and also if the IED Name is the same. If that is the case this ExtRef subscribes to the selected FCDA
-   * Element.
-   *
-   * @param extRefElement - The Ext Ref Element to check.
-   */
-  private isSubscribedTo(extRefElement: Element): boolean {
-    return (
-      extRefElement.getAttribute('iedName') ===
-        this.currentIedElement?.getAttribute('name') &&
-      this.sameAttributeValue(extRefElement, 'ldInst') &&
-      this.sameAttributeValue(extRefElement, 'prefix') &&
-      this.sameAttributeValue(extRefElement, 'lnClass') &&
-      this.sameAttributeValue(extRefElement, 'lnInst') &&
-      this.sameAttributeValue(extRefElement, 'doName') &&
-      this.sameAttributeValue(extRefElement, 'daName') &&
-      this.checkEditionSpecificRequirements(extRefElement)
-    );
   }
 
   /**
@@ -241,7 +162,13 @@ export class ExtRefLaterBindingList extends LitElement {
   }
 
   private renderSubscribedExtRefs(): TemplateResult {
-    const subscribedExtRefs = this.getSubscribedExtRefElements();
+    const subscribedExtRefs = getSubscribedExtRefElements(
+      this.doc,
+      this.currentIedElement!,
+      this.currentSelectedFcdaElement!,
+      this.currentSelectedControlElement!,
+      this.controlTag
+    );
     return html`
       <mwc-list-item
         noninteractive

--- a/src/editors/subscription/later-binding/ext-ref-later-binding-list.ts
+++ b/src/editors/subscription/later-binding/ext-ref-later-binding-list.ts
@@ -161,14 +161,19 @@ export class ExtRefLaterBindingList extends LitElement {
     </h1>`;
   }
 
-  private renderSubscribedExtRefs(): TemplateResult {
-    const subscribedExtRefs = getSubscribedExtRefElements(
+  // just here to make the tests work for now
+  private getSubscribedExtRefElements(): Element[] {
+    return getSubscribedExtRefElements(
       this.doc,
       this.currentIedElement!,
       this.currentSelectedFcdaElement!,
       this.currentSelectedControlElement!,
       this.controlTag
     );
+  }
+
+  private renderSubscribedExtRefs(): TemplateResult {
+    const subscribedExtRefs = this.getSubscribedExtRefElements()
     return html`
       <mwc-list-item
         noninteractive

--- a/src/editors/subscription/later-binding/ext-ref-later-binding-list.ts
+++ b/src/editors/subscription/later-binding/ext-ref-later-binding-list.ts
@@ -109,7 +109,7 @@ export class ExtRefLaterBindingList extends LitElement {
         this.currentSelectedControlElement
           ?.closest('LDevice')
           ?.getAttribute('inst') &&
-      (extRefElement.getAttribute('scrPrefix') || '') ===
+      (extRefElement.getAttribute('srcPrefix') || '') ===
         (this.currentSelectedControlElement
           ?.closest('LN0')
           ?.getAttribute('prefix') || '') &&

--- a/src/editors/subscription/later-binding/ext-ref-later-binding-list.ts
+++ b/src/editors/subscription/later-binding/ext-ref-later-binding-list.ts
@@ -20,7 +20,7 @@ import {
   getSclSchemaVersion,
 } from '../../../foundation.js';
 
-import { styles, updateExtRefElement, serviceTypes } from '../foundation.js';
+import { serviceTypes, styles, updateExtRefElement } from '../foundation.js';
 import { FcdaSelectEvent } from './foundation.js';
 
 /**

--- a/src/editors/subscription/later-binding/ext-ref-later-binding-list.ts
+++ b/src/editors/subscription/later-binding/ext-ref-later-binding-list.ts
@@ -266,6 +266,12 @@ export class ExtRefLaterBindingList extends LitElement {
                 this.dispatchEvent(
                   newActionEvent(this.unsubscribe(extRefElement))
                 );
+                this.dispatchEvent(
+                  new CustomEvent('lb-subscription-change', {
+                    bubbles: true,
+                    composed: true,
+                  })
+                );
               }}
               value="${identity(extRefElement)}"
             >
@@ -317,6 +323,12 @@ export class ExtRefLaterBindingList extends LitElement {
                 if (replaceAction) {
                   this.dispatchEvent(newActionEvent(replaceAction));
                 }
+                this.dispatchEvent(
+                  new CustomEvent('lb-subscription-change', {
+                    bubbles: true,
+                    composed: true,
+                  })
+                );
               }}
               value="${identity(extRefElement)}"
             >

--- a/src/editors/subscription/later-binding/fcda-later-binding-list.ts
+++ b/src/editors/subscription/later-binding/fcda-later-binding-list.ts
@@ -22,7 +22,6 @@ import {
   getDescriptionAttribute,
   getNameAttribute,
   identity,
-  isPublic,
   newWizardEvent,
 } from '../../../foundation.js';
 import { gooseIcon, smvIcon } from '../../../icons/icons.js';
@@ -30,7 +29,11 @@ import { wizards } from '../../../wizards/wizard-library.js';
 
 import { styles } from '../foundation.js';
 
-import { getFcdaTitleValue, newFcdaSelectEvent } from './foundation.js';
+import {
+  getFcdaTitleValue,
+  getSubscribedExtRefElements,
+  newFcdaSelectEvent,
+} from './foundation.js';
 
 type controlTag = 'SampledValueControl' | 'GSEControl';
 
@@ -107,25 +110,19 @@ export class FCDALaterBindingList extends LitElement {
     }
   }
 
-  private getExtRefCount(fcdaElement: Element): number {
+  private getExtRefCount(fcdaElement: Element, controlElement: Element): number {
     const fcdaIdentity = identity(fcdaElement);
+
     if (!this.extRefCounters.has(fcdaIdentity)) {
-      const iedName = fcdaElement!.closest('IED')!.getAttribute('name')!;
-      const [ldInst, prefix, lnClass, lnInst, doName, daName] = [
-        'ldInst',
-        'prefix',
-        'lnClass',
-        'lnInst',
-        'doName',
-        'daName',
-      ].map(attr => fcdaElement.getAttribute(attr));
-      const extRefCount = Array.from(
-        this.doc.querySelectorAll(
-          `Inputs > ExtRef[iedName="${iedName}"][ldInst="${ldInst}"][prefix="${prefix}"][lnClass="${lnClass}"][lnInst="${lnInst}"][doName="${doName}"][daName="${daName}"]`
-        )
-      )
-        .filter(isPublic)
-        .filter(element => element.hasAttribute('intAddr')).length;
+      const currentIedElement = fcdaElement.closest('IED');
+      const extRefCount = getSubscribedExtRefElements(
+        this.doc,
+        currentIedElement!,
+        fcdaElement,
+        controlElement!,
+        this.controlTag
+      ).length;
+      console.log('count', extRefCount)
       this.extRefCounters.set(fcdaIdentity, extRefCount);
     }
     return this.extRefCounters.get(fcdaIdentity);
@@ -167,7 +164,8 @@ export class FCDALaterBindingList extends LitElement {
   }
 
   renderFCDA(controlElement: Element, fcdaElement: Element): TemplateResult {
-    const fcdaCount = this.getExtRefCount(fcdaElement);
+    const fcdaCount = 1 
+    // this.getExtRefCount(fcdaElement, controlElement);
     return html`<mwc-list-item
       graphic="large"
       ?hasMeta=${fcdaCount !== 0}

--- a/src/editors/subscription/later-binding/fcda-later-binding-list.ts
+++ b/src/editors/subscription/later-binding/fcda-later-binding-list.ts
@@ -105,15 +105,14 @@ export class FCDALaterBindingList extends LitElement {
 
   private resetExtRefCount(): void {
     if (this.selectedFcdaElement) {
-      const fcdaIdentity = identity(this.selectedFcdaElement);
-      this.extRefCounters.delete(fcdaIdentity);
+      const controlBlockFcdaId = `${identity(this.selectedControlElement!)} ${identity(this.selectedFcdaElement)}`;
+      this.extRefCounters.delete(controlBlockFcdaId);
     }
   }
 
   private getExtRefCount(fcdaElement: Element, controlElement: Element): number {
-    const fcdaIdentity = identity(fcdaElement);
-
-    if (!this.extRefCounters.has(fcdaIdentity)) {
+    const controlBlockFcdaId = `${identity(controlElement)} ${identity(fcdaElement)}`;
+    if (!this.extRefCounters.has(controlBlockFcdaId)) {
       const currentIedElement = fcdaElement.closest('IED');
       const extRefCount = getSubscribedExtRefElements(
         this.doc,
@@ -122,10 +121,9 @@ export class FCDALaterBindingList extends LitElement {
         controlElement!,
         this.controlTag
       ).length;
-      console.log('count', extRefCount)
-      this.extRefCounters.set(fcdaIdentity, extRefCount);
+      this.extRefCounters.set(controlBlockFcdaId, extRefCount);
     }
-    return this.extRefCounters.get(fcdaIdentity);
+    return this.extRefCounters.get(controlBlockFcdaId);
   }
 
   private openEditWizard(controlElement: Element): void {
@@ -164,8 +162,7 @@ export class FCDALaterBindingList extends LitElement {
   }
 
   renderFCDA(controlElement: Element, fcdaElement: Element): TemplateResult {
-    const fcdaCount = 1 
-    // this.getExtRefCount(fcdaElement, controlElement);
+    const fcdaCount = this.getExtRefCount(fcdaElement, controlElement);
     return html`<mwc-list-item
       graphic="large"
       ?hasMeta=${fcdaCount !== 0}

--- a/src/editors/subscription/later-binding/foundation.ts
+++ b/src/editors/subscription/later-binding/foundation.ts
@@ -1,9 +1,102 @@
+import { serviceTypes } from '../foundation.js';
+
+import { compareNames, getSclSchemaVersion } from '../../../foundation.js';
+
 export function getFcdaTitleValue(fcdaElement: Element): string {
   return `${fcdaElement.getAttribute('doName')}${
     fcdaElement.hasAttribute('doName') && fcdaElement.hasAttribute('daName')
       ? `.`
       : ``
   }${fcdaElement.getAttribute('daName')}`;
+}
+
+/**
+ * Check if specific attributes from the ExtRef Element are the same as the ones from the FCDA Element
+ * and also if the IED Name is the same. If that is the case this ExtRef subscribes to the selected FCDA
+ * Element.
+ *
+ * @param extRefElement - The Ext Ref Element to check.
+ */
+export function isSubscribedTo(
+  fcdaElement: Element,
+  extRefElement: Element,
+  currentIedElement: Element,
+  controlElement: Element,
+  controlTag: 'SampledValueControl' | 'GSEControl'
+): boolean {
+  return (
+    extRefElement.getAttribute('iedName') ===
+      currentIedElement?.getAttribute('name') &&
+    sameAttributeValue(fcdaElement, extRefElement, 'ldInst') &&
+    sameAttributeValue(fcdaElement, extRefElement, 'prefix') &&
+    sameAttributeValue(fcdaElement, extRefElement, 'lnClass') &&
+    sameAttributeValue(fcdaElement, extRefElement, 'lnInst') &&
+    sameAttributeValue(fcdaElement, extRefElement, 'doName') &&
+    sameAttributeValue(fcdaElement, extRefElement, 'daName') &&
+    checkEditionSpecificRequirements(controlElement, extRefElement, controlTag)
+  );
+}
+
+export function sameAttributeValue(
+  fcdaElement: Element,
+  extRefElement: Element,
+  attributeName: string
+): boolean {
+  return (
+    (extRefElement.getAttribute(attributeName) ?? '') ===
+    (fcdaElement.getAttribute(attributeName) ?? '')
+  );
+}
+
+export function checkEditionSpecificRequirements(
+  controlElement: Element,
+  extRefElement: Element,
+  controlTag: 'SampledValueControl' | 'GSEControl'
+): boolean {
+  if (getSclSchemaVersion(extRefElement.ownerDocument) === '2003') return true;
+  return (
+    extRefElement.getAttribute('serviceType') === serviceTypes[controlTag] &&
+    extRefElement.getAttribute('srcLDInst') ===
+      controlElement?.closest('LDevice')?.getAttribute('inst') &&
+    (extRefElement.getAttribute('srcPrefix') || '') ===
+      (controlElement?.closest('LN0')?.getAttribute('prefix') || '') &&
+    extRefElement.getAttribute('srcLNClass') ===
+      controlElement?.closest('LN0')?.getAttribute('lnClass') &&
+    (extRefElement.getAttribute('srcLNInst') || '') ===
+      controlElement?.closest('LN0')?.getAttribute('inst') &&
+    extRefElement.getAttribute('srcCBName') ===
+      controlElement?.getAttribute('name')
+  );
+}
+
+export function getSubscribedExtRefElements(
+  doc: XMLDocument,
+  iedElement: Element,
+  fcdaElement: Element,
+  controlElement: Element,
+  controlTag: 'SampledValueControl' | 'GSEControl'
+): Element[] {
+  return getExtRefElements(doc, iedElement).filter(extRefElement =>
+    isSubscribedTo(fcdaElement, extRefElement, iedElement, controlElement, controlTag)
+  );
+}
+
+export function getExtRefElements(
+  doc: XMLDocument,
+  iedElement: Element
+): Element[] {
+  if (doc) {
+    return Array.from(doc.querySelectorAll('ExtRef'))
+      .filter(element => element.hasAttribute('intAddr'))
+      .filter(element => element.closest('IED') !== iedElement)
+      .sort((a, b) =>
+        compareNames(
+          `${a.getAttribute('intAddr')}`,
+          `${b.getAttribute('intAddr')}`
+        )
+      );
+  }
+  return [];
 }
 
 export interface FcdaSelectDetail {

--- a/src/editors/subscription/later-binding/foundation.ts
+++ b/src/editors/subscription/later-binding/foundation.ts
@@ -10,34 +10,7 @@ export function getFcdaTitleValue(fcdaElement: Element): string {
   }${fcdaElement.getAttribute('daName')}`;
 }
 
-/**
- * Check if specific attributes from the ExtRef Element are the same as the ones from the FCDA Element
- * and also if the IED Name is the same. If that is the case this ExtRef subscribes to the selected FCDA
- * Element.
- *
- * @param extRefElement - The Ext Ref Element to check.
- */
-export function isSubscribedTo(
-  fcdaElement: Element,
-  extRefElement: Element,
-  currentIedElement: Element,
-  controlElement: Element,
-  controlTag: 'SampledValueControl' | 'GSEControl'
-): boolean {
-  return (
-    extRefElement.getAttribute('iedName') ===
-      currentIedElement?.getAttribute('name') &&
-    sameAttributeValue(fcdaElement, extRefElement, 'ldInst') &&
-    sameAttributeValue(fcdaElement, extRefElement, 'prefix') &&
-    sameAttributeValue(fcdaElement, extRefElement, 'lnClass') &&
-    sameAttributeValue(fcdaElement, extRefElement, 'lnInst') &&
-    sameAttributeValue(fcdaElement, extRefElement, 'doName') &&
-    sameAttributeValue(fcdaElement, extRefElement, 'daName') &&
-    checkEditionSpecificRequirements(controlElement, extRefElement, controlTag)
-  );
-}
-
-export function sameAttributeValue(
+function sameAttributeValue(
   fcdaElement: Element,
   extRefElement: Element,
   attributeName: string
@@ -48,7 +21,7 @@ export function sameAttributeValue(
   );
 }
 
-export function checkEditionSpecificRequirements(
+function checkEditionSpecificRequirements(
   controlElement: Element,
   extRefElement: Element,
   controlTag: 'SampledValueControl' | 'GSEControl'
@@ -69,22 +42,34 @@ export function checkEditionSpecificRequirements(
   );
 }
 
-export function getSubscribedExtRefElements(
-  doc: XMLDocument,
-  iedElement: Element,
+/**
+ * Check if specific attributes from the ExtRef Element are the same as the ones from the FCDA Element
+ * and also if the IED Name is the same. If that is the case this ExtRef subscribes to the selected FCDA
+ * Element.
+ *
+ * @param extRefElement - The Ext Ref Element to check.
+ */
+function isSubscribedTo(
   fcdaElement: Element,
+  extRefElement: Element,
+  currentIedElement: Element,
   controlElement: Element,
   controlTag: 'SampledValueControl' | 'GSEControl'
-): Element[] {
-  return getExtRefElements(doc, iedElement).filter(extRefElement =>
-    isSubscribedTo(fcdaElement, extRefElement, iedElement, controlElement, controlTag)
+): boolean {
+  return (
+    extRefElement.getAttribute('iedName') ===
+      currentIedElement?.getAttribute('name') &&
+    sameAttributeValue(fcdaElement, extRefElement, 'ldInst') &&
+    sameAttributeValue(fcdaElement, extRefElement, 'prefix') &&
+    sameAttributeValue(fcdaElement, extRefElement, 'lnClass') &&
+    sameAttributeValue(fcdaElement, extRefElement, 'lnInst') &&
+    sameAttributeValue(fcdaElement, extRefElement, 'doName') &&
+    sameAttributeValue(fcdaElement, extRefElement, 'daName') &&
+    checkEditionSpecificRequirements(controlElement, extRefElement, controlTag)
   );
 }
 
-export function getExtRefElements(
-  doc: XMLDocument,
-  iedElement: Element
-): Element[] {
+export function getExtRefElements(doc: XMLDocument, iedElement: Element): Element[] {
   if (doc) {
     return Array.from(doc.querySelectorAll('ExtRef'))
       .filter(element => element.hasAttribute('intAddr'))
@@ -97,6 +82,24 @@ export function getExtRefElements(
       );
   }
   return [];
+}
+
+export function getSubscribedExtRefElements(
+  doc: XMLDocument,
+  iedElement: Element,
+  fcdaElement: Element,
+  controlElement: Element,
+  controlTag: 'SampledValueControl' | 'GSEControl'
+): Element[] {
+  return getExtRefElements(doc, iedElement).filter(extRefElement =>
+    isSubscribedTo(
+      fcdaElement,
+      extRefElement,
+      iedElement,
+      controlElement,
+      controlTag
+    )
+  );
 }
 
 export interface FcdaSelectDetail {

--- a/test/integration/editors/GooseSubscriberLaterBinding.test.ts
+++ b/test/integration/editors/GooseSubscriberLaterBinding.test.ts
@@ -72,14 +72,12 @@ describe('GOOSE Subscribe Later Binding Plugin', () => {
     const svcListElement = getFCDALaterBindingList(element);
     const gooseListElement = getFCDALaterBindingList(element);
     const extRefListElement = getExtrefLaterBindingList(element);
-
     (<HTMLElement>(
       gooseListElement.shadowRoot!.querySelector(
         'mwc-list-item[value="GOOSE_Publisher>>QB2_Disconnector>GOOSE2 GOOSE_Publisher>>QB2_Disconnector>GOOSE2sDataSet>QB2_Disconnector/ CSWI 1.Pos q (ST)"]'
       )
     )).click();
     await element.requestUpdate();
-    await extRefListElement.requestUpdate();
 
     expect(
       extRefListElement['getSubscribedExtRefElements']().length
@@ -90,7 +88,7 @@ describe('GOOSE Subscribe Later Binding Plugin', () => {
     expect(
       svcListElement.selectedItem.querySelector('span[slot="meta"]')
         ?.textContent
-    ).to.be.equal('3');
+    ).to.be.equal('2');
     (<HTMLElement>(
       extRefListElement.shadowRoot!.querySelector(
         'mwc-list-item[value="GOOSE_Subscriber>>Earth_Switch> CSWI 1>GOOSE:GOOSE2 QB2_Disconnector/ LLN0  GOOSE_Publisher QB2_Disconnector/ CSWI 1 Pos q@Pos;CSWI1/Pos/q"]'
@@ -107,6 +105,6 @@ describe('GOOSE Subscribe Later Binding Plugin', () => {
     expect(
       svcListElement.selectedItem.querySelector('span[slot="meta"]')
         ?.textContent
-    ).to.be.equal('2');
+    ).to.be.equal('1');
   });
 });

--- a/test/integration/editors/GooseSubscriberLaterBinding.test.ts
+++ b/test/integration/editors/GooseSubscriberLaterBinding.test.ts
@@ -46,6 +46,8 @@ describe('GOOSE Subscribe Later Binding Plugin', () => {
     expect(
       extRefListElement['getAvailableExtRefElements']().length
     ).to.be.equal(4);
+    expect(svcListElement.selectedItem.querySelector('span[slot="meta"]')).to.be
+      .null;
 
     (<HTMLElement>(
       extRefListElement.shadowRoot!.querySelector(
@@ -60,9 +62,14 @@ describe('GOOSE Subscribe Later Binding Plugin', () => {
     expect(
       extRefListElement['getAvailableExtRefElements']().length
     ).to.be.equal(3);
+    expect(
+      svcListElement.selectedItem.querySelector('span[slot="meta"]')
+        ?.textContent
+    ).to.be.equal('1');
   });
 
   it('when unsubscribing a subscribed ExtRef then the lists are changed', async () => {
+    const svcListElement = getFCDALaterBindingList(element);
     const gooseListElement = getFCDALaterBindingList(element);
     const extRefListElement = getExtrefLaterBindingList(element);
 
@@ -80,6 +87,10 @@ describe('GOOSE Subscribe Later Binding Plugin', () => {
     expect(
       extRefListElement['getAvailableExtRefElements']().length
     ).to.be.equal(4);
+    expect(
+      svcListElement.selectedItem.querySelector('span[slot="meta"]')
+        ?.textContent
+    ).to.be.equal('3');
     (<HTMLElement>(
       extRefListElement.shadowRoot!.querySelector(
         'mwc-list-item[value="GOOSE_Subscriber>>Earth_Switch> CSWI 1>GOOSE:GOOSE2 QB2_Disconnector/ LLN0  GOOSE_Publisher QB2_Disconnector/ CSWI 1 Pos q@Pos;CSWI1/Pos/q"]'
@@ -93,5 +104,9 @@ describe('GOOSE Subscribe Later Binding Plugin', () => {
     expect(
       extRefListElement['getAvailableExtRefElements']().length
     ).to.be.equal(5);
+    expect(
+      svcListElement.selectedItem.querySelector('span[slot="meta"]')
+        ?.textContent
+    ).to.be.equal('2');
   });
 });

--- a/test/integration/editors/SMVSubscriberLaterBinding.test.ts
+++ b/test/integration/editors/SMVSubscriberLaterBinding.test.ts
@@ -47,6 +47,8 @@ describe('SMV Subscribe Later Binding plugin', () => {
     expect(
       extRefListElement['getAvailableExtRefElements']().length
     ).to.be.equal(8);
+    expect(svcListElement.selectedItem.querySelector('span[slot="meta"]')).to.be
+      .null;
 
     (<HTMLElement>(
       extRefListElement.shadowRoot!.querySelector(
@@ -61,6 +63,10 @@ describe('SMV Subscribe Later Binding plugin', () => {
     expect(
       extRefListElement['getAvailableExtRefElements']().length
     ).to.be.equal(7);
+    expect(
+      svcListElement.selectedItem.querySelector('span[slot="meta"]')
+        ?.textContent
+    ).to.be.equal('1');
   });
 
   it('when unsubscribing a subscribed ExtRef then the lists are changed', async () => {
@@ -80,6 +86,10 @@ describe('SMV Subscribe Later Binding plugin', () => {
     expect(
       extRefListElement['getAvailableExtRefElements']().length
     ).to.be.equal(8);
+    expect(
+      svcListElement.selectedItem.querySelector('span[slot="meta"]')
+        ?.textContent
+    ).to.be.equal('3');
 
     (<HTMLElement>(
       extRefListElement.shadowRoot!.querySelector(
@@ -94,5 +104,9 @@ describe('SMV Subscribe Later Binding plugin', () => {
     expect(
       extRefListElement['getAvailableExtRefElements']().length
     ).to.be.equal(9);
+    expect(
+      svcListElement.selectedItem.querySelector('span[slot="meta"]')
+        ?.textContent
+    ).to.be.equal('2');
   });
 });

--- a/test/unit/editors/subscription/later-binding/__snapshots__/fcda-later-binding-list.test.snap.js
+++ b/test/unit/editors/subscription/later-binding/__snapshots__/fcda-later-binding-list.test.snap.js
@@ -49,6 +49,7 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="0"
       twoline=""
@@ -65,11 +66,15 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+        1
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -86,11 +91,15 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+        3
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -107,11 +116,14 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -128,11 +140,14 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -149,11 +164,14 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -170,6 +188,8 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
@@ -204,6 +224,7 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -220,11 +241,15 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+        1
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -241,11 +266,15 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+        3
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -262,11 +291,14 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -283,11 +315,14 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -304,11 +339,14 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -325,11 +363,14 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -346,11 +387,15 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+        1
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -367,11 +412,14 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -388,11 +436,14 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -409,11 +460,14 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -430,11 +484,14 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -451,6 +508,8 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
@@ -485,6 +544,7 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -501,11 +561,15 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+        1
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -522,11 +586,14 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -543,11 +610,14 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -564,11 +634,14 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -585,11 +658,14 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -606,6 +682,8 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+      </span>
     </mwc-list-item>
   </filtered-list>
 </section>
@@ -651,6 +729,7 @@ snapshots["fcda-list with a GSEControl doc loaded looks like the latest snapshot
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="0"
       twoline=""
@@ -667,11 +746,14 @@ snapshots["fcda-list with a GSEControl doc loaded looks like the latest snapshot
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -688,11 +770,15 @@ snapshots["fcda-list with a GSEControl doc loaded looks like the latest snapshot
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+        1
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -709,11 +795,15 @@ snapshots["fcda-list with a GSEControl doc loaded looks like the latest snapshot
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+        1
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -730,11 +820,15 @@ snapshots["fcda-list with a GSEControl doc loaded looks like the latest snapshot
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+        1
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -751,6 +845,9 @@ snapshots["fcda-list with a GSEControl doc loaded looks like the latest snapshot
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+        1
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
@@ -814,6 +911,7 @@ snapshots["fcda-list with a GSEControl doc loaded looks like the latest snapshot
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -830,11 +928,15 @@ snapshots["fcda-list with a GSEControl doc loaded looks like the latest snapshot
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+        1
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -851,11 +953,15 @@ snapshots["fcda-list with a GSEControl doc loaded looks like the latest snapshot
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+        1
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -872,6 +978,8 @@ snapshots["fcda-list with a GSEControl doc loaded looks like the latest snapshot
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
@@ -906,6 +1014,7 @@ snapshots["fcda-list with a GSEControl doc loaded looks like the latest snapshot
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -922,11 +1031,14 @@ snapshots["fcda-list with a GSEControl doc loaded looks like the latest snapshot
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -943,11 +1055,14 @@ snapshots["fcda-list with a GSEControl doc loaded looks like the latest snapshot
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -964,11 +1079,14 @@ snapshots["fcda-list with a GSEControl doc loaded looks like the latest snapshot
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -985,11 +1103,14 @@ snapshots["fcda-list with a GSEControl doc loaded looks like the latest snapshot
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -1006,6 +1127,8 @@ snapshots["fcda-list with a GSEControl doc loaded looks like the latest snapshot
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"

--- a/test/unit/editors/subscription/later-binding/__snapshots__/fcda-later-binding-list.test.snap.js
+++ b/test/unit/editors/subscription/later-binding/__snapshots__/fcda-later-binding-list.test.snap.js
@@ -212,7 +212,6 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       aria-disabled="false"
       class="subitem"
       graphic="large"
-      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -229,15 +228,11 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
-      <span slot="meta">
-        1
-      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
-      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -254,9 +249,6 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
-      <span slot="meta">
-        3
-      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
@@ -346,7 +338,6 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       aria-disabled="false"
       class="subitem"
       graphic="large"
-      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -363,9 +354,6 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
-      <span slot="meta">
-        1
-      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
@@ -696,7 +684,6 @@ snapshots["fcda-list with a GSEControl doc loaded looks like the latest snapshot
       aria-disabled="false"
       class="subitem"
       graphic="large"
-      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -713,15 +700,11 @@ snapshots["fcda-list with a GSEControl doc loaded looks like the latest snapshot
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
-      <span slot="meta">
-        1
-      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
-      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -738,15 +721,11 @@ snapshots["fcda-list with a GSEControl doc loaded looks like the latest snapshot
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
-      <span slot="meta">
-        1
-      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
-      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -763,15 +742,11 @@ snapshots["fcda-list with a GSEControl doc loaded looks like the latest snapshot
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
-      <span slot="meta">
-        1
-      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
-      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -788,9 +763,6 @@ snapshots["fcda-list with a GSEControl doc loaded looks like the latest snapshot
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
-      <span slot="meta">
-        1
-      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
@@ -854,7 +826,6 @@ snapshots["fcda-list with a GSEControl doc loaded looks like the latest snapshot
       aria-disabled="false"
       class="subitem"
       graphic="large"
-      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -871,9 +842,6 @@ snapshots["fcda-list with a GSEControl doc loaded looks like the latest snapshot
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
-      <span slot="meta">
-        1
-      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"

--- a/test/unit/editors/subscription/later-binding/__snapshots__/fcda-later-binding-list.test.snap.js
+++ b/test/unit/editors/subscription/later-binding/__snapshots__/fcda-later-binding-list.test.snap.js
@@ -99,7 +99,6 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       aria-disabled="false"
       class="subitem"
       graphic="large"
-      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -116,14 +115,11 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
-      <span slot="meta">
-      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
-      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -140,14 +136,11 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
-      <span slot="meta">
-      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
-      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -164,14 +157,11 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
-      <span slot="meta">
-      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
-      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -188,8 +178,6 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
-      <span slot="meta">
-      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
@@ -274,7 +262,6 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       aria-disabled="false"
       class="subitem"
       graphic="large"
-      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -291,14 +278,11 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
-      <span slot="meta">
-      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
-      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -315,14 +299,11 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
-      <span slot="meta">
-      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
-      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -339,14 +320,11 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
-      <span slot="meta">
-      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
-      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -363,8 +341,6 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
-      <span slot="meta">
-      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
@@ -395,7 +371,6 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       aria-disabled="false"
       class="subitem"
       graphic="large"
-      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -412,14 +387,11 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
-      <span slot="meta">
-      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
-      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -436,14 +408,11 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
-      <span slot="meta">
-      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
-      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -460,14 +429,11 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
-      <span slot="meta">
-      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
-      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -484,14 +450,11 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
-      <span slot="meta">
-      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
-      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -508,8 +471,6 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
-      <span slot="meta">
-      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
@@ -569,7 +530,6 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       aria-disabled="false"
       class="subitem"
       graphic="large"
-      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -586,14 +546,11 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
-      <span slot="meta">
-      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
-      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -610,14 +567,11 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
-      <span slot="meta">
-      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
-      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -634,14 +588,11 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
-      <span slot="meta">
-      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
-      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -658,14 +609,11 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
-      <span slot="meta">
-      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
-      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -682,8 +630,6 @@ snapshots["fcda-list with a SampledValueControl doc loaded looks like the latest
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
-      <span slot="meta">
-      </span>
     </mwc-list-item>
   </filtered-list>
 </section>
@@ -729,7 +675,6 @@ snapshots["fcda-list with a GSEControl doc loaded looks like the latest snapshot
       aria-disabled="false"
       class="subitem"
       graphic="large"
-      hasmeta=""
       mwc-list-item=""
       tabindex="0"
       twoline=""
@@ -746,8 +691,6 @@ snapshots["fcda-list with a GSEControl doc loaded looks like the latest snapshot
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
-      <span slot="meta">
-      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
@@ -961,7 +904,6 @@ snapshots["fcda-list with a GSEControl doc loaded looks like the latest snapshot
       aria-disabled="false"
       class="subitem"
       graphic="large"
-      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -978,8 +920,6 @@ snapshots["fcda-list with a GSEControl doc loaded looks like the latest snapshot
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
-      <span slot="meta">
-      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
@@ -1014,7 +954,6 @@ snapshots["fcda-list with a GSEControl doc loaded looks like the latest snapshot
       aria-disabled="false"
       class="subitem"
       graphic="large"
-      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -1031,14 +970,11 @@ snapshots["fcda-list with a GSEControl doc loaded looks like the latest snapshot
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
-      <span slot="meta">
-      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
-      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -1055,14 +991,11 @@ snapshots["fcda-list with a GSEControl doc loaded looks like the latest snapshot
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
-      <span slot="meta">
-      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
-      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -1079,14 +1012,11 @@ snapshots["fcda-list with a GSEControl doc loaded looks like the latest snapshot
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
-      <span slot="meta">
-      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
-      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -1103,14 +1033,11 @@ snapshots["fcda-list with a GSEControl doc loaded looks like the latest snapshot
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
-      <span slot="meta">
-      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
-      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -1127,8 +1054,6 @@ snapshots["fcda-list with a GSEControl doc loaded looks like the latest snapshot
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
-      <span slot="meta">
-      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"


### PR DESCRIPTION
I had a go at prototyping counting the number of references to an FCDA in project ExtRefs as suggested in #958. 

It's by no means complete. However, it seems to ruin the plugin's performance by initially making it slow to load after clicking on the editor and then slow to update after doing a binding. It's so laggy I think it would be unacceptable to users.

I would appreciate a little guidance or a hint. How should I best approach this? Can this be made async?