### PR TITLE
fix(editors/plugin): disable read-only inputs

### DIFF
--- a/src/editors/publisher/data-set-element-editor.ts
+++ b/src/editors/publisher/data-set-element-editor.ts
@@ -40,6 +40,7 @@ export class DataSetElementEditor extends LitElement {
         .maybeValue=${this.name}
         helper="${translate('scl.name')}"
         required
+        disabled
       >
       </wizard-textfield>
       <wizard-textfield
@@ -47,6 +48,7 @@ export class DataSetElementEditor extends LitElement {
         .maybeValue=${this.desc}
         helper="${translate('scl.desc')}"
         nullable
+        disabled
       >
       </wizard-textfield>
       <filtered-list

--- a/src/editors/publisher/gse-control-element-editor.ts
+++ b/src/editors/publisher/gse-control-element-editor.ts
@@ -75,6 +75,7 @@ export class GseControlElementEditor extends LitElement {
         ><mwc-checkbox
           id="instType"
           ?checked="${hasInstType}"
+          disabled
         ></mwc-checkbox></mwc-formfield
       >${Object.entries(attributes).map(
         ([key, value]) =>
@@ -84,6 +85,7 @@ export class GseControlElementEditor extends LitElement {
             .maybeValue=${value}
             pattern="${ifDefined(typePattern[key])}"
             required
+            disabled
           ></wizard-textfield>`
       )}<wizard-textfield
         label="MinTime"
@@ -91,6 +93,7 @@ export class GseControlElementEditor extends LitElement {
         nullable
         suffix="ms"
         type="number"
+        disabled
       ></wizard-textfield
       ><wizard-textfield
         label="MaxTime"
@@ -98,6 +101,7 @@ export class GseControlElementEditor extends LitElement {
         nullable
         suffix="ms"
         type="number"
+        disabled
       ></wizard-textfield>
     </div>`;
   }
@@ -122,12 +126,14 @@ export class GseControlElementEditor extends LitElement {
         pattern="${patterns.asciName}"
         maxLength="${maxLength.cbName}"
         dialogInitialFocus
+        disabled
       ></wizard-textfield>
       <wizard-textfield
         label="desc"
         .maybeValue=${desc}
         nullable
         helper="${translate('scl.desc')}"
+        disabled
       ></wizard-textfield>
       <wizard-select
         label="type"
@@ -135,6 +141,7 @@ export class GseControlElementEditor extends LitElement {
         helper="${translate('scl.type')}"
         nullable
         required
+        disabled
         >${['GOOSE', 'GSSE'].map(
           type => html`<mwc-list-item value="${type}">${type}</mwc-list-item>`
         )}</wizard-select
@@ -145,12 +152,14 @@ export class GseControlElementEditor extends LitElement {
         helper="${translate('scl.id')}"
         required
         validationMessage="${translate('textfield.nonempty')}"
+        disabled
       ></wizard-textfield>
       <wizard-checkbox
         label="fixedOffs"
         .maybeValue=${fixedOffs}
         nullable
         helper="${translate('scl.fixedOffs')}"
+        disabled
       ></wizard-checkbox>
       <wizard-select
         label="securityEnabled"
@@ -158,6 +167,7 @@ export class GseControlElementEditor extends LitElement {
         nullable
         required
         helper="${translate('scl.securityEnable')}"
+        disabled
         >${['None', 'Signature', 'SignatureAndEncryption'].map(
           type => html`<mwc-list-item value="${type}">${type}</mwc-list-item>`
         )}</wizard-select

--- a/src/editors/publisher/report-control-element-editor.ts
+++ b/src/editors/publisher/report-control-element-editor.ts
@@ -64,6 +64,7 @@ export class ReportControlElementEditor extends LitElement {
             .maybeValue=${value}
             nullable
             helper="${translate(`scl.${key}`)}"
+            disabled
           ></wizard-checkbox>`
       )}`;
   }
@@ -87,6 +88,7 @@ export class ReportControlElementEditor extends LitElement {
             .maybeValue=${value}
             nullable
             helper="${translate(`scl.${key}`)}"
+            disabled
           ></wizard-checkbox>`
       )}`;
   }
@@ -120,17 +122,20 @@ export class ReportControlElementEditor extends LitElement {
         pattern="${patterns.asciName}"
         maxLength="${maxLength.cbName}"
         dialogInitialFocus
+        disabled
       ></wizard-textfield
       ><wizard-textfield
         label="desc"
         .maybeValue=${desc}
         nullable
         helper="${translate('scl.desc')}"
+        disabled
       ></wizard-textfield
       ><wizard-checkbox
         label="buffered"
         .maybeValue=${buffered}
         helper="${translate('scl.buffered')}"
+        disabled
       ></wizard-checkbox
       ><wizard-textfield
         label="rptID"
@@ -138,12 +143,14 @@ export class ReportControlElementEditor extends LitElement {
         nullable
         required
         helper="${translate('report.rptID')}"
+        disabled
       ></wizard-textfield
       ><wizard-checkbox
         label="indexed"
         .maybeValue=${indexed}
         nullable
         helper="${translate('scl.indexed')}"
+        disabled
       ></wizard-checkbox
       ><wizard-textfield
         label="max Clients"
@@ -152,6 +159,7 @@ export class ReportControlElementEditor extends LitElement {
         nullable
         type="number"
         suffix="#"
+        disabled
       ></wizard-textfield
       ><wizard-textfield
         label="bufTime"
@@ -162,6 +170,7 @@ export class ReportControlElementEditor extends LitElement {
         type="number"
         min="0"
         suffix="ms"
+        disabled
       ></wizard-textfield
       ><wizard-textfield
         label="intgPd"
@@ -172,6 +181,7 @@ export class ReportControlElementEditor extends LitElement {
         type="number"
         min="0"
         suffix="ms"
+        disabled
       ></wizard-textfield>
     </div>`;
   }

--- a/src/editors/publisher/sampled-value-control-element-editor.ts
+++ b/src/editors/publisher/sampled-value-control-element-editor.ts
@@ -72,6 +72,7 @@ export class SampledValueControlElementEditor extends LitElement {
         ><mwc-checkbox
           id="instType"
           ?checked="${hasInstType}"
+          disabled
         ></mwc-checkbox></mwc-formfield
       >${Object.entries(attributes).map(
         ([key, value]) =>
@@ -81,6 +82,7 @@ export class SampledValueControlElementEditor extends LitElement {
             .maybeValue=${value}
             pattern="${ifDefined(typePattern[key])}"
             required
+            disabled
           ></wizard-textfield>`
       )}`;
   }
@@ -110,6 +112,7 @@ export class SampledValueControlElementEditor extends LitElement {
             .maybeValue=${value}
             nullable
             helper="${translate(`scl.${key}`)}"
+            disabled
           ></wizard-checkbox>`
       )}`;
   }
@@ -151,12 +154,14 @@ export class SampledValueControlElementEditor extends LitElement {
         pattern="${patterns.asciName}"
         maxLength="${maxLength.cbName}"
         dialogInitialFocus
+        disabled
       ></wizard-textfield>
       <wizard-textfield
         label="desc"
         .maybeValue=${desc}
         nullable
         helper="${translate('scl.desc')}"
+        disabled
       ></wizard-textfield>
       ${multicast === 'true'
         ? html``
@@ -172,6 +177,7 @@ export class SampledValueControlElementEditor extends LitElement {
         helper="${translate('scl.id')}"
         required
         validationMessage="${translate('textfield.nonempty')}"
+        disabled
       ></wizard-textfield>
       <wizard-select
         label="smpMod"
@@ -179,6 +185,7 @@ export class SampledValueControlElementEditor extends LitElement {
         nullable
         required
         helper="${translate('scl.smpMod')}"
+        disabled
         >${['SmpPerPeriod', 'SmpPerSec', 'SecPerSmp'].map(
           option =>
             html`<mwc-list-item value="${option}">${option}</mwc-list-item>`
@@ -191,6 +198,7 @@ export class SampledValueControlElementEditor extends LitElement {
         required
         type="number"
         min="0"
+        disabled
       ></wizard-textfield>
       <wizard-textfield
         label="nofASDU"
@@ -199,6 +207,7 @@ export class SampledValueControlElementEditor extends LitElement {
         required
         type="number"
         min="0"
+        disabled
       ></wizard-textfield>
       <wizard-select
         label="securityEnabled"
@@ -206,6 +215,7 @@ export class SampledValueControlElementEditor extends LitElement {
         nullable
         required
         helper="${translate('scl.securityEnable')}"
+        disabled
         >${['None', 'Signature', 'SignatureAndEncryption'].map(
           type => html`<mwc-list-item value="${type}">${type}</mwc-list-item>`
         )}</wizard-select

--- a/test/unit/editors/publisher/__snapshots__/data-set-element-editor.test.snap.js
+++ b/test/unit/editors/publisher/__snapshots__/data-set-element-editor.test.snap.js
@@ -12,6 +12,7 @@ snapshots["Editor for DataSet element with valid DataSet looks like the latest s
     </div>
   </h2>
   <wizard-textfield
+    disabled=""
     helper="[scl.name]"
     label="name"
     required=""

--- a/test/unit/editors/publisher/__snapshots__/gse-control-element-editor.test.snap.js
+++ b/test/unit/editors/publisher/__snapshots__/gse-control-element-editor.test.snap.js
@@ -16,6 +16,7 @@ snapshots["Editor for GSEControl element and its direct children with valid GSEC
   <div class="content">
     <wizard-textfield
       dialoginitialfocus=""
+      disabled=""
       helper="[scl.name]"
       label="name"
       maxlength="32"
@@ -32,6 +33,7 @@ snapshots["Editor for GSEControl element and its direct children with valid GSEC
     >
     </wizard-textfield>
     <wizard-select
+      disabled=""
       helper="[scl.type]"
       label="type"
       nullable=""
@@ -60,6 +62,7 @@ snapshots["Editor for GSEControl element and its direct children with valid GSEC
       </mwc-list-item>
     </wizard-select>
     <wizard-textfield
+      disabled=""
       helper="[scl.id]"
       label="appID"
       required=""
@@ -67,6 +70,7 @@ snapshots["Editor for GSEControl element and its direct children with valid GSEC
     >
     </wizard-textfield>
     <wizard-checkbox
+      disabled=""
       helper="[scl.fixedOffs]"
       label="fixedOffs"
       nullable=""
@@ -113,22 +117,28 @@ snapshots["Editor for GSEControl element and its direct children with valid GSEC
       Communication Settings (GSE)
     </h3>
     <mwc-formfield label="[connectedap.wizard.addschemainsttype]">
-      <mwc-checkbox id="instType">
+      <mwc-checkbox
+        disabled=""
+        id="instType"
+      >
       </mwc-checkbox>
     </mwc-formfield>
     <wizard-textfield
+      disabled=""
       label="MAC-Address"
       pattern="([0-9A-F]{2}-){5}[0-9A-F]{2}"
       required=""
     >
     </wizard-textfield>
     <wizard-textfield
+      disabled=""
       label="APPID"
       pattern="[0-9A-F]{4}"
       required=""
     >
     </wizard-textfield>
     <wizard-textfield
+      disabled=""
       label="VLAN-ID"
       nullable=""
       pattern="[0-9A-F]{3}"
@@ -136,6 +146,7 @@ snapshots["Editor for GSEControl element and its direct children with valid GSEC
     >
     </wizard-textfield>
     <wizard-textfield
+      disabled=""
       label="VLAN-PRIORITY"
       nullable=""
       pattern="[0-7]"
@@ -143,6 +154,7 @@ snapshots["Editor for GSEControl element and its direct children with valid GSEC
     >
     </wizard-textfield>
     <wizard-textfield
+      disabled=""
       label="MinTime"
       nullable=""
       suffix="ms"
@@ -150,6 +162,7 @@ snapshots["Editor for GSEControl element and its direct children with valid GSEC
     >
     </wizard-textfield>
     <wizard-textfield
+      disabled=""
       label="MaxTime"
       nullable=""
       suffix="ms"

--- a/test/unit/editors/publisher/__snapshots__/report-control-element-editor.test.snap.js
+++ b/test/unit/editors/publisher/__snapshots__/report-control-element-editor.test.snap.js
@@ -16,6 +16,7 @@ snapshots["Editor for ReportControl element and its direct children with valid R
   <div class="content">
     <wizard-textfield
       dialoginitialfocus=""
+      disabled=""
       helper="[scl.name]"
       label="name"
       maxlength="32"
@@ -32,11 +33,13 @@ snapshots["Editor for ReportControl element and its direct children with valid R
     >
     </wizard-textfield>
     <wizard-checkbox
+      disabled=""
       helper="[scl.buffered]"
       label="buffered"
     >
     </wizard-checkbox>
     <wizard-textfield
+      disabled=""
       helper="[report.rptID]"
       label="rptID"
       nullable=""
@@ -44,12 +47,14 @@ snapshots["Editor for ReportControl element and its direct children with valid R
     >
     </wizard-textfield>
     <wizard-checkbox
+      disabled=""
       helper="[scl.indexed]"
       label="indexed"
       nullable=""
     >
     </wizard-checkbox>
     <wizard-textfield
+      disabled=""
       helper="[scl.maxReport]"
       label="max Clients"
       nullable=""
@@ -58,6 +63,7 @@ snapshots["Editor for ReportControl element and its direct children with valid R
     >
     </wizard-textfield>
     <wizard-textfield
+      disabled=""
       helper="[scl.bufTime]"
       label="bufTime"
       min="0"
@@ -68,6 +74,7 @@ snapshots["Editor for ReportControl element and its direct children with valid R
     >
     </wizard-textfield>
     <wizard-textfield
+      disabled=""
       helper="[scl.intgPd]"
       label="intgPd"
       min="0"
@@ -83,30 +90,35 @@ snapshots["Editor for ReportControl element and its direct children with valid R
       Trigger Options
     </h3>
     <wizard-checkbox
+      disabled=""
       helper="[scl.dchg]"
       label="dchg"
       nullable=""
     >
     </wizard-checkbox>
     <wizard-checkbox
+      disabled=""
       helper="[scl.qchg]"
       label="qchg"
       nullable=""
     >
     </wizard-checkbox>
     <wizard-checkbox
+      disabled=""
       helper="[scl.dupd]"
       label="dupd"
       nullable=""
     >
     </wizard-checkbox>
     <wizard-checkbox
+      disabled=""
       helper="[scl.period]"
       label="period"
       nullable=""
     >
     </wizard-checkbox>
     <wizard-checkbox
+      disabled=""
       helper="[scl.gi]"
       label="gi"
       nullable=""
@@ -116,48 +128,56 @@ snapshots["Editor for ReportControl element and its direct children with valid R
       Optional Fields
     </h3>
     <wizard-checkbox
+      disabled=""
       helper="[scl.seqNum]"
       label="seqNum"
       nullable=""
     >
     </wizard-checkbox>
     <wizard-checkbox
+      disabled=""
       helper="[scl.timeStamp]"
       label="timeStamp"
       nullable=""
     >
     </wizard-checkbox>
     <wizard-checkbox
+      disabled=""
       helper="[scl.dataSet]"
       label="dataSet"
       nullable=""
     >
     </wizard-checkbox>
     <wizard-checkbox
+      disabled=""
       helper="[scl.reasonCode]"
       label="reasonCode"
       nullable=""
     >
     </wizard-checkbox>
     <wizard-checkbox
+      disabled=""
       helper="[scl.dataRef]"
       label="dataRef"
       nullable=""
     >
     </wizard-checkbox>
     <wizard-checkbox
+      disabled=""
       helper="[scl.entryID]"
       label="entryID"
       nullable=""
     >
     </wizard-checkbox>
     <wizard-checkbox
+      disabled=""
       helper="[scl.configRef]"
       label="configRef"
       nullable=""
     >
     </wizard-checkbox>
     <wizard-checkbox
+      disabled=""
       helper="[scl.bufOvfl]"
       label="bufOvfl"
       nullable=""

--- a/test/unit/editors/publisher/__snapshots__/sampled-value-control-element-editor.test.snap.js
+++ b/test/unit/editors/publisher/__snapshots__/sampled-value-control-element-editor.test.snap.js
@@ -16,6 +16,7 @@ snapshots["Editor for SampledValueControl element its referenced elements with d
   <div class="content">
     <wizard-textfield
       dialoginitialfocus=""
+      disabled=""
       helper="[scl.name]"
       label="name"
       maxlength="32"
@@ -38,6 +39,7 @@ snapshots["Editor for SampledValueControl element its referenced elements with d
     >
     </wizard-checkbox>
     <wizard-textfield
+      disabled=""
       helper="[scl.id]"
       label="smvID"
       required=""
@@ -80,6 +82,7 @@ snapshots["Editor for SampledValueControl element its referenced elements with d
       </mwc-list-item>
     </wizard-select>
     <wizard-textfield
+      disabled=""
       helper="[scl.smpRate]"
       label="smpRate"
       min="0"
@@ -88,6 +91,7 @@ snapshots["Editor for SampledValueControl element its referenced elements with d
     >
     </wizard-textfield>
     <wizard-textfield
+      disabled=""
       helper="[scl.nofASDU]"
       label="nofASDU"
       min="0"
@@ -136,30 +140,35 @@ snapshots["Editor for SampledValueControl element its referenced elements with d
       [publisher.smv.smvopts]
     </h3>
     <wizard-checkbox
+      disabled=""
       helper="[scl.refreshTime]"
       label="refreshTime"
       nullable=""
     >
     </wizard-checkbox>
     <wizard-checkbox
+      disabled=""
       helper="[scl.sampleRate]"
       label="sampleRate"
       nullable=""
     >
     </wizard-checkbox>
     <wizard-checkbox
+      disabled=""
       helper="[scl.dataSet]"
       label="dataSet"
       nullable=""
     >
     </wizard-checkbox>
     <wizard-checkbox
+      disabled=""
       helper="[scl.security]"
       label="security"
       nullable=""
     >
     </wizard-checkbox>
     <wizard-checkbox
+      disabled=""
       helper="[scl.synchSourceId]"
       label="synchSourceId"
       nullable=""
@@ -169,22 +178,28 @@ snapshots["Editor for SampledValueControl element its referenced elements with d
       [publisher.smv.commsetting]
     </h3>
     <mwc-formfield label="[connectedap.wizard.addschemainsttype]">
-      <mwc-checkbox id="instType">
+      <mwc-checkbox
+        disabled=""
+        id="instType"
+      >
       </mwc-checkbox>
     </mwc-formfield>
     <wizard-textfield
+      disabled=""
       label="MAC-Address"
       pattern="([0-9A-F]{2}-){5}[0-9A-F]{2}"
       required=""
     >
     </wizard-textfield>
     <wizard-textfield
+      disabled=""
       label="APPID"
       pattern="[0-9A-F]{4}"
       required=""
     >
     </wizard-textfield>
     <wizard-textfield
+      disabled=""
       label="VLAN-ID"
       nullable=""
       pattern="[0-9A-F]{3}"
@@ -192,6 +207,7 @@ snapshots["Editor for SampledValueControl element its referenced elements with d
     >
     </wizard-textfield>
     <wizard-textfield
+      disabled=""
       label="VLAN-PRIORITY"
       nullable=""
       pattern="[0-7]"
@@ -218,6 +234,7 @@ snapshots["Editor for SampledValueControl element its referenced elements with m
   <div class="content">
     <wizard-textfield
       dialoginitialfocus=""
+      disabled=""
       helper="[scl.name]"
       label="name"
       maxlength="32"
@@ -234,6 +251,7 @@ snapshots["Editor for SampledValueControl element its referenced elements with m
     >
     </wizard-textfield>
     <wizard-textfield
+      disabled=""
       helper="[scl.id]"
       label="smvID"
       required=""
@@ -276,6 +294,7 @@ snapshots["Editor for SampledValueControl element its referenced elements with m
       </mwc-list-item>
     </wizard-select>
     <wizard-textfield
+      disabled=""
       helper="[scl.smpRate]"
       label="smpRate"
       min="0"
@@ -284,6 +303,7 @@ snapshots["Editor for SampledValueControl element its referenced elements with m
     >
     </wizard-textfield>
     <wizard-textfield
+      disabled=""
       helper="[scl.nofASDU]"
       label="nofASDU"
       min="0"
@@ -332,30 +352,35 @@ snapshots["Editor for SampledValueControl element its referenced elements with m
       [publisher.smv.smvopts]
     </h3>
     <wizard-checkbox
+      disabled=""
       helper="[scl.refreshTime]"
       label="refreshTime"
       nullable=""
     >
     </wizard-checkbox>
     <wizard-checkbox
+      disabled=""
       helper="[scl.sampleRate]"
       label="sampleRate"
       nullable=""
     >
     </wizard-checkbox>
     <wizard-checkbox
+      disabled=""
       helper="[scl.dataSet]"
       label="dataSet"
       nullable=""
     >
     </wizard-checkbox>
     <wizard-checkbox
+      disabled=""
       helper="[scl.security]"
       label="security"
       nullable=""
     >
     </wizard-checkbox>
     <wizard-checkbox
+      disabled=""
       helper="[scl.synchSourceId]"
       label="synchSourceId"
       nullable=""


### PR DESCRIPTION
Fixes #994 

We decided to disable read-only inputs for now. The main reason is that we will allow editing step by step and it makes sense then to clearly identify what is editable. Thanks for the hint @arulrajirudayasamy