### PR TITLE
Add ? and * wildcards to filtered-search, closes #1006.

### DIFF
--- a/public/md/Home.md
+++ b/public/md/Home.md
@@ -3,6 +3,7 @@ This is an open repository of information on OpenSCD and IEC 61850-6. You are we
 You can find information related to topics like
 
 - [Installation](https://github.com/openscd/open-scd/wiki/Install-OpenSCD)
+- [Interface](https://github.com/openscd/open-scd/wiki/Interface)
 - [Project workflow](https://github.com/openscd/open-scd/wiki/Project-workflow)
 - [Validators used in OpenSCD](https://github.com/openscd/open-scd/wiki/Validators)
 - [Extensions](https://github.com/openscd/open-scd/wiki/Extensions)

--- a/public/md/Interface.md
+++ b/public/md/Interface.md
@@ -1,0 +1,6 @@
+OpenSCD makes extensive use of lists which allow filtering by a search query.
+
+You can use wildcards as part of a search query:
+
+* A question mark, `?` will match any single character 
+* An asterisk, `*` will match one or more characters

--- a/public/md/_Sidebar.md
+++ b/public/md/_Sidebar.md
@@ -2,6 +2,8 @@
 
 ### 1.1 [Install OpenSCD](https://github.com/openscd/open-scd/wiki/Install-OpenSCD)
 
+### 1.2 [Interface](https://github.com/openscd/open-scd/wiki/Interface)
+
 ## 2. [Project management](https://github.com/openscd/open-scd/wiki/Project-workflow)
 
 ### 2.1 [Import IEDs](https://github.com/openscd/open-scd/wiki/Import-IEDs)

--- a/src/filtered-list.ts
+++ b/src/filtered-list.ts
@@ -38,11 +38,15 @@ function hideFiltered(item: ListItemBase, searchText: string): void {
     value
   ).toUpperCase();
 
-  const terms: string[] = searchText.toUpperCase().split(' ');
-
-  terms.some(term => !filterTarget.includes(term))
-    ? slotItem(item).classList.add('hidden')
-    : slotItem(item).classList.remove('hidden');
+  const terms: string[] = searchText.toUpperCase().trim().split(' ');
+  terms.some(term => {
+    // regexp escape 
+    const termRegexed = `*${term}*`.replace(/[.+^${}()|[\]\\]/g, '\\$&'); 
+    const reTerm = new RegExp(termRegexed.replace(/\*/g,'.*').replace(/\?/g,'.'),'i');
+    !reTerm.test(filterTarget)
+      ? slotItem(item).classList.add('hidden')
+      : slotItem(item).classList.remove('hidden');
+  });
 }
 
 /**

--- a/src/filtered-list.ts
+++ b/src/filtered-list.ts
@@ -18,6 +18,7 @@ import { List } from '@material/mwc-list';
 import { ListBase } from '@material/mwc-list/mwc-list-base';
 import { ListItemBase } from '@material/mwc-list/mwc-list-item-base';
 import { TextField } from '@material/mwc-textfield';
+import { ReportControlElementEditor } from './editors/publisher/report-control-element-editor';
 
 function slotItem(item: Element): Element {
   if (!item.closest('filtered-list') || !item.parentElement) return item;
@@ -38,18 +39,23 @@ function hideFiltered(item: ListItemBase, searchText: string): void {
     value
   ).toUpperCase();
 
-  const terms: string[] = searchText.toUpperCase().trim().split(' ');
-  terms.some(term => {
+  const terms: string[] = searchText
+    .toUpperCase()
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .trim()
+    .split(' ');
+
+  (terms.length === 1 && terms[0] === '') ||
+  terms.every(term => {
     // regexp escape
-    const termRegexed = `*${term}*`.replace(/[.+^${}()|[\]\\]/g, '\\$&');
     const reTerm = new RegExp(
-      termRegexed.replace(/\*/g, '.*').replace(/\?/g, '.{1}'),
+      `*${term}*`.replace(/\*/g, '.*').replace(/\?/g, '.{1}'),
       'i'
     );
-    !reTerm.test(filterTarget)
-      ? slotItem(item).classList.add('hidden')
-      : slotItem(item).classList.remove('hidden');
-  });
+    return reTerm.test(filterTarget);
+  })
+    ? slotItem(item).classList.remove('hidden')
+    : slotItem(item).classList.add('hidden');
 }
 
 /**

--- a/src/filtered-list.ts
+++ b/src/filtered-list.ts
@@ -43,7 +43,7 @@ function hideFiltered(item: ListItemBase, searchText: string): void {
     .toUpperCase()
     .replace(/[.+^${}()|[\]\\]/g, '\\$&')
     .trim()
-    .split(' ');
+    .split(/\s+/g);
 
   (terms.length === 1 && terms[0] === '') ||
   terms.every(term => {

--- a/src/filtered-list.ts
+++ b/src/filtered-list.ts
@@ -40,9 +40,12 @@ function hideFiltered(item: ListItemBase, searchText: string): void {
 
   const terms: string[] = searchText.toUpperCase().trim().split(' ');
   terms.some(term => {
-    // regexp escape 
-    const termRegexed = `*${term}*`.replace(/[.+^${}()|[\]\\]/g, '\\$&'); 
-    const reTerm = new RegExp(termRegexed.replace(/\*/g,'.*').replace(/\?/g,'.'),'i');
+    // regexp escape
+    const termRegexed = `*${term}*`.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+    const reTerm = new RegExp(
+      termRegexed.replace(/\*/g, '.*').replace(/\?/g, '.{1}'),
+      'i'
+    );
     !reTerm.test(filterTarget)
       ? slotItem(item).classList.add('hidden')
       : slotItem(item).classList.remove('hidden');

