### PR TITLE
feat(hosting) Allow renaming project file

### DIFF
--- a/src/Hosting.ts
+++ b/src/Hosting.ts
@@ -275,11 +275,19 @@ export function Hosting<
 
     private changeProjectName(e: Event): void {
       let proposedName = (<HTMLInputElement>e.target!).value;
-      proposedName = proposedName.indexOf('.')
-        ? `${proposedName}.scd`
-        : proposedName;
+      // make filenames somewhat likely to work on Windows (not comprehensive)
+      proposedName = proposedName
+        .trim()
+        .replace(/[\\/:*?\"<>|]/g, '')
+        .substring(0, 240);
+      // untitled if nothing left over
+      proposedName = proposedName === '' ? 'untitled' : proposedName;
+      // would like a file extension, default to scd
+      proposedName =
+        proposedName.indexOf('.') !== -1 ? proposedName : `${proposedName}.scd`;
+  
       this.docName = proposedName;
-      (<HTMLInputElement>e.target!).value = proposedName
+      (<HTMLInputElement>e.target!).value = proposedName;
     }
 
     render(): TemplateResult {
@@ -314,15 +322,15 @@ export function Hosting<
               slot="navigationIcon"
               @click=${() => (this.menuUI.open = true)}
             ></mwc-icon-button>
-            <div slot="title" id="title">
-              <input
-                class="project_name"
-                type="text"
-                value="${this.docName}"
-                @change="${this.changeProjectName}"
-                ?disabled="${this.docName === ''}"
-              />
-            </div>
+            <input
+              class="project_name"
+              slot="title"
+              type="text"
+              spellcheck="false"
+              value="${this.docName}"
+              @change="${this.changeProjectName}"
+              ?disabled="${this.docName === ''}"
+            />
             ${this.menu.map(this.renderActionItem)}
             ${this.doc
               ? html`<mwc-tab-bar

--- a/src/Hosting.ts
+++ b/src/Hosting.ts
@@ -58,6 +58,9 @@ export function Hosting<
 
     @query('#menu') menuUI!: Drawer;
 
+    @query('.project_name')
+    projectName!: HTMLInputElement;
+
     get menu(): (MenuItem | 'divider')[] {
       const topMenu: (MenuItem | 'divider')[] = [];
       const middleMenu: (MenuItem | 'divider')[] = [];
@@ -229,6 +232,9 @@ export function Hosting<
         ).then();
         this.dispatchEvent(newPendingStateEvent(this.validated));
       });
+      this.addEventListener('open-doc', () => {
+        this.projectName!.value = this.docName;
+      });
     }
 
     renderMenuItem(me: MenuItem | 'divider'): TemplateResult {
@@ -267,6 +273,15 @@ export function Hosting<
       </mwc-tab>`;
     }
 
+    private changeProjectName(e: Event): void {
+      let proposedName = (<HTMLInputElement>e.target!).value;
+      proposedName = proposedName.indexOf('.')
+        ? `${proposedName}.scd`
+        : proposedName;
+      this.docName = proposedName;
+      (<HTMLInputElement>e.target!).value = proposedName
+    }
+
     render(): TemplateResult {
       return html` <mwc-drawer
           class="mdc-theme--surface"
@@ -282,7 +297,7 @@ export function Hosting<
             wrapFocus
             @action=${(ae: CustomEvent<ActionDetail>) => {
               //FIXME: dirty hack to be fixed in open-scd-core
-              //       if clause not neccassary when oscd... compenents in open-scd not list
+              //       if clause not necessary when oscd... components in open-scd not list
               if (ae.target instanceof List)
                 (<MenuItem>(
                   this.menu.filter(item => item !== 'divider')[ae.detail.index]
@@ -299,7 +314,15 @@ export function Hosting<
               slot="navigationIcon"
               @click=${() => (this.menuUI.open = true)}
             ></mwc-icon-button>
-            <div slot="title" id="title">${this.docName}</div>
+            <div slot="title" id="title">
+              <input
+                class="project_name"
+                type="text"
+                value="${this.docName}"
+                @change="${this.changeProjectName}"
+                ?disabled="${this.docName === ''}"
+              />
+            </div>
             ${this.menu.map(this.renderActionItem)}
             ${this.doc
               ? html`<mwc-tab-bar

--- a/src/open-scd.ts
+++ b/src/open-scd.ts
@@ -195,6 +195,11 @@ export class OpenSCD extends Hosting(
 
     .project_name:focus {
       outline: none;
+      filter: brightness(95%);
+    }
+
+    .project_name:hover {
+      filter: brightness(95%);
     }
 
     .plugin.menu {

--- a/src/open-scd.ts
+++ b/src/open-scd.ts
@@ -171,10 +171,6 @@ export class OpenSCD extends Hosting(
       font-family: 'Roboto', sans-serif;
     }
 
-    #title {
-      width: var(--mdc-top-app-bar-width, 100%);
-    }
-
     .project_name {
       background: var(--primary);
       border: none;

--- a/src/open-scd.ts
+++ b/src/open-scd.ts
@@ -171,6 +171,36 @@ export class OpenSCD extends Hosting(
       font-family: 'Roboto', sans-serif;
     }
 
+    #title {
+      width: var(--mdc-top-app-bar-width, 100%);
+    }
+
+    .project_name {
+      background: var(--primary);
+      border: none;
+      color: var(--mdc-theme-on-secondary);
+      font-family: var(
+        --mdc-typography-headline6-font-family,
+        var(--mdc-typography-font-family, Roboto, sans-serif)
+      );
+      font-size: var(--mdc-typography-headline6-font-size, 1.25rem);
+      font-weight: var(--mdc-typography-headline6-font-weight, 500);
+      line-height: var(--mdc-typography-headline6-line-height, 2rem);
+      letter-spacing: var(--mdc-typography-headline6-letter-spacing, 0.0125em);
+      padding-right: 0px;
+      text-decoration: var(--mdc-typography-headline6-text-decoration, inherit);
+      text-overflow: ellipsis;
+      text-transform: var(--mdc-typography-headline6-text-transform, inherit);
+      white-space: nowrap;
+      overflow: hidden;
+      z-index: 1;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    .project_name:focus {
+      outline: none;
+    }
+
     .plugin.menu {
       display: flex;
     }

--- a/test/integration/__snapshots__/open-scd.test.snap.js
+++ b/test/integration/__snapshots__/open-scd.test.snap.js
@@ -337,11 +337,14 @@ snapshots["open-scd looks like its snapshot"] =
       slot="navigationIcon"
     >
     </mwc-icon-button>
-    <div
-      id="title"
+    <input
+      class="project_name"
+      disabled=""
       slot="title"
+      spellcheck="false"
+      type="text"
+      value=""
     >
-    </div>
     <mwc-icon-button
       disabled=""
       icon="undo"


### PR DESCRIPTION
Closes #1027

This may be an unwanted feature since the issue has yet to go through refinement.

My excuse is that I was curious to see if I could do it :wink: 

I couldn't figure out the correct CSS to allow the width of the filename using the `<input`> element to be longer (it should be longer by default then it is as the previous implementation had).

I'm not quite sure whether this requires tests or where best to put them.