### PR TITLE
fix(filtered-list) Filter when document changes

### DIFF
--- a/src/filtered-list.ts
+++ b/src/filtered-list.ts
@@ -18,7 +18,6 @@ import { List } from '@material/mwc-list';
 import { ListBase } from '@material/mwc-list/mwc-list-base';
 import { ListItemBase } from '@material/mwc-list/mwc-list-item-base';
 import { TextField } from '@material/mwc-textfield';
-import { ReportControlElementEditor } from './editors/publisher/report-control-element-editor';
 
 function slotItem(item: Element): Element {
   if (!item.closest('filtered-list') || !item.parentElement) return item;
@@ -46,14 +45,14 @@ function hideFiltered(item: ListItemBase, searchText: string): void {
     .split(/\s+/g);
 
   (terms.length === 1 && terms[0] === '') ||
-  terms.every(term => {
-    // regexp escape
-    const reTerm = new RegExp(
-      `*${term}*`.replace(/\*/g, '.*').replace(/\?/g, '.{1}'),
-      'i'
-    );
-    return reTerm.test(filterTarget);
-  })
+    terms.every(term => {
+      // regexp escape
+      const reTerm = new RegExp(
+        `*${term}*`.replace(/\*/g, '.*').replace(/\?/g, '.{1}'),
+        'i'
+      );
+      return reTerm.test(filterTarget);
+    })
     ? slotItem(item).classList.remove('hidden')
     : slotItem(item).classList.add('hidden');
 }
@@ -115,6 +114,12 @@ export class FilteredList extends ListBase {
     this.requestUpdate();
   }
 
+  public layout(): void {
+    super.layout();
+    // regenerate filtering of text
+    this.onFilterInput();
+  }
+
   constructor() {
     super();
     this.addEventListener('selected', () => {
@@ -129,8 +134,8 @@ export class FilteredList extends ListBase {
             ?indeterminate=${!this.isAllSelected && this.isSomeSelected}
             ?checked=${this.isAllSelected}
             @change=${() => {
-              this.onCheckAll();
-            }}
+          this.onCheckAll();
+        }}
           ></mwc-checkbox
         ></mwc-formfield>`
       : html``;

--- a/src/filtered-list.ts
+++ b/src/filtered-list.ts
@@ -114,7 +114,10 @@ export class FilteredList extends ListBase {
     this.requestUpdate();
   }
 
-  public updated(): void {
+  protected update(
+    changedProperties: Map<string | number | symbol, unknown>
+  ): void {
+    super.update(changedProperties);
     // regenerate filtering of text
     this.onFilterInput();
   }

--- a/src/filtered-list.ts
+++ b/src/filtered-list.ts
@@ -114,8 +114,7 @@ export class FilteredList extends ListBase {
     this.requestUpdate();
   }
 
-  public layout(): void {
-    super.layout();
+  public updated(): void {
     // regenerate filtering of text
     this.onFilterInput();
   }

--- a/test/unit/filtered-list.test.ts
+++ b/test/unit/filtered-list.test.ts
@@ -40,6 +40,14 @@ describe('filtered-list', () => {
     await expect(element).shadowDom.to.equalSnapshot();
   });
 
+  it('allows items to be activated when selected', async () => {
+    element.setAttribute('activatable', '');
+    element.children[0].setAttribute('selected', '');
+    element.requestUpdate();
+    await element.updateComplete;
+    expect(element.children[0].hasAttribute('activated')).to.be.true;
+  });
+
   describe('has a check all checkbox that', () => {
     it('is indeterminate if one but not all check-list-items are selected', async () => {
       expect(


### PR DESCRIPTION
Closes #1018 

When a document is changed the filtered list doesn't receive a new filtering action, and its internal state appears to become inconsistent.

Only a couple of lines change for the new updated method. This seems like the right place to do this but I am interested and would be grateful for a review.

I noticed an incorrect import which seems to have been added by me and there is a few formatting changes.

I think this is an issue in the Cleanup plugin and probably other places (everywhere where a document update on a filtered list occurs and the filtered list has filter text).

I can't see how to add tests for this so I have not.
