### PR TITLE
fix(Logging) Correct toggle colors in log

### DIFF
--- a/src/Logging.ts
+++ b/src/Logging.ts
@@ -320,6 +320,22 @@ export function Logging<TBase extends LitElementConstructor>(Base: TBase) {
             display: flex;
           }
 
+          #infofilter[on] {
+            color: var(--cyan);
+          }
+
+          #warningfilter[on] {
+            color: var(--yellow);
+          }
+
+          #errorfilter[on] {
+            color: var(--red);
+          }
+
+          #actionfilter[on] {
+            color: var(--blue);
+          }
+
           #log {
             --mdc-dialog-min-width: 92vw;
           }

--- a/src/icons/icons.ts
+++ b/src/icons/icons.ts
@@ -132,7 +132,6 @@ export function getFilterIcon(type: iconType, state: boolean): TemplateResult {
   const width = iconProperties[type]?.width ?? 24;
   return html`<svg
     slot="${state ? 'onIcon' : 'offIcon'}"
-    style="${state ? `color:var(${iconColors[type]})` : ''})"
     xmlns="http://www.w3.org/2000/svg"
     height="${height}"
     viewBox="0 0 ${width} ${height}"


### PR DESCRIPTION
Closes #1035

I'm not sure what was wrong with the previous approach. 

The inline style expression had an extra bracket on the end (from when I modified it to allow toggle buttons in the cleanup editor), but that was not the only cause.

It seems more general to rely on CSS here than inline styles, and that also resolves the issue, so perhaps this is an acceptable fix? (In the cleanup editor I used CSS and didn't add to the colours which had the side-effect of an "undefined" in the styles attribute.)