--- a/test/unit/filtered-list.test.ts
+++ b/test/unit/filtered-list.test.ts
@@ -207,5 +207,57 @@ describe('filtered-list', () => {
       expect(element.children[5].classList.contains('hidden')).to.be.true;
       expect(element.children[6].classList.contains('hidden')).to.be.false;
     });
+
+    it('allows filtering with a ? wildcard', async () => {
+      element.searchField.value = 'item?';
+      element.onFilterInput();
+      element.requestUpdate();
+      await element.updateComplete;
+      expect(element.children[0].classList.contains('hidden')).to.be.false;
+      expect(element.children[1].classList.contains('hidden')).to.be.false;
+      expect(element.children[2].classList.contains('hidden')).to.be.false;
+      expect(element.children[3].classList.contains('hidden')).to.be.false;
+      expect(element.children[4].classList.contains('hidden')).to.be.false;
+      expect(element.children[5].classList.contains('hidden')).to.be.false;
+    });
+
+    it('allows filtering with a * wildcard', async () => {
+      element.searchField.value = 'te*sec';
+      element.onFilterInput();
+      element.requestUpdate();
+      await element.updateComplete;
+      expect(element.children[0].classList.contains('hidden')).to.be.false;
+      expect(element.children[1].classList.contains('hidden')).to.be.false;
+      expect(element.children[2].classList.contains('hidden')).to.be.false;
+      expect(element.children[3].classList.contains('hidden')).to.be.false;
+      expect(element.children[4].classList.contains('hidden')).to.be.true;
+      expect(element.children[5].classList.contains('hidden')).to.be.true;
+    });
+
+    it('allows filtering with two ? wildcards', async () => {
+      element.searchField.value = 'nest??item';
+      element.onFilterInput();
+      element.requestUpdate();
+      await element.updateComplete;
+      expect(element.children[0].classList.contains('hidden')).to.be.true;
+      expect(element.children[1].classList.contains('hidden')).to.be.true;
+      expect(element.children[2].classList.contains('hidden')).to.be.true;
+      expect(element.children[3].classList.contains('hidden')).to.be.true;
+      expect(element.children[4].classList.contains('hidden')).to.be.false;
+      expect(element.children[5].classList.contains('hidden')).to.be.false;
+    });
+
+    it('allows filtering with a * and ? wildcard', async () => {
+      element.searchField.value = 'n*tem?';
+      element.onFilterInput();
+      element.requestUpdate();
+      await element.updateComplete;
+      expect(element.children[0].classList.contains('hidden')).to.be.true;
+      expect(element.children[1].classList.contains('hidden')).to.be.true;
+      expect(element.children[2].classList.contains('hidden')).to.be.true;
+      expect(element.children[3].classList.contains('hidden')).to.be.true;
+      expect(element.children[4].classList.contains('hidden')).to.be.false;
+      expect(element.children[5].classList.contains('hidden')).to.be.false;
+    });
   });
 });


### PR DESCRIPTION
This is just a prototype.

It does allow you to do a nice thing, i.e. line up phases between left and right.

![image](https://user-images.githubusercontent.com/674783/190924577-00a2cc07-48d6-4794-8773-ca2fd727c396.png)

