### PR TITLE
feat(editor/subscriber): Show counter for Subscriber Plugins (Logical Nodes / Later) (GOOSE/SMV)

### DIFF
--- a/src/editors/GooseSubscriberDataBinding.ts
+++ b/src/editors/GooseSubscriberDataBinding.ts
@@ -17,7 +17,8 @@ export default class GooseSubscribeDataBindingPlugin extends LitElement {
         <fcda-binding-list
           class="column"
           controlTag="GSEControl"
-          .doc=${this.doc}
+          .includeLaterBinding="${false}"
+          .doc="${this.doc}"
         >
         </fcda-binding-list>
         <extref-ln-binding-list

--- a/src/editors/GooseSubscriberLaterBinding.ts
+++ b/src/editors/GooseSubscriberLaterBinding.ts
@@ -12,14 +12,15 @@ export default class GooseSubscribeLaterBindingPlugin extends LitElement {
       <div class="container">
         <fcda-binding-list
           class="column"
-          .doc=${this.doc}
           controlTag="GSEControl"
+          .includeLaterBinding="${true}"
+          .doc="${this.doc}"
         >
         </fcda-binding-list>
         <extref-later-binding-list
           class="column"
           controlTag="GSEControl"
-          .doc=${this.doc}
+          .doc="${this.doc}"
         >
         </extref-later-binding-list>
       </div>

--- a/src/editors/SMVSubscriberDataBinding.ts
+++ b/src/editors/SMVSubscriberDataBinding.ts
@@ -5,7 +5,6 @@ import { Nsdoc } from '../foundation/nsdoc.js';
 import './subscription/fcda-binding-list.js';
 import './subscription/later-binding/ext-ref-ln-binding-list.js';
 
-/** An editor [[`plugin`]] for Subscribe Later Binding (SMV). */
 export default class SMVSubscribeDataBindingPlugin extends LitElement {
   @property({ attribute: false })
   doc!: XMLDocument;
@@ -18,7 +17,8 @@ export default class SMVSubscribeDataBindingPlugin extends LitElement {
         <fcda-binding-list
           class="column"
           controlTag="SampledValueControl"
-          .doc=${this.doc}
+          .includeLaterBinding="${false}"
+          .doc="${this.doc}"
         >
         </fcda-binding-list>
         <extref-ln-binding-list

--- a/src/editors/SMVSubscriberLaterBinding.ts
+++ b/src/editors/SMVSubscriberLaterBinding.ts
@@ -13,14 +13,15 @@ export default class SMVSubscribeLaterBindingPlugin extends LitElement {
       <div class="container">
         <fcda-binding-list
           class="column"
-          .doc=${this.doc}
           controlTag="SampledValueControl"
+          .includeLaterBinding="${true}"
+          .doc="${this.doc}"
         >
         </fcda-binding-list>
         <extref-later-binding-list
           class="column"
-          .doc=${this.doc}
           controlTag="SampledValueControl"
+          .doc="${this.doc}"
         >
         </extref-later-binding-list>
       </div>

--- a/src/editors/subscription/fcda-binding-list.ts
+++ b/src/editors/subscription/fcda-binding-list.ts
@@ -16,7 +16,6 @@ import '@material/mwc-list';
 import '@material/mwc-list/mwc-list-item';
 
 import {
-  compareNames,
   getDescriptionAttribute,
   getNameAttribute,
   identity,
@@ -63,9 +62,7 @@ export class FcdaBindingList extends LitElement {
 
   private getControlElements(): Element[] {
     if (this.doc) {
-      return Array.from(
-        this.doc.querySelectorAll(`LN0 > ${this.controlTag}`)
-      ).sort((a, b) => compareNames(`${identity(a)}`, `${identity(b)}`));
+      return Array.from(this.doc.querySelectorAll(`LN0 > ${this.controlTag}`));
     }
     return [];
   }
@@ -79,7 +76,7 @@ export class FcdaBindingList extends LitElement {
             'datSet'
           )}] > FCDA`
         )
-      ).sort((a, b) => compareNames(`${identity(a)}`, `${identity(b)}`));
+      );
     }
     return [];
   }

--- a/src/editors/subscription/foundation.ts
+++ b/src/editors/subscription/foundation.ts
@@ -54,12 +54,12 @@ export function newIEDSelectEvent(
 }
 
 export interface FcdaSelectDetail {
-  controlElement: Element | undefined;
+  control: Element | undefined;
   fcda: Element | undefined;
 }
 export type FcdaSelectEvent = CustomEvent<FcdaSelectDetail>;
 export function newFcdaSelectEvent(
-  controlElement: Element | undefined,
+  control: Element | undefined,
   fcda: Element | undefined,
   eventInitDict?: CustomEventInit<FcdaSelectDetail>
 ): FcdaSelectEvent {
@@ -67,7 +67,25 @@ export function newFcdaSelectEvent(
     bubbles: true,
     composed: true,
     ...eventInitDict,
-    detail: { controlElement, fcda, ...eventInitDict?.detail },
+    detail: { control, fcda, ...eventInitDict?.detail },
+  });
+}
+
+export interface SubscriptionChangedDetail {
+  control: Element | undefined;
+  fcda: Element | undefined;
+}
+export type SubscriptionChangedEvent = CustomEvent<SubscriptionChangedDetail>;
+export function newSubscriptionChangedEvent(
+  control: Element | undefined,
+  fcda: Element | undefined,
+  eventInitDict?: CustomEventInit<SubscriptionChangedDetail>
+): SubscriptionChangedEvent {
+  return new CustomEvent<SubscriptionChangedDetail>('subscription-changed', {
+    bubbles: true,
+    composed: true,
+    ...eventInitDict,
+    detail: { control, fcda, ...eventInitDict?.detail },
   });
 }
 
@@ -408,5 +426,6 @@ declare global {
     ['view']: ViewEvent;
     ['ied-select']: IEDSelectEvent;
     ['fcda-select']: FcdaSelectEvent;
+    ['subscription-changed']: SubscriptionChangedEvent;
   }
 }

--- a/src/editors/subscription/later-binding/ext-ref-later-binding-list.ts
+++ b/src/editors/subscription/later-binding/ext-ref-later-binding-list.ts
@@ -18,7 +18,12 @@ import {
   Replace,
 } from '../../../foundation.js';
 
-import { FcdaSelectEvent, styles, updateExtRefElement } from '../foundation.js';
+import {
+  FcdaSelectEvent,
+  newSubscriptionChangedEvent,
+  styles,
+  updateExtRefElement,
+} from '../foundation.js';
 import {
   getAvailableExtRefElements,
   getSubscribedExtRefElements,
@@ -53,7 +58,7 @@ export class ExtRefLaterBindingList extends LitElement {
   }
 
   private async onFcdaSelectEvent(event: FcdaSelectEvent) {
-    this.currentSelectedControlElement = event.detail.controlElement;
+    this.currentSelectedControlElement = event.detail.control;
     this.currentSelectedFcdaElement = event.detail.fcda;
 
     // Retrieve the IED Element to which the FCDA belongs.
@@ -190,6 +195,12 @@ export class ExtRefLaterBindingList extends LitElement {
                 const replaceAction = this.unsubscribe(extRefElement);
                 if (replaceAction) {
                   this.dispatchEvent(newActionEvent(replaceAction));
+                  this.dispatchEvent(
+                    newSubscriptionChangedEvent(
+                      this.currentSelectedControlElement,
+                      this.currentSelectedFcdaElement
+                    )
+                  );
                 }
               }}
               value="${identity(extRefElement)}"
@@ -241,6 +252,12 @@ export class ExtRefLaterBindingList extends LitElement {
                 const replaceAction = this.subscribe(extRefElement);
                 if (replaceAction) {
                   this.dispatchEvent(newActionEvent(replaceAction));
+                  this.dispatchEvent(
+                    newSubscriptionChangedEvent(
+                      this.currentSelectedControlElement,
+                      this.currentSelectedFcdaElement
+                    )
+                  );
                 }
               }}
               value="${identity(extRefElement)}"

--- a/src/editors/subscription/later-binding/ext-ref-ln-binding-list.ts
+++ b/src/editors/subscription/later-binding/ext-ref-ln-binding-list.ts
@@ -24,6 +24,7 @@ import {
   createExtRefElement,
   existExtRef,
   FcdaSelectEvent,
+  newSubscriptionChangedEvent,
   styles,
 } from '../foundation.js';
 import { getSubscribedExtRefElements } from './foundation.js';
@@ -98,7 +99,7 @@ export class ExtRefLnBindingList extends LitElement {
   }
 
   private async onFcdaSelectEvent(event: FcdaSelectEvent) {
-    this.currentSelectedControlElement = event.detail.controlElement;
+    this.currentSelectedControlElement = event.detail.control;
     this.currentSelectedFcdaElement = event.detail.fcda;
 
     // Retrieve the IED Element to which the FCDA belongs.
@@ -224,6 +225,12 @@ export class ExtRefLnBindingList extends LitElement {
                 const replaceAction = this.unsubscribe(lnElement);
                 if (replaceAction) {
                   this.dispatchEvent(newActionEvent(replaceAction));
+                  this.dispatchEvent(
+                    newSubscriptionChangedEvent(
+                      this.currentSelectedControlElement,
+                      this.currentSelectedFcdaElement
+                    )
+                  );
                 }
               }}
             >
@@ -270,6 +277,12 @@ export class ExtRefLnBindingList extends LitElement {
                 const replaceAction = this.subscribe(lnElement);
                 if (replaceAction) {
                   this.dispatchEvent(newActionEvent(replaceAction));
+                  this.dispatchEvent(
+                    newSubscriptionChangedEvent(
+                      this.currentSelectedControlElement,
+                      this.currentSelectedFcdaElement
+                    )
+                  );
                 }
               }}
             >

--- a/src/editors/subscription/later-binding/ext-ref-ln-binding-list.ts
+++ b/src/editors/subscription/later-binding/ext-ref-ln-binding-list.ts
@@ -24,14 +24,13 @@ import {
   createExtRefElement,
   existExtRef,
   FcdaSelectEvent,
-  serviceTypes,
   styles,
 } from '../foundation.js';
-import { isSubscribedTo } from './foundation.js';
+import { getSubscribedExtRefElements } from './foundation.js';
 import {
   emptyInputsDeleteActions,
   getFcdaReferences,
-} from '../../../foundation/ied';
+} from '../../../foundation/ied.js';
 
 /**
  * A sub element for showing all Ext Refs from a FCDA Element.
@@ -67,17 +66,7 @@ export class ExtRefLnBindingList extends LitElement {
     if (this.doc) {
       return Array.from(
         this.doc.querySelectorAll('LDevice > LN0, LDevice > LN')
-      )
-        .filter(element => element.closest('IED') !== this.currentIedElement)
-        .sort((a, b) =>
-          (
-            identity(a.closest('LDevice')) +
-            ' ' +
-            this.buildLNTitle(a)
-          ).localeCompare(
-            identity(b.closest('LDevice')) + ' ' + this.buildLNTitle(b)
-          )
-        );
+      ).filter(element => element.closest('IED') !== this.currentIedElement);
     }
     return [];
   }
@@ -85,33 +74,25 @@ export class ExtRefLnBindingList extends LitElement {
   private getSubscribedLNElements(): Element[] {
     return this.getLNElements().filter(
       element =>
-        Array.from(element.querySelectorAll('ExtRef'))
-          .filter(
-            extRefElement => extRefElement.getAttribute('intAddr') === null
-          )
-          .filter(extRefElement =>
-            isSubscribedTo(
-              serviceTypes[this.controlTag],
-              this.currentIedElement,
-              this.currentSelectedControlElement,
-              this.currentSelectedFcdaElement,
-              extRefElement
-            )
-          ).length > 0
+        getSubscribedExtRefElements(
+          element,
+          this.controlTag,
+          this.currentSelectedFcdaElement,
+          this.currentSelectedControlElement,
+          false
+        ).length > 0
     );
   }
 
   private getAvailableLNElements(): Element[] {
     return this.getLNElements().filter(
       element =>
-        Array.from(element.querySelectorAll('ExtRef')).filter(extRefElement =>
-          isSubscribedTo(
-            serviceTypes[this.controlTag],
-            this.currentIedElement,
-            this.currentSelectedControlElement,
-            this.currentSelectedFcdaElement,
-            extRefElement
-          )
+        getSubscribedExtRefElements(
+          element,
+          this.controlTag,
+          this.currentSelectedFcdaElement,
+          this.currentSelectedControlElement,
+          undefined // We also want to exclude LN that are already bind using Later Binding.
         ).length == 0
     );
   }

--- a/test/integration/editors/GooseSubscriberDataBinding.test.ts
+++ b/test/integration/editors/GooseSubscriberDataBinding.test.ts
@@ -8,6 +8,7 @@ import GooseSubscriberDataBinding from '../../../src/editors/GooseSubscriberData
 import {
   getExtrefDataBindingList,
   getFCDABindingList,
+  getSelectedSubItemValue,
 } from './test-support.js';
 
 describe('GOOSE Subscribe Data Binding Plugin', async () => {
@@ -48,6 +49,7 @@ describe('GOOSE Subscribe Data Binding Plugin', async () => {
     expect(extRefListElement['getSubscribedLNElements']().length).to.be.equal(
       0
     );
+    expect(getSelectedSubItemValue(fcdaListElement)).to.be.null;
     expect(extRefListElement['getAvailableLNElements']().length).to.be.equal(8);
 
     (<HTMLElement>(
@@ -60,6 +62,7 @@ describe('GOOSE Subscribe Data Binding Plugin', async () => {
     expect(extRefListElement['getSubscribedLNElements']().length).to.be.equal(
       1
     );
+    expect(getSelectedSubItemValue(fcdaListElement)).to.have.text('1');
     expect(extRefListElement['getAvailableLNElements']().length).to.be.equal(7);
   });
 
@@ -78,6 +81,7 @@ describe('GOOSE Subscribe Data Binding Plugin', async () => {
     expect(extRefListElement['getSubscribedLNElements']().length).to.be.equal(
       1
     );
+    expect(getSelectedSubItemValue(fcdaListElement)).to.have.text('1');
     expect(extRefListElement['getAvailableLNElements']().length).to.be.equal(5);
 
     (<HTMLElement>(
@@ -90,6 +94,7 @@ describe('GOOSE Subscribe Data Binding Plugin', async () => {
     expect(extRefListElement['getSubscribedLNElements']().length).to.be.equal(
       0
     );
+    expect(getSelectedSubItemValue(fcdaListElement)).to.be.null;
     expect(extRefListElement['getAvailableLNElements']().length).to.be.equal(6);
   });
 });

--- a/test/integration/editors/GooseSubscriberLaterBinding.test.ts
+++ b/test/integration/editors/GooseSubscriberLaterBinding.test.ts
@@ -6,6 +6,7 @@ import GooseSubscriberLaterBinding from '../../../src/editors/GooseSubscriberLat
 import {
   getExtrefLaterBindingList,
   getFCDABindingList,
+  getSelectedSubItemValue,
 } from './test-support.js';
 
 describe('GOOSE Subscribe Later Binding Plugin', () => {
@@ -43,6 +44,7 @@ describe('GOOSE Subscribe Later Binding Plugin', () => {
     expect(
       extRefListElement['getSubscribedExtRefElements']().length
     ).to.be.equal(0);
+    expect(getSelectedSubItemValue(fcdaListElement)).to.be.null;
     expect(
       extRefListElement['getAvailableExtRefElements']().length
     ).to.be.equal(4);
@@ -57,6 +59,7 @@ describe('GOOSE Subscribe Later Binding Plugin', () => {
     expect(
       extRefListElement['getSubscribedExtRefElements']().length
     ).to.be.equal(1);
+    expect(getSelectedSubItemValue(fcdaListElement)).to.have.text('1');
     expect(
       extRefListElement['getAvailableExtRefElements']().length
     ).to.be.equal(3);
@@ -77,6 +80,7 @@ describe('GOOSE Subscribe Later Binding Plugin', () => {
     expect(
       extRefListElement['getSubscribedExtRefElements']().length
     ).to.be.equal(2);
+    expect(getSelectedSubItemValue(fcdaListElement)).to.have.text('2');
     expect(
       extRefListElement['getAvailableExtRefElements']().length
     ).to.be.equal(4);
@@ -91,6 +95,7 @@ describe('GOOSE Subscribe Later Binding Plugin', () => {
     expect(
       extRefListElement['getSubscribedExtRefElements']().length
     ).to.be.equal(1);
+    expect(getSelectedSubItemValue(fcdaListElement)).to.have.text('1');
     expect(
       extRefListElement['getAvailableExtRefElements']().length
     ).to.be.equal(5);

--- a/test/integration/editors/SMVSubscriberDataBinding.test.ts
+++ b/test/integration/editors/SMVSubscriberDataBinding.test.ts
@@ -8,6 +8,7 @@ import SMVSubscriberDataBinding from '../../../src/editors/SMVSubscriberDataBind
 import {
   getExtrefDataBindingList,
   getFCDABindingList,
+  getSelectedSubItemValue,
 } from './test-support.js';
 
 describe('SMV Subscribe Data Binding Plugin', async () => {
@@ -48,6 +49,7 @@ describe('SMV Subscribe Data Binding Plugin', async () => {
     expect(extRefListElement['getSubscribedLNElements']().length).to.be.equal(
       1
     );
+    expect(getSelectedSubItemValue(fcdaListElement)).to.have.text('1');
     expect(extRefListElement['getAvailableLNElements']().length).to.be.equal(7);
 
     (<HTMLElement>(
@@ -60,6 +62,7 @@ describe('SMV Subscribe Data Binding Plugin', async () => {
     expect(extRefListElement['getSubscribedLNElements']().length).to.be.equal(
       2
     );
+    expect(getSelectedSubItemValue(fcdaListElement)).to.have.text('2');
     expect(extRefListElement['getAvailableLNElements']().length).to.be.equal(6);
   });
 
@@ -78,6 +81,7 @@ describe('SMV Subscribe Data Binding Plugin', async () => {
     expect(extRefListElement['getSubscribedLNElements']().length).to.be.equal(
       2
     );
+    expect(getSelectedSubItemValue(fcdaListElement)).to.have.text('2');
     expect(extRefListElement['getAvailableLNElements']().length).to.be.equal(6);
 
     (<HTMLElement>(
@@ -90,6 +94,7 @@ describe('SMV Subscribe Data Binding Plugin', async () => {
     expect(extRefListElement['getSubscribedLNElements']().length).to.be.equal(
       1
     );
+    expect(getSelectedSubItemValue(fcdaListElement)).to.have.text('1');
     expect(extRefListElement['getAvailableLNElements']().length).to.be.equal(7);
   });
 });

--- a/test/integration/editors/SMVSubscriberLaterBinding.test.ts
+++ b/test/integration/editors/SMVSubscriberLaterBinding.test.ts
@@ -7,6 +7,7 @@ import SMVSubscribeLaterBindingPlugin from '../../../src/editors/SMVSubscriberLa
 import {
   getExtrefLaterBindingList,
   getFCDABindingList,
+  getSelectedSubItemValue,
 } from './test-support.js';
 
 describe('SMV Subscribe Later Binding plugin', () => {
@@ -44,6 +45,7 @@ describe('SMV Subscribe Later Binding plugin', () => {
     expect(
       extRefListElement['getSubscribedExtRefElements']().length
     ).to.be.equal(0);
+    expect(getSelectedSubItemValue(fcdaListElement)).to.be.null;
     expect(
       extRefListElement['getAvailableExtRefElements']().length
     ).to.be.equal(8);
@@ -58,6 +60,7 @@ describe('SMV Subscribe Later Binding plugin', () => {
     expect(
       extRefListElement['getSubscribedExtRefElements']().length
     ).to.be.equal(1);
+    expect(getSelectedSubItemValue(fcdaListElement)).to.have.text('1');
     expect(
       extRefListElement['getAvailableExtRefElements']().length
     ).to.be.equal(7);
@@ -77,6 +80,7 @@ describe('SMV Subscribe Later Binding plugin', () => {
     expect(
       extRefListElement['getSubscribedExtRefElements']().length
     ).to.be.equal(3);
+    expect(getSelectedSubItemValue(fcdaListElement)).to.have.text('3');
     expect(
       extRefListElement['getAvailableExtRefElements']().length
     ).to.be.equal(8);
@@ -91,6 +95,7 @@ describe('SMV Subscribe Later Binding plugin', () => {
     expect(
       extRefListElement['getSubscribedExtRefElements']().length
     ).to.be.equal(2);
+    expect(getSelectedSubItemValue(fcdaListElement)).to.have.text('2');
     expect(
       extRefListElement['getAvailableExtRefElements']().length
     ).to.be.equal(9);

--- a/test/integration/editors/test-support.ts
+++ b/test/integration/editors/test-support.ts
@@ -34,3 +34,11 @@ export function getExtrefLaterBindingList(
     element.shadowRoot?.querySelector('extref-later-binding-list')
   );
 }
+
+export function getSelectedSubItemValue(
+  element: FcdaBindingList
+): Element | null {
+  return element.shadowRoot!.querySelector(
+    '.subitem[selected] span[slot="meta"]'
+  );
+}

--- a/test/unit/editors/subscription/__snapshots__/fcda-binding-list.test.snap.js
+++ b/test/unit/editors/subscription/__snapshots__/fcda-binding-list.test.snap.js
@@ -23,162 +23,7 @@ snapshots["fcda-binding-list with a SampledValueControl doc loaded looks like th
       noninteractive=""
       tabindex="-1"
       twoline=""
-      value="SMV_Publisher>>CurrentTransformer>currentOnly SMV_Publisher>>CurrentTransformer>currentOnlysDataSet>CurrentTransformer/L1 TCTR 1.AmpSv instMag.i (MX) SMV_Publisher>>CurrentTransformer>currentOnlysDataSet>CurrentTransformer/L1 TCTR 1.AmpSv q (MX) SMV_Publisher>>CurrentTransformer>currentOnlysDataSet>CurrentTransformer/L2 TCTR 1.AmpSv instMag.i (MX) SMV_Publisher>>CurrentTransformer>currentOnlysDataSet>CurrentTransformer/L2 TCTR 1.AmpSv q (MX) SMV_Publisher>>CurrentTransformer>currentOnlysDataSet>CurrentTransformer/L3 TCTR 1.AmpSv instMag.i (MX) SMV_Publisher>>CurrentTransformer>currentOnlysDataSet>CurrentTransformer/L3 TCTR 1.AmpSv q (MX)"
-    >
-      <mwc-icon-button
-        class="interactive"
-        icon="edit"
-        slot="meta"
-      >
-      </mwc-icon-button>
-      <span>
-        currentOnly
-      </span>
-      <span slot="secondary">
-        SMV_Publisher>>CurrentTransformer>currentOnly
-      </span>
-      <mwc-icon slot="graphic">
-      </mwc-icon>
-    </mwc-list-item>
-    <li
-      divider=""
-      role="separator"
-    >
-    </li>
-    <mwc-list-item
-      aria-disabled="false"
-      class="subitem"
-      graphic="large"
-      mwc-list-item=""
-      tabindex="0"
-      twoline=""
-      value="SMV_Publisher>>CurrentTransformer>currentOnly SMV_Publisher>>CurrentTransformer>currentOnlysDataSet>CurrentTransformer/L1 TCTR 1.AmpSv instMag.i (MX)"
-    >
-      <span>
-        AmpSv.instMag.i
-      </span>
-      <span slot="secondary">
-        CurrentTransformer/L1
-        TCTR
-        1
-      </span>
-      <mwc-icon slot="graphic">
-        subdirectory_arrow_right
-      </mwc-icon>
-    </mwc-list-item>
-    <mwc-list-item
-      aria-disabled="false"
-      class="subitem"
-      graphic="large"
-      mwc-list-item=""
-      tabindex="-1"
-      twoline=""
-      value="SMV_Publisher>>CurrentTransformer>currentOnly SMV_Publisher>>CurrentTransformer>currentOnlysDataSet>CurrentTransformer/L1 TCTR 1.AmpSv q (MX)"
-    >
-      <span>
-        AmpSv.q
-      </span>
-      <span slot="secondary">
-        CurrentTransformer/L1
-        TCTR
-        1
-      </span>
-      <mwc-icon slot="graphic">
-        subdirectory_arrow_right
-      </mwc-icon>
-    </mwc-list-item>
-    <mwc-list-item
-      aria-disabled="false"
-      class="subitem"
-      graphic="large"
-      mwc-list-item=""
-      tabindex="-1"
-      twoline=""
-      value="SMV_Publisher>>CurrentTransformer>currentOnly SMV_Publisher>>CurrentTransformer>currentOnlysDataSet>CurrentTransformer/L2 TCTR 1.AmpSv instMag.i (MX)"
-    >
-      <span>
-        AmpSv.instMag.i
-      </span>
-      <span slot="secondary">
-        CurrentTransformer/L2
-        TCTR
-        1
-      </span>
-      <mwc-icon slot="graphic">
-        subdirectory_arrow_right
-      </mwc-icon>
-    </mwc-list-item>
-    <mwc-list-item
-      aria-disabled="false"
-      class="subitem"
-      graphic="large"
-      mwc-list-item=""
-      tabindex="-1"
-      twoline=""
-      value="SMV_Publisher>>CurrentTransformer>currentOnly SMV_Publisher>>CurrentTransformer>currentOnlysDataSet>CurrentTransformer/L2 TCTR 1.AmpSv q (MX)"
-    >
-      <span>
-        AmpSv.q
-      </span>
-      <span slot="secondary">
-        CurrentTransformer/L2
-        TCTR
-        1
-      </span>
-      <mwc-icon slot="graphic">
-        subdirectory_arrow_right
-      </mwc-icon>
-    </mwc-list-item>
-    <mwc-list-item
-      aria-disabled="false"
-      class="subitem"
-      graphic="large"
-      mwc-list-item=""
-      tabindex="-1"
-      twoline=""
-      value="SMV_Publisher>>CurrentTransformer>currentOnly SMV_Publisher>>CurrentTransformer>currentOnlysDataSet>CurrentTransformer/L3 TCTR 1.AmpSv instMag.i (MX)"
-    >
-      <span>
-        AmpSv.instMag.i
-      </span>
-      <span slot="secondary">
-        CurrentTransformer/L3
-        TCTR
-        1
-      </span>
-      <mwc-icon slot="graphic">
-        subdirectory_arrow_right
-      </mwc-icon>
-    </mwc-list-item>
-    <mwc-list-item
-      aria-disabled="false"
-      class="subitem"
-      graphic="large"
-      mwc-list-item=""
-      tabindex="-1"
-      twoline=""
-      value="SMV_Publisher>>CurrentTransformer>currentOnly SMV_Publisher>>CurrentTransformer>currentOnlysDataSet>CurrentTransformer/L3 TCTR 1.AmpSv q (MX)"
-    >
-      <span>
-        AmpSv.q
-      </span>
-      <span slot="secondary">
-        CurrentTransformer/L3
-        TCTR
-        1
-      </span>
-      <mwc-icon slot="graphic">
-        subdirectory_arrow_right
-      </mwc-icon>
-    </mwc-list-item>
-    <mwc-list-item
-      aria-disabled="false"
-      graphic="icon"
-      hasmeta=""
-      noninteractive=""
-      tabindex="-1"
-      twoline=""
-      value="SMV_Publisher>>CurrentTransformer>fullSmv SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>CurrentTransformer/L1 TCTR 1.AmpSv instMag.i (MX) SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>CurrentTransformer/L1 TCTR 1.AmpSv q (MX) SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>CurrentTransformer/L2 TCTR 1.AmpSv instMag.i (MX) SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>CurrentTransformer/L2 TCTR 1.AmpSv q (MX) SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>CurrentTransformer/L3 TCTR 1.AmpSv instMag.i (MX) SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>CurrentTransformer/L3 TCTR 1.AmpSv q (MX) SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>VoltageTransformer/L1 TVTR 1.VolSv instMag.i (MX) SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>VoltageTransformer/L1 TVTR 1.VolSv q (MX) SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>VoltageTransformer/L2 TVTR 1.VolSv instMag.i (MX) SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>VoltageTransformer/L2 TVTR 1.VolSv q (MX) SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>VoltageTransformer/L3 TVTR 1.VolSv instMag.i (MX) SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>VoltageTransformer/L3 TVTR 1.VolSv q (MX)"
+      value="SMV_Publisher>>CurrentTransformer>fullSmv SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>CurrentTransformer/L3 TCTR 1.AmpSv instMag.i (MX) SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>CurrentTransformer/L3 TCTR 1.AmpSv q (MX) SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>CurrentTransformer/L2 TCTR 1.AmpSv instMag.i (MX) SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>CurrentTransformer/L2 TCTR 1.AmpSv q (MX) SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>CurrentTransformer/L1 TCTR 1.AmpSv instMag.i (MX) SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>CurrentTransformer/L1 TCTR 1.AmpSv q (MX) SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>VoltageTransformer/L3 TVTR 1.VolSv instMag.i (MX) SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>VoltageTransformer/L3 TVTR 1.VolSv q (MX) SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>VoltageTransformer/L2 TVTR 1.VolSv instMag.i (MX) SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>VoltageTransformer/L2 TVTR 1.VolSv q (MX) SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>VoltageTransformer/L1 TVTR 1.VolSv instMag.i (MX) SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>VoltageTransformer/L1 TVTR 1.VolSv q (MX)"
     >
       <mwc-icon-button
         class="interactive"
@@ -205,15 +50,15 @@ snapshots["fcda-binding-list with a SampledValueControl doc loaded looks like th
       class="subitem"
       graphic="large"
       mwc-list-item=""
-      tabindex="-1"
+      tabindex="0"
       twoline=""
-      value="SMV_Publisher>>CurrentTransformer>fullSmv SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>CurrentTransformer/L1 TCTR 1.AmpSv instMag.i (MX)"
+      value="SMV_Publisher>>CurrentTransformer>fullSmv SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>CurrentTransformer/L3 TCTR 1.AmpSv instMag.i (MX)"
     >
       <span>
         AmpSv.instMag.i
       </span>
       <span slot="secondary">
-        CurrentTransformer/L1
+        CurrentTransformer/L3
         TCTR
         1
       </span>
@@ -228,13 +73,13 @@ snapshots["fcda-binding-list with a SampledValueControl doc loaded looks like th
       mwc-list-item=""
       tabindex="-1"
       twoline=""
-      value="SMV_Publisher>>CurrentTransformer>fullSmv SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>CurrentTransformer/L1 TCTR 1.AmpSv q (MX)"
+      value="SMV_Publisher>>CurrentTransformer>fullSmv SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>CurrentTransformer/L3 TCTR 1.AmpSv q (MX)"
     >
       <span>
         AmpSv.q
       </span>
       <span slot="secondary">
-        CurrentTransformer/L1
+        CurrentTransformer/L3
         TCTR
         1
       </span>
@@ -291,13 +136,13 @@ snapshots["fcda-binding-list with a SampledValueControl doc loaded looks like th
       mwc-list-item=""
       tabindex="-1"
       twoline=""
-      value="SMV_Publisher>>CurrentTransformer>fullSmv SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>CurrentTransformer/L3 TCTR 1.AmpSv instMag.i (MX)"
+      value="SMV_Publisher>>CurrentTransformer>fullSmv SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>CurrentTransformer/L1 TCTR 1.AmpSv instMag.i (MX)"
     >
       <span>
         AmpSv.instMag.i
       </span>
       <span slot="secondary">
-        CurrentTransformer/L3
+        CurrentTransformer/L1
         TCTR
         1
       </span>
@@ -312,13 +157,13 @@ snapshots["fcda-binding-list with a SampledValueControl doc loaded looks like th
       mwc-list-item=""
       tabindex="-1"
       twoline=""
-      value="SMV_Publisher>>CurrentTransformer>fullSmv SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>CurrentTransformer/L3 TCTR 1.AmpSv q (MX)"
+      value="SMV_Publisher>>CurrentTransformer>fullSmv SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>CurrentTransformer/L1 TCTR 1.AmpSv q (MX)"
     >
       <span>
         AmpSv.q
       </span>
       <span slot="secondary">
-        CurrentTransformer/L3
+        CurrentTransformer/L1
         TCTR
         1
       </span>
@@ -333,13 +178,13 @@ snapshots["fcda-binding-list with a SampledValueControl doc loaded looks like th
       mwc-list-item=""
       tabindex="-1"
       twoline=""
-      value="SMV_Publisher>>CurrentTransformer>fullSmv SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>VoltageTransformer/L1 TVTR 1.VolSv instMag.i (MX)"
+      value="SMV_Publisher>>CurrentTransformer>fullSmv SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>VoltageTransformer/L3 TVTR 1.VolSv instMag.i (MX)"
     >
       <span>
         VolSv.instMag.i
       </span>
       <span slot="secondary">
-        VoltageTransformer/L1
+        VoltageTransformer/L3
         TVTR
         1
       </span>
@@ -354,13 +199,13 @@ snapshots["fcda-binding-list with a SampledValueControl doc loaded looks like th
       mwc-list-item=""
       tabindex="-1"
       twoline=""
-      value="SMV_Publisher>>CurrentTransformer>fullSmv SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>VoltageTransformer/L1 TVTR 1.VolSv q (MX)"
+      value="SMV_Publisher>>CurrentTransformer>fullSmv SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>VoltageTransformer/L3 TVTR 1.VolSv q (MX)"
     >
       <span>
         VolSv.q
       </span>
       <span slot="secondary">
-        VoltageTransformer/L1
+        VoltageTransformer/L3
         TVTR
         1
       </span>
@@ -417,13 +262,13 @@ snapshots["fcda-binding-list with a SampledValueControl doc loaded looks like th
       mwc-list-item=""
       tabindex="-1"
       twoline=""
-      value="SMV_Publisher>>CurrentTransformer>fullSmv SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>VoltageTransformer/L3 TVTR 1.VolSv instMag.i (MX)"
+      value="SMV_Publisher>>CurrentTransformer>fullSmv SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>VoltageTransformer/L1 TVTR 1.VolSv instMag.i (MX)"
     >
       <span>
         VolSv.instMag.i
       </span>
       <span slot="secondary">
-        VoltageTransformer/L3
+        VoltageTransformer/L1
         TVTR
         1
       </span>
@@ -438,13 +283,13 @@ snapshots["fcda-binding-list with a SampledValueControl doc loaded looks like th
       mwc-list-item=""
       tabindex="-1"
       twoline=""
-      value="SMV_Publisher>>CurrentTransformer>fullSmv SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>VoltageTransformer/L3 TVTR 1.VolSv q (MX)"
+      value="SMV_Publisher>>CurrentTransformer>fullSmv SMV_Publisher>>CurrentTransformer>fullSmvsDataSet>VoltageTransformer/L1 TVTR 1.VolSv q (MX)"
     >
       <span>
         VolSv.q
       </span>
       <span slot="secondary">
-        VoltageTransformer/L3
+        VoltageTransformer/L1
         TVTR
         1
       </span>
@@ -607,6 +452,161 @@ snapshots["fcda-binding-list with a SampledValueControl doc loaded looks like th
         subdirectory_arrow_right
       </mwc-icon>
     </mwc-list-item>
+    <mwc-list-item
+      aria-disabled="false"
+      graphic="icon"
+      hasmeta=""
+      noninteractive=""
+      tabindex="-1"
+      twoline=""
+      value="SMV_Publisher>>CurrentTransformer>currentOnly SMV_Publisher>>CurrentTransformer>currentOnlysDataSet>CurrentTransformer/L1 TCTR 1.AmpSv instMag.i (MX) SMV_Publisher>>CurrentTransformer>currentOnlysDataSet>CurrentTransformer/L1 TCTR 1.AmpSv q (MX) SMV_Publisher>>CurrentTransformer>currentOnlysDataSet>CurrentTransformer/L2 TCTR 1.AmpSv instMag.i (MX) SMV_Publisher>>CurrentTransformer>currentOnlysDataSet>CurrentTransformer/L2 TCTR 1.AmpSv q (MX) SMV_Publisher>>CurrentTransformer>currentOnlysDataSet>CurrentTransformer/L3 TCTR 1.AmpSv instMag.i (MX) SMV_Publisher>>CurrentTransformer>currentOnlysDataSet>CurrentTransformer/L3 TCTR 1.AmpSv q (MX)"
+    >
+      <mwc-icon-button
+        class="interactive"
+        icon="edit"
+        slot="meta"
+      >
+      </mwc-icon-button>
+      <span>
+        currentOnly
+      </span>
+      <span slot="secondary">
+        SMV_Publisher>>CurrentTransformer>currentOnly
+      </span>
+      <mwc-icon slot="graphic">
+      </mwc-icon>
+    </mwc-list-item>
+    <li
+      divider=""
+      role="separator"
+    >
+    </li>
+    <mwc-list-item
+      aria-disabled="false"
+      class="subitem"
+      graphic="large"
+      mwc-list-item=""
+      tabindex="-1"
+      twoline=""
+      value="SMV_Publisher>>CurrentTransformer>currentOnly SMV_Publisher>>CurrentTransformer>currentOnlysDataSet>CurrentTransformer/L1 TCTR 1.AmpSv instMag.i (MX)"
+    >
+      <span>
+        AmpSv.instMag.i
+      </span>
+      <span slot="secondary">
+        CurrentTransformer/L1
+        TCTR
+        1
+      </span>
+      <mwc-icon slot="graphic">
+        subdirectory_arrow_right
+      </mwc-icon>
+    </mwc-list-item>
+    <mwc-list-item
+      aria-disabled="false"
+      class="subitem"
+      graphic="large"
+      mwc-list-item=""
+      tabindex="-1"
+      twoline=""
+      value="SMV_Publisher>>CurrentTransformer>currentOnly SMV_Publisher>>CurrentTransformer>currentOnlysDataSet>CurrentTransformer/L1 TCTR 1.AmpSv q (MX)"
+    >
+      <span>
+        AmpSv.q
+      </span>
+      <span slot="secondary">
+        CurrentTransformer/L1
+        TCTR
+        1
+      </span>
+      <mwc-icon slot="graphic">
+        subdirectory_arrow_right
+      </mwc-icon>
+    </mwc-list-item>
+    <mwc-list-item
+      aria-disabled="false"
+      class="subitem"
+      graphic="large"
+      mwc-list-item=""
+      tabindex="-1"
+      twoline=""
+      value="SMV_Publisher>>CurrentTransformer>currentOnly SMV_Publisher>>CurrentTransformer>currentOnlysDataSet>CurrentTransformer/L2 TCTR 1.AmpSv instMag.i (MX)"
+    >
+      <span>
+        AmpSv.instMag.i
+      </span>
+      <span slot="secondary">
+        CurrentTransformer/L2
+        TCTR
+        1
+      </span>
+      <mwc-icon slot="graphic">
+        subdirectory_arrow_right
+      </mwc-icon>
+    </mwc-list-item>
+    <mwc-list-item
+      aria-disabled="false"
+      class="subitem"
+      graphic="large"
+      mwc-list-item=""
+      tabindex="-1"
+      twoline=""
+      value="SMV_Publisher>>CurrentTransformer>currentOnly SMV_Publisher>>CurrentTransformer>currentOnlysDataSet>CurrentTransformer/L2 TCTR 1.AmpSv q (MX)"
+    >
+      <span>
+        AmpSv.q
+      </span>
+      <span slot="secondary">
+        CurrentTransformer/L2
+        TCTR
+        1
+      </span>
+      <mwc-icon slot="graphic">
+        subdirectory_arrow_right
+      </mwc-icon>
+    </mwc-list-item>
+    <mwc-list-item
+      aria-disabled="false"
+      class="subitem"
+      graphic="large"
+      mwc-list-item=""
+      tabindex="-1"
+      twoline=""
+      value="SMV_Publisher>>CurrentTransformer>currentOnly SMV_Publisher>>CurrentTransformer>currentOnlysDataSet>CurrentTransformer/L3 TCTR 1.AmpSv instMag.i (MX)"
+    >
+      <span>
+        AmpSv.instMag.i
+      </span>
+      <span slot="secondary">
+        CurrentTransformer/L3
+        TCTR
+        1
+      </span>
+      <mwc-icon slot="graphic">
+        subdirectory_arrow_right
+      </mwc-icon>
+    </mwc-list-item>
+    <mwc-list-item
+      aria-disabled="false"
+      class="subitem"
+      graphic="large"
+      mwc-list-item=""
+      tabindex="-1"
+      twoline=""
+      value="SMV_Publisher>>CurrentTransformer>currentOnly SMV_Publisher>>CurrentTransformer>currentOnlysDataSet>CurrentTransformer/L3 TCTR 1.AmpSv q (MX)"
+    >
+      <span>
+        AmpSv.q
+      </span>
+      <span slot="secondary">
+        CurrentTransformer/L3
+        TCTR
+        1
+      </span>
+      <mwc-icon slot="graphic">
+        subdirectory_arrow_right
+      </mwc-icon>
+    </mwc-list-item>
   </filtered-list>
 </section>
 `;
@@ -625,7 +625,7 @@ snapshots["fcda-binding-list with a GSEControl doc loaded looks like the latest 
       noninteractive=""
       tabindex="-1"
       twoline=""
-      value="IED1>>CircuitBreaker_CB1>GCB IED1>>CircuitBreaker_CB1>GooseDataSet1>CircuitBreaker_CB1/ CSWI 1.Pos stVal (ST) IED1>>CircuitBreaker_CB1>GooseDataSet1>CircuitBreaker_CB1/ XCBR 1.Pos q (ST) IED1>>CircuitBreaker_CB1>GooseDataSet1>CircuitBreaker_CB1/ XCBR 1.Pos stVal (ST) IED1>>CircuitBreaker_CB1>GooseDataSet1>Disconnectors/DC XSWI 1.Pos q (ST) IED1>>CircuitBreaker_CB1>GooseDataSet1>Disconnectors/DC XSWI 1.Pos stVal (ST)"
+      value="IED1>>CircuitBreaker_CB1>GCB IED1>>CircuitBreaker_CB1>GooseDataSet1>CircuitBreaker_CB1/ XCBR 1.Pos stVal (ST) IED1>>CircuitBreaker_CB1>GooseDataSet1>CircuitBreaker_CB1/ XCBR 1.Pos q (ST) IED1>>CircuitBreaker_CB1>GooseDataSet1>CircuitBreaker_CB1/ CSWI 1.Pos stVal (ST) IED1>>CircuitBreaker_CB1>GooseDataSet1>Disconnectors/DC XSWI 1.Pos stVal (ST) IED1>>CircuitBreaker_CB1>GooseDataSet1>Disconnectors/DC XSWI 1.Pos q (ST)"
     >
       <mwc-icon-button
         class="interactive"
@@ -654,14 +654,14 @@ snapshots["fcda-binding-list with a GSEControl doc loaded looks like the latest 
       mwc-list-item=""
       tabindex="0"
       twoline=""
-      value="IED1>>CircuitBreaker_CB1>GCB IED1>>CircuitBreaker_CB1>GooseDataSet1>CircuitBreaker_CB1/ CSWI 1.Pos stVal (ST)"
+      value="IED1>>CircuitBreaker_CB1>GCB IED1>>CircuitBreaker_CB1>GooseDataSet1>CircuitBreaker_CB1/ XCBR 1.Pos stVal (ST)"
     >
       <span>
         Pos.stVal
       </span>
       <span slot="secondary">
         CircuitBreaker_CB1/
-        CSWI
+        XCBR
         1
       </span>
       <mwc-icon slot="graphic">
@@ -696,35 +696,14 @@ snapshots["fcda-binding-list with a GSEControl doc loaded looks like the latest 
       mwc-list-item=""
       tabindex="-1"
       twoline=""
-      value="IED1>>CircuitBreaker_CB1>GCB IED1>>CircuitBreaker_CB1>GooseDataSet1>CircuitBreaker_CB1/ XCBR 1.Pos stVal (ST)"
+      value="IED1>>CircuitBreaker_CB1>GCB IED1>>CircuitBreaker_CB1>GooseDataSet1>CircuitBreaker_CB1/ CSWI 1.Pos stVal (ST)"
     >
       <span>
         Pos.stVal
       </span>
       <span slot="secondary">
         CircuitBreaker_CB1/
-        XCBR
-        1
-      </span>
-      <mwc-icon slot="graphic">
-        subdirectory_arrow_right
-      </mwc-icon>
-    </mwc-list-item>
-    <mwc-list-item
-      aria-disabled="false"
-      class="subitem"
-      graphic="large"
-      mwc-list-item=""
-      tabindex="-1"
-      twoline=""
-      value="IED1>>CircuitBreaker_CB1>GCB IED1>>CircuitBreaker_CB1>GooseDataSet1>Disconnectors/DC XSWI 1.Pos q (ST)"
-    >
-      <span>
-        Pos.q
-      </span>
-      <span slot="secondary">
-        Disconnectors/DC
-        XSWI
+        CSWI
         1
       </span>
       <mwc-icon slot="graphic">
@@ -742,6 +721,27 @@ snapshots["fcda-binding-list with a GSEControl doc loaded looks like the latest 
     >
       <span>
         Pos.stVal
+      </span>
+      <span slot="secondary">
+        Disconnectors/DC
+        XSWI
+        1
+      </span>
+      <mwc-icon slot="graphic">
+        subdirectory_arrow_right
+      </mwc-icon>
+    </mwc-list-item>
+    <mwc-list-item
+      aria-disabled="false"
+      class="subitem"
+      graphic="large"
+      mwc-list-item=""
+      tabindex="-1"
+      twoline=""
+      value="IED1>>CircuitBreaker_CB1>GCB IED1>>CircuitBreaker_CB1>GooseDataSet1>Disconnectors/DC XSWI 1.Pos q (ST)"
+    >
+      <span>
+        Pos.q
       </span>
       <span slot="secondary">
         Disconnectors/DC
@@ -788,7 +788,7 @@ snapshots["fcda-binding-list with a GSEControl doc loaded looks like the latest 
       noninteractive=""
       tabindex="-1"
       twoline=""
-      value="IED2>>CBSW>GCB IED2>>CBSW>GooseDataSet1>CBSW/ XSWI 2.Pos q (ST) IED2>>CBSW>GooseDataSet1>CBSW/ XSWI 2.Pos stVal (ST) IED2>>CBSW>GooseDataSet1>CBSW/ XSWI 3.Pos q (ST)"
+      value="IED2>>CBSW>GCB IED2>>CBSW>GooseDataSet1>CBSW/ XSWI 2.Pos stVal (ST) IED2>>CBSW>GooseDataSet1>CBSW/ XSWI 2.Pos q (ST) IED2>>CBSW>GooseDataSet1>CBSW/ XSWI 3.Pos q (ST)"
     >
       <mwc-icon-button
         class="interactive"
@@ -817,10 +817,10 @@ snapshots["fcda-binding-list with a GSEControl doc loaded looks like the latest 
       mwc-list-item=""
       tabindex="-1"
       twoline=""
-      value="IED2>>CBSW>GCB IED2>>CBSW>GooseDataSet1>CBSW/ XSWI 2.Pos q (ST)"
+      value="IED2>>CBSW>GCB IED2>>CBSW>GooseDataSet1>CBSW/ XSWI 2.Pos stVal (ST)"
     >
       <span>
-        Pos.q
+        Pos.stVal
       </span>
       <span slot="secondary">
         CBSW/
@@ -838,10 +838,10 @@ snapshots["fcda-binding-list with a GSEControl doc loaded looks like the latest 
       mwc-list-item=""
       tabindex="-1"
       twoline=""
-      value="IED2>>CBSW>GCB IED2>>CBSW>GooseDataSet1>CBSW/ XSWI 2.Pos stVal (ST)"
+      value="IED2>>CBSW>GCB IED2>>CBSW>GooseDataSet1>CBSW/ XSWI 2.Pos q (ST)"
     >
       <span>
-        Pos.stVal
+        Pos.q
       </span>
       <span slot="secondary">
         CBSW/
@@ -880,7 +880,7 @@ snapshots["fcda-binding-list with a GSEControl doc loaded looks like the latest 
       noninteractive=""
       tabindex="-1"
       twoline=""
-      value="IED4>>CircuitBreaker_CB1>GCB IED4>>CircuitBreaker_CB1>GooseDataSet1>CircuitBreaker_CB1/ CSWI 1.Pos stVal (ST) IED4>>CircuitBreaker_CB1>GooseDataSet1>CircuitBreaker_CB1/ XCBR 1.Pos q (ST) IED4>>CircuitBreaker_CB1>GooseDataSet1>CircuitBreaker_CB1/ XCBR 1.Pos stVal (ST) IED4>>CircuitBreaker_CB1>GooseDataSet1>Disconnectors/DC XSWI 1.Pos q (ST) IED4>>CircuitBreaker_CB1>GooseDataSet1>Disconnectors/DC XSWI 1.Pos stVal (ST)"
+      value="IED4>>CircuitBreaker_CB1>GCB IED4>>CircuitBreaker_CB1>GooseDataSet1>CircuitBreaker_CB1/ XCBR 1.Pos stVal (ST) IED4>>CircuitBreaker_CB1>GooseDataSet1>CircuitBreaker_CB1/ XCBR 1.Pos q (ST) IED4>>CircuitBreaker_CB1>GooseDataSet1>CircuitBreaker_CB1/ CSWI 1.Pos stVal (ST) IED4>>CircuitBreaker_CB1>GooseDataSet1>Disconnectors/DC XSWI 1.Pos stVal (ST) IED4>>CircuitBreaker_CB1>GooseDataSet1>Disconnectors/DC XSWI 1.Pos q (ST)"
     >
       <mwc-icon-button
         class="interactive"
@@ -909,14 +909,14 @@ snapshots["fcda-binding-list with a GSEControl doc loaded looks like the latest 
       mwc-list-item=""
       tabindex="-1"
       twoline=""
-      value="IED4>>CircuitBreaker_CB1>GCB IED4>>CircuitBreaker_CB1>GooseDataSet1>CircuitBreaker_CB1/ CSWI 1.Pos stVal (ST)"
+      value="IED4>>CircuitBreaker_CB1>GCB IED4>>CircuitBreaker_CB1>GooseDataSet1>CircuitBreaker_CB1/ XCBR 1.Pos stVal (ST)"
     >
       <span>
         Pos.stVal
       </span>
       <span slot="secondary">
         CircuitBreaker_CB1/
-        CSWI
+        XCBR
         1
       </span>
       <mwc-icon slot="graphic">
@@ -951,35 +951,14 @@ snapshots["fcda-binding-list with a GSEControl doc loaded looks like the latest 
       mwc-list-item=""
       tabindex="-1"
       twoline=""
-      value="IED4>>CircuitBreaker_CB1>GCB IED4>>CircuitBreaker_CB1>GooseDataSet1>CircuitBreaker_CB1/ XCBR 1.Pos stVal (ST)"
+      value="IED4>>CircuitBreaker_CB1>GCB IED4>>CircuitBreaker_CB1>GooseDataSet1>CircuitBreaker_CB1/ CSWI 1.Pos stVal (ST)"
     >
       <span>
         Pos.stVal
       </span>
       <span slot="secondary">
         CircuitBreaker_CB1/
-        XCBR
-        1
-      </span>
-      <mwc-icon slot="graphic">
-        subdirectory_arrow_right
-      </mwc-icon>
-    </mwc-list-item>
-    <mwc-list-item
-      aria-disabled="false"
-      class="subitem"
-      graphic="large"
-      mwc-list-item=""
-      tabindex="-1"
-      twoline=""
-      value="IED4>>CircuitBreaker_CB1>GCB IED4>>CircuitBreaker_CB1>GooseDataSet1>Disconnectors/DC XSWI 1.Pos q (ST)"
-    >
-      <span>
-        Pos.q
-      </span>
-      <span slot="secondary">
-        Disconnectors/DC
-        XSWI
+        CSWI
         1
       </span>
       <mwc-icon slot="graphic">
@@ -997,6 +976,27 @@ snapshots["fcda-binding-list with a GSEControl doc loaded looks like the latest 
     >
       <span>
         Pos.stVal
+      </span>
+      <span slot="secondary">
+        Disconnectors/DC
+        XSWI
+        1
+      </span>
+      <mwc-icon slot="graphic">
+        subdirectory_arrow_right
+      </mwc-icon>
+    </mwc-list-item>
+    <mwc-list-item
+      aria-disabled="false"
+      class="subitem"
+      graphic="large"
+      mwc-list-item=""
+      tabindex="-1"
+      twoline=""
+      value="IED4>>CircuitBreaker_CB1>GCB IED4>>CircuitBreaker_CB1>GooseDataSet1>Disconnectors/DC XSWI 1.Pos q (ST)"
+    >
+      <span>
+        Pos.q
       </span>
       <span slot="secondary">
         Disconnectors/DC

--- a/test/unit/editors/subscription/__snapshots__/fcda-binding-list.test.snap.js
+++ b/test/unit/editors/subscription/__snapshots__/fcda-binding-list.test.snap.js
@@ -330,6 +330,7 @@ snapshots["fcda-binding-list with a SampledValueControl doc loaded looks like th
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -346,6 +347,9 @@ snapshots["fcda-binding-list with a SampledValueControl doc loaded looks like th
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+        1
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
@@ -485,6 +489,7 @@ snapshots["fcda-binding-list with a SampledValueControl doc loaded looks like th
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -501,11 +506,15 @@ snapshots["fcda-binding-list with a SampledValueControl doc loaded looks like th
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+        1
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -522,6 +531,9 @@ snapshots["fcda-binding-list with a SampledValueControl doc loaded looks like th
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+        3
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
@@ -814,6 +826,7 @@ snapshots["fcda-binding-list with a GSEControl doc loaded looks like the latest 
       aria-disabled="false"
       class="subitem"
       graphic="large"
+      hasmeta=""
       mwc-list-item=""
       tabindex="-1"
       twoline=""
@@ -830,6 +843,9 @@ snapshots["fcda-binding-list with a GSEControl doc loaded looks like the latest 
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
       </mwc-icon>
+      <span slot="meta">
+        1
+      </span>
     </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"

--- a/test/unit/editors/subscription/fcda-binding-list.test.ts
+++ b/test/unit/editors/subscription/fcda-binding-list.test.ts
@@ -101,7 +101,7 @@ describe('fcda-binding-list', () => {
       await element.updateComplete;
 
       expect(selectEvent).to.have.been.called;
-      expect(selectEvent.args[0][0].detail.controlElement).to.equal(
+      expect(selectEvent.args[0][0].detail.control).to.equal(
         doc.querySelector(
           'IED[name="SMV_Publisher"] LN0 > SampledValueControl[name="currentOnly"]'
         )

--- a/test/unit/editors/subscription/fcda-binding-list.test.ts
+++ b/test/unit/editors/subscription/fcda-binding-list.test.ts
@@ -75,7 +75,7 @@ describe('fcda-binding-list', () => {
       const nameField = <WizardTextField>(
         parent.wizardUI.dialog?.querySelector('wizard-textfield[label="name"]')
       );
-      expect(nameField.value).to.be.equal('currentOnly');
+      expect(nameField.value).to.be.equal('fullSmv');
     });
 
     it('event is fired, but properties are undefined', () => {

--- a/test/unit/editors/subscription/later-binding/__snapshots__/ext-ref-later-binding-list.test.snap.js
+++ b/test/unit/editors/subscription/later-binding/__snapshots__/ext-ref-later-binding-list.test.snap.js
@@ -52,7 +52,7 @@ snapshots["extref-later-binding-list for Sampled Value Control when SVC has no s
       aria-disabled="false"
       noninteractive=""
       tabindex="-1"
-      value="MeasPoint.CT2 SMV_Subscriber>>Overvoltage> PTRC 1>AmpSv;TCTR2/AmpSv/instMag.i[0] MeasPoint.CT3 SMV_Subscriber>>Overvoltage> PTRC 1>AmpSv;TCTR3/AmpSv/instMag.i[0] Restricted To AmpSV SMV_Subscriber>>Overcurrent> PTRC 1>someRestrictedExtRef[0] MeasPoint.VT1 SMV_Subscriber>>Overcurrent> PTRC 1>VolSv;TVTR1/VolSv/q[0] MeasPoint.VT2 SMV_Subscriber>>Overcurrent> PTRC 1>VolSv;TVTR2/VolSv/instMag.i[0] MeasPoint.VT1 SMV_Subscriber>>Overcurrent> PTRC 1>VolSv;TVTR2/VolSv/q[0] MeasPoint.VT3 SMV_Subscriber>>Overcurrent> PTRC 1>VolSv;TVTR3/VolSv/instMag.i[0] MeasPoint.VT1 SMV_Subscriber>>Overcurrent> PTRC 1>VolSv;TVTR3/VolSv/q[0]"
+      value="MeasPoint.CT2 SMV_Subscriber>>Overvoltage> PTRC 1>AmpSv;TCTR2/AmpSv/instMag.i[0] MeasPoint.CT3 SMV_Subscriber>>Overvoltage> PTRC 1>AmpSv;TCTR3/AmpSv/instMag.i[0] MeasPoint.VT1 SMV_Subscriber>>Overcurrent> PTRC 1>VolSv;TVTR1/VolSv/q[0] MeasPoint.VT2 SMV_Subscriber>>Overcurrent> PTRC 1>VolSv;TVTR2/VolSv/instMag.i[0] MeasPoint.VT1 SMV_Subscriber>>Overcurrent> PTRC 1>VolSv;TVTR2/VolSv/q[0] MeasPoint.VT3 SMV_Subscriber>>Overcurrent> PTRC 1>VolSv;TVTR3/VolSv/instMag.i[0] MeasPoint.VT1 SMV_Subscriber>>Overcurrent> PTRC 1>VolSv;TVTR3/VolSv/q[0] Restricted To AmpSV SMV_Subscriber>>Overcurrent> PTRC 1>someRestrictedExtRef[0]"
     >
       <span>
         [subscription.subscriber.availableToSubscribe]
@@ -96,26 +96,6 @@ snapshots["extref-later-binding-list for Sampled Value Control when SVC has no s
       </span>
       <span slot="secondary">
         SMV_Subscriber>>Overvoltage> PTRC 1>AmpSv;TCTR3/AmpSv/instMag.i[0]
-      </span>
-      <mwc-icon slot="graphic">
-        arrow_back
-      </mwc-icon>
-    </mwc-list-item>
-    <mwc-list-item
-      aria-disabled="true"
-      disabled=""
-      graphic="large"
-      mwc-list-item=""
-      tabindex="-1"
-      twoline=""
-      value="SMV_Subscriber>>Overcurrent> PTRC 1>someRestrictedExtRef[0]"
-    >
-      <span>
-        someRestrictedExtRef
-                 (Restricted To AmpSV)
-      </span>
-      <span slot="secondary">
-        SMV_Subscriber>>Overcurrent> PTRC 1>someRestrictedExtRef[0]
       </span>
       <mwc-icon slot="graphic">
         arrow_back
@@ -211,6 +191,26 @@ snapshots["extref-later-binding-list for Sampled Value Control when SVC has no s
       </span>
       <span slot="secondary">
         SMV_Subscriber>>Overcurrent> PTRC 1>VolSv;TVTR3/VolSv/q[0]
+      </span>
+      <mwc-icon slot="graphic">
+        arrow_back
+      </mwc-icon>
+    </mwc-list-item>
+    <mwc-list-item
+      aria-disabled="true"
+      disabled=""
+      graphic="large"
+      mwc-list-item=""
+      tabindex="-1"
+      twoline=""
+      value="SMV_Subscriber>>Overcurrent> PTRC 1>someRestrictedExtRef[0]"
+    >
+      <span>
+        someRestrictedExtRef
+                 (Restricted To AmpSV)
+      </span>
+      <span slot="secondary">
+        SMV_Subscriber>>Overcurrent> PTRC 1>someRestrictedExtRef[0]
       </span>
       <mwc-icon slot="graphic">
         arrow_back
@@ -265,7 +265,7 @@ snapshots["extref-later-binding-list for Sampled Value Control when SVC has a si
       aria-disabled="false"
       noninteractive=""
       tabindex="-1"
-      value="MeasPoint.CT2 SMV_Subscriber>>Overvoltage> PTRC 1>AmpSv;TCTR2/AmpSv/instMag.i[0] MeasPoint.CT3 SMV_Subscriber>>Overvoltage> PTRC 1>AmpSv;TCTR3/AmpSv/instMag.i[0] Restricted To AmpSV SMV_Subscriber>>Overcurrent> PTRC 1>someRestrictedExtRef[0] MeasPoint.VT1 SMV_Subscriber>>Overcurrent> PTRC 1>VolSv;TVTR1/VolSv/q[0] MeasPoint.VT2 SMV_Subscriber>>Overcurrent> PTRC 1>VolSv;TVTR2/VolSv/instMag.i[0] MeasPoint.VT1 SMV_Subscriber>>Overcurrent> PTRC 1>VolSv;TVTR2/VolSv/q[0] MeasPoint.VT3 SMV_Subscriber>>Overcurrent> PTRC 1>VolSv;TVTR3/VolSv/instMag.i[0] MeasPoint.VT1 SMV_Subscriber>>Overcurrent> PTRC 1>VolSv;TVTR3/VolSv/q[0]"
+      value="MeasPoint.CT2 SMV_Subscriber>>Overvoltage> PTRC 1>AmpSv;TCTR2/AmpSv/instMag.i[0] MeasPoint.CT3 SMV_Subscriber>>Overvoltage> PTRC 1>AmpSv;TCTR3/AmpSv/instMag.i[0] MeasPoint.VT1 SMV_Subscriber>>Overcurrent> PTRC 1>VolSv;TVTR1/VolSv/q[0] MeasPoint.VT2 SMV_Subscriber>>Overcurrent> PTRC 1>VolSv;TVTR2/VolSv/instMag.i[0] MeasPoint.VT1 SMV_Subscriber>>Overcurrent> PTRC 1>VolSv;TVTR2/VolSv/q[0] MeasPoint.VT3 SMV_Subscriber>>Overcurrent> PTRC 1>VolSv;TVTR3/VolSv/instMag.i[0] MeasPoint.VT1 SMV_Subscriber>>Overcurrent> PTRC 1>VolSv;TVTR3/VolSv/q[0] Restricted To AmpSV SMV_Subscriber>>Overcurrent> PTRC 1>someRestrictedExtRef[0]"
     >
       <span>
         [subscription.subscriber.availableToSubscribe]
@@ -309,26 +309,6 @@ snapshots["extref-later-binding-list for Sampled Value Control when SVC has a si
       </span>
       <span slot="secondary">
         SMV_Subscriber>>Overvoltage> PTRC 1>AmpSv;TCTR3/AmpSv/instMag.i[0]
-      </span>
-      <mwc-icon slot="graphic">
-        arrow_back
-      </mwc-icon>
-    </mwc-list-item>
-    <mwc-list-item
-      aria-disabled="true"
-      disabled=""
-      graphic="large"
-      mwc-list-item=""
-      tabindex="-1"
-      twoline=""
-      value="SMV_Subscriber>>Overcurrent> PTRC 1>someRestrictedExtRef[0]"
-    >
-      <span>
-        someRestrictedExtRef
-                 (Restricted To AmpSV)
-      </span>
-      <span slot="secondary">
-        SMV_Subscriber>>Overcurrent> PTRC 1>someRestrictedExtRef[0]
       </span>
       <mwc-icon slot="graphic">
         arrow_back
@@ -424,6 +404,26 @@ snapshots["extref-later-binding-list for Sampled Value Control when SVC has a si
       </span>
       <span slot="secondary">
         SMV_Subscriber>>Overcurrent> PTRC 1>VolSv;TVTR3/VolSv/q[0]
+      </span>
+      <mwc-icon slot="graphic">
+        arrow_back
+      </mwc-icon>
+    </mwc-list-item>
+    <mwc-list-item
+      aria-disabled="true"
+      disabled=""
+      graphic="large"
+      mwc-list-item=""
+      tabindex="-1"
+      twoline=""
+      value="SMV_Subscriber>>Overcurrent> PTRC 1>someRestrictedExtRef[0]"
+    >
+      <span>
+        someRestrictedExtRef
+                 (Restricted To AmpSV)
+      </span>
+      <span slot="secondary">
+        SMV_Subscriber>>Overcurrent> PTRC 1>someRestrictedExtRef[0]
       </span>
       <mwc-icon slot="graphic">
         arrow_back
@@ -510,7 +510,7 @@ snapshots["extref-later-binding-list when SVC has a multiple subscriptions looks
       aria-disabled="false"
       noninteractive=""
       tabindex="-1"
-      value="MeasPoint.CT2 SMV_Subscriber>>Overvoltage> PTRC 1>AmpSv;TCTR2/AmpSv/instMag.i[0] MeasPoint.CT3 SMV_Subscriber>>Overvoltage> PTRC 1>AmpSv;TCTR3/AmpSv/instMag.i[0] Restricted To AmpSV SMV_Subscriber>>Overcurrent> PTRC 1>someRestrictedExtRef[0] MeasPoint.VT1 SMV_Subscriber>>Overcurrent> PTRC 1>VolSv;TVTR1/VolSv/q[0] MeasPoint.VT2 SMV_Subscriber>>Overcurrent> PTRC 1>VolSv;TVTR2/VolSv/instMag.i[0] MeasPoint.VT1 SMV_Subscriber>>Overcurrent> PTRC 1>VolSv;TVTR2/VolSv/q[0] MeasPoint.VT3 SMV_Subscriber>>Overcurrent> PTRC 1>VolSv;TVTR3/VolSv/instMag.i[0] MeasPoint.VT1 SMV_Subscriber>>Overcurrent> PTRC 1>VolSv;TVTR3/VolSv/q[0]"
+      value="MeasPoint.CT2 SMV_Subscriber>>Overvoltage> PTRC 1>AmpSv;TCTR2/AmpSv/instMag.i[0] MeasPoint.CT3 SMV_Subscriber>>Overvoltage> PTRC 1>AmpSv;TCTR3/AmpSv/instMag.i[0] MeasPoint.VT1 SMV_Subscriber>>Overcurrent> PTRC 1>VolSv;TVTR1/VolSv/q[0] MeasPoint.VT2 SMV_Subscriber>>Overcurrent> PTRC 1>VolSv;TVTR2/VolSv/instMag.i[0] MeasPoint.VT1 SMV_Subscriber>>Overcurrent> PTRC 1>VolSv;TVTR2/VolSv/q[0] MeasPoint.VT3 SMV_Subscriber>>Overcurrent> PTRC 1>VolSv;TVTR3/VolSv/instMag.i[0] MeasPoint.VT1 SMV_Subscriber>>Overcurrent> PTRC 1>VolSv;TVTR3/VolSv/q[0] Restricted To AmpSV SMV_Subscriber>>Overcurrent> PTRC 1>someRestrictedExtRef[0]"
     >
       <span>
         [subscription.subscriber.availableToSubscribe]
@@ -554,26 +554,6 @@ snapshots["extref-later-binding-list when SVC has a multiple subscriptions looks
       </span>
       <span slot="secondary">
         SMV_Subscriber>>Overvoltage> PTRC 1>AmpSv;TCTR3/AmpSv/instMag.i[0]
-      </span>
-      <mwc-icon slot="graphic">
-        arrow_back
-      </mwc-icon>
-    </mwc-list-item>
-    <mwc-list-item
-      aria-disabled="true"
-      disabled=""
-      graphic="large"
-      mwc-list-item=""
-      tabindex="-1"
-      twoline=""
-      value="SMV_Subscriber>>Overcurrent> PTRC 1>someRestrictedExtRef[0]"
-    >
-      <span>
-        someRestrictedExtRef
-                 (Restricted To AmpSV)
-      </span>
-      <span slot="secondary">
-        SMV_Subscriber>>Overcurrent> PTRC 1>someRestrictedExtRef[0]
       </span>
       <mwc-icon slot="graphic">
         arrow_back
@@ -674,6 +654,26 @@ snapshots["extref-later-binding-list when SVC has a multiple subscriptions looks
         arrow_back
       </mwc-icon>
     </mwc-list-item>
+    <mwc-list-item
+      aria-disabled="true"
+      disabled=""
+      graphic="large"
+      mwc-list-item=""
+      tabindex="-1"
+      twoline=""
+      value="SMV_Subscriber>>Overcurrent> PTRC 1>someRestrictedExtRef[0]"
+    >
+      <span>
+        someRestrictedExtRef
+                 (Restricted To AmpSV)
+      </span>
+      <span slot="secondary">
+        SMV_Subscriber>>Overcurrent> PTRC 1>someRestrictedExtRef[0]
+      </span>
+      <mwc-icon slot="graphic">
+        arrow_back
+      </mwc-icon>
+    </mwc-list-item>
   </filtered-list>
 </section>
 `;
@@ -721,7 +721,7 @@ snapshots["extref-later-binding-list for GOOSE Control when GSEControl has no su
       aria-disabled="false"
       noninteractive=""
       tabindex="-1"
-      value="Interlocking.Input3 GOOSE_Subscriber>>Earth_Switch> CILO 1>GOOSE:GOOSE2 QB2_Disconnector/ LLN0  GOOSE_Publisher QB1_Disconnector/ CILO 1 EnaCls stVal@Pos;CILO/EnaCls/stVal Interlocking.Input4 GOOSE_Subscriber>>Earth_Switch> CILO 1>GOOSE:GOOSE2 QB2_Disconnector/ LLN0  GOOSE_Publisher QB2_Disconnector/ CILO 1 EnaOpn stVal@Pos;CILO/EnaOpn2/stVal Interlocking.Input GOOSE_Subscriber>>Earth_Switch> CILO 1>Pos;CSWI1/Pos/stVal[0] Restricted To Pos GOOSE_Subscriber>>Earth_Switch> CSWI 1>someRestrictedExtRef[0]"
+      value="Interlocking.Input GOOSE_Subscriber>>Earth_Switch> CILO 1>Pos;CSWI1/Pos/stVal[0] Interlocking.Input3 GOOSE_Subscriber>>Earth_Switch> CILO 1>GOOSE:GOOSE2 QB2_Disconnector/ LLN0  GOOSE_Publisher QB1_Disconnector/ CILO 1 EnaCls stVal@Pos;CILO/EnaCls/stVal Interlocking.Input4 GOOSE_Subscriber>>Earth_Switch> CILO 1>GOOSE:GOOSE2 QB2_Disconnector/ LLN0  GOOSE_Publisher QB2_Disconnector/ CILO 1 EnaOpn stVal@Pos;CILO/EnaOpn2/stVal Restricted To Pos GOOSE_Subscriber>>Earth_Switch> CSWI 1>someRestrictedExtRef[0]"
     >
       <span>
         [subscription.subscriber.availableToSubscribe]
@@ -732,6 +732,25 @@ snapshots["extref-later-binding-list for GOOSE Control when GSEControl has no su
       role="separator"
     >
     </li>
+    <mwc-list-item
+      aria-disabled="false"
+      graphic="large"
+      mwc-list-item=""
+      tabindex="-1"
+      twoline=""
+      value="GOOSE_Subscriber>>Earth_Switch> CILO 1>Pos;CSWI1/Pos/stVal[0]"
+    >
+      <span>
+        Pos;CSWI1/Pos/stVal
+                 (Interlocking.Input)
+      </span>
+      <span slot="secondary">
+        GOOSE_Subscriber>>Earth_Switch> CILO 1>Pos;CSWI1/Pos/stVal[0]
+      </span>
+      <mwc-icon slot="graphic">
+        arrow_back
+      </mwc-icon>
+    </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       graphic="large"
@@ -765,25 +784,6 @@ snapshots["extref-later-binding-list for GOOSE Control when GSEControl has no su
       </span>
       <span slot="secondary">
         GOOSE_Subscriber>>Earth_Switch> CILO 1>GOOSE:GOOSE2 QB2_Disconnector/ LLN0  GOOSE_Publisher QB2_Disconnector/ CILO 1 EnaOpn stVal@Pos;CILO/EnaOpn2/stVal
-      </span>
-      <mwc-icon slot="graphic">
-        arrow_back
-      </mwc-icon>
-    </mwc-list-item>
-    <mwc-list-item
-      aria-disabled="false"
-      graphic="large"
-      mwc-list-item=""
-      tabindex="-1"
-      twoline=""
-      value="GOOSE_Subscriber>>Earth_Switch> CILO 1>Pos;CSWI1/Pos/stVal[0]"
-    >
-      <span>
-        Pos;CSWI1/Pos/stVal
-                 (Interlocking.Input)
-      </span>
-      <span slot="secondary">
-        GOOSE_Subscriber>>Earth_Switch> CILO 1>Pos;CSWI1/Pos/stVal[0]
       </span>
       <mwc-icon slot="graphic">
         arrow_back
@@ -858,7 +858,7 @@ snapshots["extref-later-binding-list for GOOSE Control when GSEControl has a sin
       aria-disabled="false"
       noninteractive=""
       tabindex="-1"
-      value="Interlocking.Input3 GOOSE_Subscriber>>Earth_Switch> CILO 1>GOOSE:GOOSE2 QB2_Disconnector/ LLN0  GOOSE_Publisher QB1_Disconnector/ CILO 1 EnaCls stVal@Pos;CILO/EnaCls/stVal Interlocking.Input4 GOOSE_Subscriber>>Earth_Switch> CILO 1>GOOSE:GOOSE2 QB2_Disconnector/ LLN0  GOOSE_Publisher QB2_Disconnector/ CILO 1 EnaOpn stVal@Pos;CILO/EnaOpn2/stVal Interlocking.Input GOOSE_Subscriber>>Earth_Switch> CILO 1>Pos;CSWI1/Pos/stVal[0] Restricted To Pos GOOSE_Subscriber>>Earth_Switch> CSWI 1>someRestrictedExtRef[0]"
+      value="Interlocking.Input GOOSE_Subscriber>>Earth_Switch> CILO 1>Pos;CSWI1/Pos/stVal[0] Interlocking.Input3 GOOSE_Subscriber>>Earth_Switch> CILO 1>GOOSE:GOOSE2 QB2_Disconnector/ LLN0  GOOSE_Publisher QB1_Disconnector/ CILO 1 EnaCls stVal@Pos;CILO/EnaCls/stVal Interlocking.Input4 GOOSE_Subscriber>>Earth_Switch> CILO 1>GOOSE:GOOSE2 QB2_Disconnector/ LLN0  GOOSE_Publisher QB2_Disconnector/ CILO 1 EnaOpn stVal@Pos;CILO/EnaOpn2/stVal Restricted To Pos GOOSE_Subscriber>>Earth_Switch> CSWI 1>someRestrictedExtRef[0]"
     >
       <span>
         [subscription.subscriber.availableToSubscribe]
@@ -869,6 +869,25 @@ snapshots["extref-later-binding-list for GOOSE Control when GSEControl has a sin
       role="separator"
     >
     </li>
+    <mwc-list-item
+      aria-disabled="false"
+      graphic="large"
+      mwc-list-item=""
+      tabindex="-1"
+      twoline=""
+      value="GOOSE_Subscriber>>Earth_Switch> CILO 1>Pos;CSWI1/Pos/stVal[0]"
+    >
+      <span>
+        Pos;CSWI1/Pos/stVal
+                 (Interlocking.Input)
+      </span>
+      <span slot="secondary">
+        GOOSE_Subscriber>>Earth_Switch> CILO 1>Pos;CSWI1/Pos/stVal[0]
+      </span>
+      <mwc-icon slot="graphic">
+        arrow_back
+      </mwc-icon>
+    </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       graphic="large"
@@ -902,25 +921,6 @@ snapshots["extref-later-binding-list for GOOSE Control when GSEControl has a sin
       </span>
       <span slot="secondary">
         GOOSE_Subscriber>>Earth_Switch> CILO 1>GOOSE:GOOSE2 QB2_Disconnector/ LLN0  GOOSE_Publisher QB2_Disconnector/ CILO 1 EnaOpn stVal@Pos;CILO/EnaOpn2/stVal
-      </span>
-      <mwc-icon slot="graphic">
-        arrow_back
-      </mwc-icon>
-    </mwc-list-item>
-    <mwc-list-item
-      aria-disabled="false"
-      graphic="large"
-      mwc-list-item=""
-      tabindex="-1"
-      twoline=""
-      value="GOOSE_Subscriber>>Earth_Switch> CILO 1>Pos;CSWI1/Pos/stVal[0]"
-    >
-      <span>
-        Pos;CSWI1/Pos/stVal
-                 (Interlocking.Input)
-      </span>
-      <span slot="secondary">
-        GOOSE_Subscriber>>Earth_Switch> CILO 1>Pos;CSWI1/Pos/stVal[0]
       </span>
       <mwc-icon slot="graphic">
         arrow_back
@@ -1011,7 +1011,7 @@ snapshots["extref-later-binding-list when GSEControl has a multiple subscription
       aria-disabled="false"
       noninteractive=""
       tabindex="-1"
-      value="Interlocking.Input3 GOOSE_Subscriber>>Earth_Switch> CILO 1>GOOSE:GOOSE2 QB2_Disconnector/ LLN0  GOOSE_Publisher QB1_Disconnector/ CILO 1 EnaCls stVal@Pos;CILO/EnaCls/stVal Interlocking.Input4 GOOSE_Subscriber>>Earth_Switch> CILO 1>GOOSE:GOOSE2 QB2_Disconnector/ LLN0  GOOSE_Publisher QB2_Disconnector/ CILO 1 EnaOpn stVal@Pos;CILO/EnaOpn2/stVal Interlocking.Input GOOSE_Subscriber>>Earth_Switch> CILO 1>Pos;CSWI1/Pos/stVal[0] Restricted To Pos GOOSE_Subscriber>>Earth_Switch> CSWI 1>someRestrictedExtRef[0]"
+      value="Interlocking.Input GOOSE_Subscriber>>Earth_Switch> CILO 1>Pos;CSWI1/Pos/stVal[0] Interlocking.Input3 GOOSE_Subscriber>>Earth_Switch> CILO 1>GOOSE:GOOSE2 QB2_Disconnector/ LLN0  GOOSE_Publisher QB1_Disconnector/ CILO 1 EnaCls stVal@Pos;CILO/EnaCls/stVal Interlocking.Input4 GOOSE_Subscriber>>Earth_Switch> CILO 1>GOOSE:GOOSE2 QB2_Disconnector/ LLN0  GOOSE_Publisher QB2_Disconnector/ CILO 1 EnaOpn stVal@Pos;CILO/EnaOpn2/stVal Restricted To Pos GOOSE_Subscriber>>Earth_Switch> CSWI 1>someRestrictedExtRef[0]"
     >
       <span>
         [subscription.subscriber.availableToSubscribe]
@@ -1022,6 +1022,25 @@ snapshots["extref-later-binding-list when GSEControl has a multiple subscription
       role="separator"
     >
     </li>
+    <mwc-list-item
+      aria-disabled="false"
+      graphic="large"
+      mwc-list-item=""
+      tabindex="-1"
+      twoline=""
+      value="GOOSE_Subscriber>>Earth_Switch> CILO 1>Pos;CSWI1/Pos/stVal[0]"
+    >
+      <span>
+        Pos;CSWI1/Pos/stVal
+                 (Interlocking.Input)
+      </span>
+      <span slot="secondary">
+        GOOSE_Subscriber>>Earth_Switch> CILO 1>Pos;CSWI1/Pos/stVal[0]
+      </span>
+      <mwc-icon slot="graphic">
+        arrow_back
+      </mwc-icon>
+    </mwc-list-item>
     <mwc-list-item
       aria-disabled="false"
       graphic="large"
@@ -1055,25 +1074,6 @@ snapshots["extref-later-binding-list when GSEControl has a multiple subscription
       </span>
       <span slot="secondary">
         GOOSE_Subscriber>>Earth_Switch> CILO 1>GOOSE:GOOSE2 QB2_Disconnector/ LLN0  GOOSE_Publisher QB2_Disconnector/ CILO 1 EnaOpn stVal@Pos;CILO/EnaOpn2/stVal
-      </span>
-      <mwc-icon slot="graphic">
-        arrow_back
-      </mwc-icon>
-    </mwc-list-item>
-    <mwc-list-item
-      aria-disabled="false"
-      graphic="large"
-      mwc-list-item=""
-      tabindex="-1"
-      twoline=""
-      value="GOOSE_Subscriber>>Earth_Switch> CILO 1>Pos;CSWI1/Pos/stVal[0]"
-    >
-      <span>
-        Pos;CSWI1/Pos/stVal
-                 (Interlocking.Input)
-      </span>
-      <span slot="secondary">
-        GOOSE_Subscriber>>Earth_Switch> CILO 1>Pos;CSWI1/Pos/stVal[0]
       </span>
       <mwc-icon slot="graphic">
         arrow_back

--- a/test/unit/editors/subscription/later-binding/__snapshots__/ext-ref-ln-binding-list.test.snap.js
+++ b/test/unit/editors/subscription/later-binding/__snapshots__/ext-ref-ln-binding-list.test.snap.js
@@ -52,7 +52,7 @@ snapshots["for Sampled Value Control when SVC has no subscriptions looks like th
       aria-disabled="false"
       noninteractive=""
       tabindex="-1"
-      value="PTRC  - 1 SMV_Subscriber1>>Overcurrent Some LN title (LLN0)  SMV_Subscriber1>>Overcurrent PTRC  - 1 SMV_Subscriber1>>Overvoltage Some LN title (LLN0)  SMV_Subscriber1>>Overvoltage PTRC  - 1 SMV_Subscriber2>>Overcurrent Some LN title (LLN0)  SMV_Subscriber2>>Overcurrent PTRC  - 1 SMV_Subscriber2>>Overvoltage Some LN title (LLN0)  SMV_Subscriber2>>Overvoltage"
+      value="Some LN title (LLN0)  SMV_Subscriber1>>Overvoltage PTRC  - 1 SMV_Subscriber1>>Overvoltage Some LN title (LLN0)  SMV_Subscriber1>>Overcurrent PTRC  - 1 SMV_Subscriber1>>Overcurrent Some LN title (LLN0)  SMV_Subscriber2>>Overvoltage PTRC  - 1 SMV_Subscriber2>>Overvoltage Some LN title (LLN0)  SMV_Subscriber2>>Overcurrent PTRC  - 1 SMV_Subscriber2>>Overcurrent"
     >
       <span>
         [subscription.subscriber.availableToSubscribe]
@@ -69,31 +69,13 @@ snapshots["for Sampled Value Control when SVC has no subscriptions looks like th
       mwc-list-item=""
       tabindex="-1"
       twoline=""
-      value="SMV_Subscriber1>>Overcurrent> PTRC 1"
-    >
-      <span>
-        PTRC  - 1
-      </span>
-      <span slot="secondary">
-        SMV_Subscriber1>>Overcurrent
-      </span>
-      <mwc-icon slot="graphic">
-        arrow_back
-      </mwc-icon>
-    </mwc-list-item>
-    <mwc-list-item
-      aria-disabled="false"
-      graphic="large"
-      mwc-list-item=""
-      tabindex="-1"
-      twoline=""
-      value="SMV_Subscriber1>>Overcurrent"
+      value="SMV_Subscriber1>>Overvoltage"
     >
       <span>
         Some LN title (LLN0)
       </span>
       <span slot="secondary">
-        SMV_Subscriber1>>Overcurrent
+        SMV_Subscriber1>>Overvoltage
       </span>
       <mwc-icon slot="graphic">
         arrow_back
@@ -123,32 +105,31 @@ snapshots["for Sampled Value Control when SVC has no subscriptions looks like th
       mwc-list-item=""
       tabindex="-1"
       twoline=""
-      value="SMV_Subscriber1>>Overvoltage"
+      value="SMV_Subscriber1>>Overcurrent"
     >
       <span>
         Some LN title (LLN0)
       </span>
       <span slot="secondary">
-        SMV_Subscriber1>>Overvoltage
+        SMV_Subscriber1>>Overcurrent
       </span>
       <mwc-icon slot="graphic">
         arrow_back
       </mwc-icon>
     </mwc-list-item>
     <mwc-list-item
-      aria-disabled="true"
-      disabled=""
+      aria-disabled="false"
       graphic="large"
       mwc-list-item=""
       tabindex="-1"
       twoline=""
-      value="SMV_Subscriber2>>Overcurrent> PTRC 1"
+      value="SMV_Subscriber1>>Overcurrent> PTRC 1"
     >
       <span>
         PTRC  - 1
       </span>
       <span slot="secondary">
-        SMV_Subscriber2>>Overcurrent
+        SMV_Subscriber1>>Overcurrent
       </span>
       <mwc-icon slot="graphic">
         arrow_back
@@ -161,13 +142,13 @@ snapshots["for Sampled Value Control when SVC has no subscriptions looks like th
       mwc-list-item=""
       tabindex="-1"
       twoline=""
-      value="SMV_Subscriber2>>Overcurrent"
+      value="SMV_Subscriber2>>Overvoltage"
     >
       <span>
         Some LN title (LLN0)
       </span>
       <span slot="secondary">
-        SMV_Subscriber2>>Overcurrent
+        SMV_Subscriber2>>Overvoltage
       </span>
       <mwc-icon slot="graphic">
         arrow_back
@@ -199,13 +180,32 @@ snapshots["for Sampled Value Control when SVC has no subscriptions looks like th
       mwc-list-item=""
       tabindex="-1"
       twoline=""
-      value="SMV_Subscriber2>>Overvoltage"
+      value="SMV_Subscriber2>>Overcurrent"
     >
       <span>
         Some LN title (LLN0)
       </span>
       <span slot="secondary">
-        SMV_Subscriber2>>Overvoltage
+        SMV_Subscriber2>>Overcurrent
+      </span>
+      <mwc-icon slot="graphic">
+        arrow_back
+      </mwc-icon>
+    </mwc-list-item>
+    <mwc-list-item
+      aria-disabled="true"
+      disabled=""
+      graphic="large"
+      mwc-list-item=""
+      tabindex="-1"
+      twoline=""
+      value="SMV_Subscriber2>>Overcurrent> PTRC 1"
+    >
+      <span>
+        PTRC  - 1
+      </span>
+      <span slot="secondary">
+        SMV_Subscriber2>>Overcurrent
       </span>
       <mwc-icon slot="graphic">
         arrow_back
@@ -259,7 +259,7 @@ snapshots["for Sampled Value Control when SVC has a single subscriptions looks l
       aria-disabled="false"
       noninteractive=""
       tabindex="-1"
-      value="PTRC  - 1 SMV_Subscriber1>>Overcurrent Some LN title (LLN0)  SMV_Subscriber1>>Overcurrent PTRC  - 1 SMV_Subscriber1>>Overvoltage PTRC  - 1 SMV_Subscriber2>>Overcurrent Some LN title (LLN0)  SMV_Subscriber2>>Overcurrent PTRC  - 1 SMV_Subscriber2>>Overvoltage Some LN title (LLN0)  SMV_Subscriber2>>Overvoltage"
+      value="PTRC  - 1 SMV_Subscriber1>>Overvoltage Some LN title (LLN0)  SMV_Subscriber1>>Overcurrent PTRC  - 1 SMV_Subscriber1>>Overcurrent Some LN title (LLN0)  SMV_Subscriber2>>Overvoltage PTRC  - 1 SMV_Subscriber2>>Overvoltage Some LN title (LLN0)  SMV_Subscriber2>>Overcurrent PTRC  - 1 SMV_Subscriber2>>Overcurrent"
     >
       <span>
         [subscription.subscriber.availableToSubscribe]
@@ -276,13 +276,13 @@ snapshots["for Sampled Value Control when SVC has a single subscriptions looks l
       mwc-list-item=""
       tabindex="-1"
       twoline=""
-      value="SMV_Subscriber1>>Overcurrent> PTRC 1"
+      value="SMV_Subscriber1>>Overvoltage> PTRC 1"
     >
       <span>
         PTRC  - 1
       </span>
       <span slot="secondary">
-        SMV_Subscriber1>>Overcurrent
+        SMV_Subscriber1>>Overvoltage
       </span>
       <mwc-icon slot="graphic">
         arrow_back
@@ -312,13 +312,13 @@ snapshots["for Sampled Value Control when SVC has a single subscriptions looks l
       mwc-list-item=""
       tabindex="-1"
       twoline=""
-      value="SMV_Subscriber1>>Overvoltage> PTRC 1"
+      value="SMV_Subscriber1>>Overcurrent> PTRC 1"
     >
       <span>
         PTRC  - 1
       </span>
       <span slot="secondary">
-        SMV_Subscriber1>>Overvoltage
+        SMV_Subscriber1>>Overcurrent
       </span>
       <mwc-icon slot="graphic">
         arrow_back
@@ -331,32 +331,13 @@ snapshots["for Sampled Value Control when SVC has a single subscriptions looks l
       mwc-list-item=""
       tabindex="-1"
       twoline=""
-      value="SMV_Subscriber2>>Overcurrent> PTRC 1"
-    >
-      <span>
-        PTRC  - 1
-      </span>
-      <span slot="secondary">
-        SMV_Subscriber2>>Overcurrent
-      </span>
-      <mwc-icon slot="graphic">
-        arrow_back
-      </mwc-icon>
-    </mwc-list-item>
-    <mwc-list-item
-      aria-disabled="true"
-      disabled=""
-      graphic="large"
-      mwc-list-item=""
-      tabindex="-1"
-      twoline=""
-      value="SMV_Subscriber2>>Overcurrent"
+      value="SMV_Subscriber2>>Overvoltage"
     >
       <span>
         Some LN title (LLN0)
       </span>
       <span slot="secondary">
-        SMV_Subscriber2>>Overcurrent
+        SMV_Subscriber2>>Overvoltage
       </span>
       <mwc-icon slot="graphic">
         arrow_back
@@ -388,13 +369,32 @@ snapshots["for Sampled Value Control when SVC has a single subscriptions looks l
       mwc-list-item=""
       tabindex="-1"
       twoline=""
-      value="SMV_Subscriber2>>Overvoltage"
+      value="SMV_Subscriber2>>Overcurrent"
     >
       <span>
         Some LN title (LLN0)
       </span>
       <span slot="secondary">
-        SMV_Subscriber2>>Overvoltage
+        SMV_Subscriber2>>Overcurrent
+      </span>
+      <mwc-icon slot="graphic">
+        arrow_back
+      </mwc-icon>
+    </mwc-list-item>
+    <mwc-list-item
+      aria-disabled="true"
+      disabled=""
+      graphic="large"
+      mwc-list-item=""
+      tabindex="-1"
+      twoline=""
+      value="SMV_Subscriber2>>Overcurrent> PTRC 1"
+    >
+      <span>
+        PTRC  - 1
+      </span>
+      <span slot="secondary">
+        SMV_Subscriber2>>Overcurrent
       </span>
       <mwc-icon slot="graphic">
         arrow_back
@@ -464,7 +464,7 @@ snapshots["when SVC has a multiple subscriptions looks like the latest snapshot,
       aria-disabled="false"
       noninteractive=""
       tabindex="-1"
-      value="PTRC  - 1 SMV_Subscriber1>>Overcurrent Some LN title (LLN0)  SMV_Subscriber1>>Overcurrent PTRC  - 1 SMV_Subscriber1>>Overvoltage PTRC  - 1 SMV_Subscriber2>>Overcurrent Some LN title (LLN0)  SMV_Subscriber2>>Overcurrent PTRC  - 1 SMV_Subscriber2>>Overvoltage"
+      value="PTRC  - 1 SMV_Subscriber1>>Overvoltage Some LN title (LLN0)  SMV_Subscriber1>>Overcurrent PTRC  - 1 SMV_Subscriber1>>Overcurrent PTRC  - 1 SMV_Subscriber2>>Overvoltage Some LN title (LLN0)  SMV_Subscriber2>>Overcurrent PTRC  - 1 SMV_Subscriber2>>Overcurrent"
     >
       <span>
         [subscription.subscriber.availableToSubscribe]
@@ -481,13 +481,13 @@ snapshots["when SVC has a multiple subscriptions looks like the latest snapshot,
       mwc-list-item=""
       tabindex="-1"
       twoline=""
-      value="SMV_Subscriber1>>Overcurrent> PTRC 1"
+      value="SMV_Subscriber1>>Overvoltage> PTRC 1"
     >
       <span>
         PTRC  - 1
       </span>
       <span slot="secondary">
-        SMV_Subscriber1>>Overcurrent
+        SMV_Subscriber1>>Overvoltage
       </span>
       <mwc-icon slot="graphic">
         arrow_back
@@ -517,13 +517,13 @@ snapshots["when SVC has a multiple subscriptions looks like the latest snapshot,
       mwc-list-item=""
       tabindex="-1"
       twoline=""
-      value="SMV_Subscriber1>>Overvoltage> PTRC 1"
+      value="SMV_Subscriber1>>Overcurrent> PTRC 1"
     >
       <span>
         PTRC  - 1
       </span>
       <span slot="secondary">
-        SMV_Subscriber1>>Overvoltage
+        SMV_Subscriber1>>Overcurrent
       </span>
       <mwc-icon slot="graphic">
         arrow_back
@@ -536,13 +536,13 @@ snapshots["when SVC has a multiple subscriptions looks like the latest snapshot,
       mwc-list-item=""
       tabindex="-1"
       twoline=""
-      value="SMV_Subscriber2>>Overcurrent> PTRC 1"
+      value="SMV_Subscriber2>>Overvoltage> PTRC 1"
     >
       <span>
         PTRC  - 1
       </span>
       <span slot="secondary">
-        SMV_Subscriber2>>Overcurrent
+        SMV_Subscriber2>>Overvoltage
       </span>
       <mwc-icon slot="graphic">
         arrow_back
@@ -574,13 +574,13 @@ snapshots["when SVC has a multiple subscriptions looks like the latest snapshot,
       mwc-list-item=""
       tabindex="-1"
       twoline=""
-      value="SMV_Subscriber2>>Overvoltage> PTRC 1"
+      value="SMV_Subscriber2>>Overcurrent> PTRC 1"
     >
       <span>
         PTRC  - 1
       </span>
       <span slot="secondary">
-        SMV_Subscriber2>>Overvoltage
+        SMV_Subscriber2>>Overcurrent
       </span>
       <mwc-icon slot="graphic">
         arrow_back
@@ -633,7 +633,7 @@ snapshots["for GOOSE Control when GSEControl has no subscriptions looks like the
       aria-disabled="false"
       noninteractive=""
       tabindex="-1"
-      value="CILO  - 1 GOOSE_Subscriber1>>Earth_Switch CSWI  - 1 GOOSE_Subscriber1>>Earth_Switch Some LN title (LLN0)  GOOSE_Subscriber1>>Earth_Switch XSWI  - 1 GOOSE_Subscriber1>>Earth_Switch CILO  - 1 GOOSE_Subscriber2>>Earth_Switch CSWI  - 1 GOOSE_Subscriber2>>Earth_Switch Some LN title (LLN0)  GOOSE_Subscriber2>>Earth_Switch XSWI  - 1 GOOSE_Subscriber2>>Earth_Switch"
+      value="Some LN title (LLN0)  GOOSE_Subscriber1>>Earth_Switch CILO  - 1 GOOSE_Subscriber1>>Earth_Switch CSWI  - 1 GOOSE_Subscriber1>>Earth_Switch XSWI  - 1 GOOSE_Subscriber1>>Earth_Switch Some LN title (LLN0)  GOOSE_Subscriber2>>Earth_Switch CILO  - 1 GOOSE_Subscriber2>>Earth_Switch CSWI  - 1 GOOSE_Subscriber2>>Earth_Switch XSWI  - 1 GOOSE_Subscriber2>>Earth_Switch"
     >
       <span>
         [subscription.subscriber.availableToSubscribe]
@@ -644,6 +644,25 @@ snapshots["for GOOSE Control when GSEControl has no subscriptions looks like the
       role="separator"
     >
     </li>
+    <mwc-list-item
+      aria-disabled="true"
+      disabled=""
+      graphic="large"
+      mwc-list-item=""
+      tabindex="-1"
+      twoline=""
+      value="GOOSE_Subscriber1>>Earth_Switch"
+    >
+      <span>
+        Some LN title (LLN0)
+      </span>
+      <span slot="secondary">
+        GOOSE_Subscriber1>>Earth_Switch
+      </span>
+      <mwc-icon slot="graphic">
+        arrow_back
+      </mwc-icon>
+    </mwc-list-item>
     <mwc-list-item
       aria-disabled="true"
       disabled=""
@@ -689,10 +708,10 @@ snapshots["for GOOSE Control when GSEControl has no subscriptions looks like the
       mwc-list-item=""
       tabindex="-1"
       twoline=""
-      value="GOOSE_Subscriber1>>Earth_Switch"
+      value="GOOSE_Subscriber1>>Earth_Switch> XSWI 1"
     >
       <span>
-        Some LN title (LLN0)
+        XSWI  - 1
       </span>
       <span slot="secondary">
         GOOSE_Subscriber1>>Earth_Switch
@@ -702,19 +721,18 @@ snapshots["for GOOSE Control when GSEControl has no subscriptions looks like the
       </mwc-icon>
     </mwc-list-item>
     <mwc-list-item
-      aria-disabled="true"
-      disabled=""
+      aria-disabled="false"
       graphic="large"
       mwc-list-item=""
       tabindex="-1"
       twoline=""
-      value="GOOSE_Subscriber1>>Earth_Switch> XSWI 1"
+      value="GOOSE_Subscriber2>>Earth_Switch"
     >
       <span>
-        XSWI  - 1
+        Some LN title (LLN0)
       </span>
       <span slot="secondary">
-        GOOSE_Subscriber1>>Earth_Switch
+        GOOSE_Subscriber2>>Earth_Switch
       </span>
       <mwc-icon slot="graphic">
         arrow_back
@@ -748,24 +766,6 @@ snapshots["for GOOSE Control when GSEControl has no subscriptions looks like the
     >
       <span>
         CSWI  - 1
-      </span>
-      <span slot="secondary">
-        GOOSE_Subscriber2>>Earth_Switch
-      </span>
-      <mwc-icon slot="graphic">
-        arrow_back
-      </mwc-icon>
-    </mwc-list-item>
-    <mwc-list-item
-      aria-disabled="false"
-      graphic="large"
-      mwc-list-item=""
-      tabindex="-1"
-      twoline=""
-      value="GOOSE_Subscriber2>>Earth_Switch"
-    >
-      <span>
-        Some LN title (LLN0)
       </span>
       <span slot="secondary">
         GOOSE_Subscriber2>>Earth_Switch
@@ -840,7 +840,7 @@ snapshots["for GOOSE Control when GSEControl has a single subscription looks lik
       aria-disabled="false"
       noninteractive=""
       tabindex="-1"
-      value="CILO  - 1 GOOSE_Subscriber1>>Earth_Switch Some LN title (LLN0)  GOOSE_Subscriber1>>Earth_Switch XSWI  - 1 GOOSE_Subscriber1>>Earth_Switch CILO  - 1 GOOSE_Subscriber2>>Earth_Switch XSWI  - 1 GOOSE_Subscriber2>>Earth_Switch"
+      value="Some LN title (LLN0)  GOOSE_Subscriber1>>Earth_Switch CILO  - 1 GOOSE_Subscriber1>>Earth_Switch XSWI  - 1 GOOSE_Subscriber1>>Earth_Switch CILO  - 1 GOOSE_Subscriber2>>Earth_Switch XSWI  - 1 GOOSE_Subscriber2>>Earth_Switch"
     >
       <span>
         [subscription.subscriber.availableToSubscribe]
@@ -858,10 +858,10 @@ snapshots["for GOOSE Control when GSEControl has a single subscription looks lik
       mwc-list-item=""
       tabindex="-1"
       twoline=""
-      value="GOOSE_Subscriber1>>Earth_Switch> CILO 1"
+      value="GOOSE_Subscriber1>>Earth_Switch"
     >
       <span>
-        CILO  - 1
+        Some LN title (LLN0)
       </span>
       <span slot="secondary">
         GOOSE_Subscriber1>>Earth_Switch
@@ -877,10 +877,10 @@ snapshots["for GOOSE Control when GSEControl has a single subscription looks lik
       mwc-list-item=""
       tabindex="-1"
       twoline=""
-      value="GOOSE_Subscriber1>>Earth_Switch"
+      value="GOOSE_Subscriber1>>Earth_Switch> CILO 1"
     >
       <span>
-        Some LN title (LLN0)
+        CILO  - 1
       </span>
       <span slot="secondary">
         GOOSE_Subscriber1>>Earth_Switch
@@ -959,7 +959,7 @@ snapshots["when GSEControl has a multiple subscriptions looks like the latest sn
       aria-disabled="false"
       noninteractive=""
       tabindex="-1"
-      value="Some LN title (LLN0)  GOOSE_Subscriber1>>Earth_Switch CILO  - 1 GOOSE_Subscriber2>>Earth_Switch Some LN title (LLN0)  GOOSE_Subscriber2>>Earth_Switch"
+      value="Some LN title (LLN0)  GOOSE_Subscriber1>>Earth_Switch Some LN title (LLN0)  GOOSE_Subscriber2>>Earth_Switch CILO  - 1 GOOSE_Subscriber2>>Earth_Switch"
     >
       <span>
         [subscription.subscriber.subscribed]
@@ -992,10 +992,10 @@ snapshots["when GSEControl has a multiple subscriptions looks like the latest sn
     <mwc-list-item
       graphic="large"
       twoline=""
-      value="GOOSE_Subscriber2>>Earth_Switch> CILO 1"
+      value="GOOSE_Subscriber2>>Earth_Switch"
     >
       <span>
-        CILO  - 1
+        Some LN title (LLN0)
       </span>
       <span slot="secondary">
         GOOSE_Subscriber2>>Earth_Switch
@@ -1007,10 +1007,10 @@ snapshots["when GSEControl has a multiple subscriptions looks like the latest sn
     <mwc-list-item
       graphic="large"
       twoline=""
-      value="GOOSE_Subscriber2>>Earth_Switch"
+      value="GOOSE_Subscriber2>>Earth_Switch> CILO 1"
     >
       <span>
-        Some LN title (LLN0)
+        CILO  - 1
       </span>
       <span slot="secondary">
         GOOSE_Subscriber2>>Earth_Switch

--- a/test/unit/editors/subscription/later-binding/foundation.test.ts
+++ b/test/unit/editors/subscription/later-binding/foundation.test.ts
@@ -134,8 +134,7 @@ describe('smv-list', () => {
   });
 
   describe('isSubscribedTo', () => {
-    const type = 'SMV';
-    let ied: Element;
+    const type = 'SampledValueControl';
     let control: Element;
     let fcda: Element;
     let extRef: Element;
@@ -148,79 +147,78 @@ describe('smv-list', () => {
         control = doc.querySelector(
           'IED[name="SMV_Publisher"] SampledValueControl[name="currentOnly"]'
         )!;
-        ied = fcda.closest('IED')!;
         extRef = doc.querySelector(
           'IED[name="SMV_Subscriber"] LDevice[inst="Overvoltage"] ExtRef[doName="AmpSv"][daName="instMag.i"][srcCBName="currentOnly"]'
         )!;
       });
 
       it('when ExtRef and FDCA have same values then ExtRef is subscribed', () => {
-        expect(isSubscribedTo(type, ied, control, fcda, extRef)).to.be.true;
+        expect(isSubscribedTo(type, control, fcda, extRef)).to.be.true;
       });
 
       it('when ExtRef and FDCA have different IED then ExtRef is not subscribed', () => {
-        ied.setAttribute('name', 'OtherName');
-        expect(isSubscribedTo(type, ied, control, fcda, extRef)).to.be.false;
+        fcda.closest('IED')!.setAttribute('name', 'OtherName');
+        expect(isSubscribedTo(type, control, fcda, extRef)).to.be.false;
       });
 
       it('when ExtRef and FDCA have different ldInst Value then ExtRef is not subscribed', () => {
         extRef.setAttribute('ldInst', 'OtherValue');
-        expect(isSubscribedTo(type, ied, control, fcda, extRef)).to.be.false;
+        expect(isSubscribedTo(type, control, fcda, extRef)).to.be.false;
       });
 
       it('when ExtRef and FDCA have different prefix Value then ExtRef is not subscribed', () => {
         extRef.setAttribute('prefix', 'OtherValue');
-        expect(isSubscribedTo(type, ied, control, fcda, extRef)).to.be.false;
+        expect(isSubscribedTo(type, control, fcda, extRef)).to.be.false;
       });
 
       it('when ExtRef and FDCA have different lnClass Value then ExtRef is not subscribed', () => {
         extRef.setAttribute('lnClass', 'OtherValue');
-        expect(isSubscribedTo(type, ied, control, fcda, extRef)).to.be.false;
+        expect(isSubscribedTo(type, control, fcda, extRef)).to.be.false;
       });
 
       it('when ExtRef and FDCA have different lnInst Value then ExtRef is not subscribed', () => {
         extRef.setAttribute('lnInst', 'OtherValue');
-        expect(isSubscribedTo(type, ied, control, fcda, extRef)).to.be.false;
+        expect(isSubscribedTo(type, control, fcda, extRef)).to.be.false;
       });
 
       it('when ExtRef and FDCA have different doName Value then ExtRef is not subscribed', () => {
         extRef.setAttribute('doName', 'OtherValue');
-        expect(isSubscribedTo(type, ied, control, fcda, extRef)).to.be.false;
+        expect(isSubscribedTo(type, control, fcda, extRef)).to.be.false;
       });
 
       it('when ExtRef and FDCA have different daName Value then ExtRef is not subscribed', () => {
         extRef.setAttribute('daName', 'OtherValue');
-        expect(isSubscribedTo(type, ied, control, fcda, extRef)).to.be.false;
+        expect(isSubscribedTo(type, control, fcda, extRef)).to.be.false;
       });
 
       it('when ExtRef has a different ServiceType Value then ExtRef is not subscribed', () => {
         extRef.setAttribute('serviceType', 'OtherValue');
-        expect(isSubscribedTo(type, ied, control, fcda, extRef)).to.be.false;
+        expect(isSubscribedTo(type, control, fcda, extRef)).to.be.false;
       });
 
       it('when ExtRef and FDCA have different srcLDInst Value then ExtRef is not subscribed', () => {
         extRef.setAttribute('srcLDInst', 'OtherValue');
-        expect(isSubscribedTo(type, ied, control, fcda, extRef)).to.be.false;
+        expect(isSubscribedTo(type, control, fcda, extRef)).to.be.false;
       });
 
       it('when ExtRef and FDCA have different scrPrefix Value then ExtRef is not subscribed', () => {
         extRef.setAttribute('scrPrefix', 'OtherValue');
-        expect(isSubscribedTo(type, ied, control, fcda, extRef)).to.be.false;
+        expect(isSubscribedTo(type, control, fcda, extRef)).to.be.false;
       });
 
       it('when ExtRef and FDCA have different srcLNClass Value then ExtRef is not subscribed', () => {
         extRef.setAttribute('srcLNClass', 'OtherValue');
-        expect(isSubscribedTo(type, ied, control, fcda, extRef)).to.be.false;
+        expect(isSubscribedTo(type, control, fcda, extRef)).to.be.false;
       });
 
       it('when ExtRef and FDCA have different srcLNInst Value then ExtRef is not subscribed', () => {
         extRef.setAttribute('srcLNInst', 'OtherValue');
-        expect(isSubscribedTo(type, ied, control, fcda, extRef)).to.be.false;
+        expect(isSubscribedTo(type, control, fcda, extRef)).to.be.false;
       });
 
       it('when ExtRef and FDCA have different srcCBName Value then ExtRef is not subscribed', () => {
         extRef.setAttribute('srcCBName', 'OtherValue');
-        expect(isSubscribedTo(type, ied, control, fcda, extRef)).to.be.false;
+        expect(isSubscribedTo(type, control, fcda, extRef)).to.be.false;
       });
     });
 
@@ -236,14 +234,13 @@ describe('smv-list', () => {
         control = doc.querySelector(
           'IED[name="SMV_Publisher"] SampledValueControl[name="currentOnly"]'
         )!;
-        ied = fcda.closest('IED')!;
         extRef = doc.querySelector(
           'IED[name="SMV_Subscriber"] LDevice[inst="Overvoltage"] ExtRef[ldInst="CurrentTransformer"][doName="AmpSv"][daName="instMag.i"]'
         )!;
       });
 
       it('when ExtRef and FDCA have same values then ExtRef is subscribed', () => {
-        expect(isSubscribedTo(type, ied, control, fcda, extRef)).to.be.true;
+        expect(isSubscribedTo(type, control, fcda, extRef)).to.be.true;
       });
     });
   });


### PR DESCRIPTION
This will replace PR https://github.com/openscd/open-scd/pull/993.

Thanks @danyill for the code. 

It will added the counter to the Left Side of the Editor for both Data and Later Binding.
Through a event the counter will be updated if the subscription changes.