### PR TITLE
fix(subscription) Coalesce lack of prefix to empty string, allow no prefix in FCDA description

### DIFF
--- a/src/editors/subscription/foundation.ts
+++ b/src/editors/subscription/foundation.ts
@@ -1,4 +1,6 @@
-import { css, LitElement, query } from 'lit-element';
+import { css, html, LitElement, query } from 'lit-element';
+import { nothing } from 'lit-html';
+
 import {
   cloneElement,
   compareNames,
@@ -99,12 +101,14 @@ export function getFcdaTitleValue(fcdaElement: Element): string {
 
 export function getFcdaSubtitleValue(fcdaElement: Element): string {
   return `${fcdaElement.getAttribute('ldInst')} ${
-    fcdaElement.hasAttribute('ldInst')
-      ? `/`
+    fcdaElement.hasAttribute('ldInst') ? `/` : ''
+  }${
+    fcdaElement.getAttribute('prefix')
+      ? ` ${fcdaElement.getAttribute('prefix')}`
       : ''
-  } ${fcdaElement.getAttribute('prefix') ?? ''} ${fcdaElement.getAttribute(
-    'lnClass'
-  )} ${fcdaElement.getAttribute('lnInst')}`;
+  } ${fcdaElement.getAttribute('lnClass')} ${fcdaElement.getAttribute(
+    'lnInst'
+  )}`;
 }
 
 export function existExtRef(

--- a/src/editors/subscription/foundation.ts
+++ b/src/editors/subscription/foundation.ts
@@ -99,10 +99,10 @@ export function getFcdaTitleValue(fcdaElement: Element): string {
 
 export function getFcdaSubtitleValue(fcdaElement: Element): string {
   return `${fcdaElement.getAttribute('ldInst')} ${
-    fcdaElement.hasAttribute('ldInst') && fcdaElement.hasAttribute('prefix')
+    fcdaElement.hasAttribute('ldInst')
       ? `/`
       : ''
-  } ${fcdaElement.getAttribute('prefix')} ${fcdaElement.getAttribute(
+  } ${fcdaElement.getAttribute('prefix') ?? ''} ${fcdaElement.getAttribute(
     'lnClass'
   )} ${fcdaElement.getAttribute('lnInst')}`;
 }

--- a/test/unit/editors/subscription/__snapshots__/fcda-binding-list.test.snap.js
+++ b/test/unit/editors/subscription/__snapshots__/fcda-binding-list.test.snap.js
@@ -679,19 +679,19 @@ snapshots["fcda-binding-list with a GSEControl doc loaded looks like the latest 
       value="
                         GOOSE_Publisher>>QB2_Disconnector>GOOSE2
                         Pos.stVal
-                        QB2_Disconnector /  CSWI 1
+                        QB2_Disconnector / CSWI 1
                         GOOSE_Publisher>>QB2_Disconnector>GOOSE2sDataSet>QB2_Disconnector/ CSWI 1.Pos stVal (ST)
                         Pos.q
-                        QB2_Disconnector /  CSWI 1
+                        QB2_Disconnector / CSWI 1
                         GOOSE_Publisher>>QB2_Disconnector>GOOSE2sDataSet>QB2_Disconnector/ CSWI 1.Pos q (ST)
                         EnaOpn.stVal
-                        QB1_Disconnector /  CILO 1
+                        QB1_Disconnector / CILO 1
                         GOOSE_Publisher>>QB2_Disconnector>GOOSE2sDataSet>QB1_Disconnector/ CILO 1.EnaOpn stVal (ST)
                         EnaCls.stVal
-                        QB1_Disconnector /  CILO 1
+                        QB1_Disconnector / CILO 1
                         GOOSE_Publisher>>QB2_Disconnector>GOOSE2sDataSet>QB1_Disconnector/ CILO 1.EnaCls stVal (ST)
                         EnaOpn.stVal
-                        QB2_Disconnector /  CILO 1
+                        QB2_Disconnector / CILO 1
                         GOOSE_Publisher>>QB2_Disconnector>GOOSE2sDataSet>QB2_Disconnector/ CILO 1.EnaOpn stVal (ST)"
     >
       <mwc-icon-button
@@ -729,7 +729,7 @@ snapshots["fcda-binding-list with a GSEControl doc loaded looks like the latest 
         Pos.stVal
       </span>
       <span slot="secondary">
-        QB2_Disconnector /  CSWI 1
+        QB2_Disconnector / CSWI 1
       </span>
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
@@ -753,7 +753,7 @@ snapshots["fcda-binding-list with a GSEControl doc loaded looks like the latest 
         Pos.q
       </span>
       <span slot="secondary">
-        QB2_Disconnector /  CSWI 1
+        QB2_Disconnector / CSWI 1
       </span>
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
@@ -776,7 +776,7 @@ snapshots["fcda-binding-list with a GSEControl doc loaded looks like the latest 
         EnaOpn.stVal
       </span>
       <span slot="secondary">
-        QB1_Disconnector /  CILO 1
+        QB1_Disconnector / CILO 1
       </span>
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
@@ -796,7 +796,7 @@ snapshots["fcda-binding-list with a GSEControl doc loaded looks like the latest 
         EnaCls.stVal
       </span>
       <span slot="secondary">
-        QB1_Disconnector /  CILO 1
+        QB1_Disconnector / CILO 1
       </span>
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
@@ -816,7 +816,7 @@ snapshots["fcda-binding-list with a GSEControl doc loaded looks like the latest 
         EnaOpn.stVal
       </span>
       <span slot="secondary">
-        QB2_Disconnector /  CILO 1
+        QB2_Disconnector / CILO 1
       </span>
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
@@ -832,10 +832,10 @@ snapshots["fcda-binding-list with a GSEControl doc loaded looks like the latest 
       value="
                         GOOSE_Publisher>>QB2_Disconnector>GOOSE1
                         Pos.stVal
-                        QB1_Disconnector /  CSWI 1
+                        QB1_Disconnector / CSWI 1
                         GOOSE_Publisher>>QB2_Disconnector>GOOSE1sDataSet>QB1_Disconnector/ CSWI 1.Pos stVal (ST)
                         Pos.q
-                        QB1_Disconnector /  CSWI 1
+                        QB1_Disconnector / CSWI 1
                         GOOSE_Publisher>>QB2_Disconnector>GOOSE1sDataSet>QB1_Disconnector/ CSWI 1.Pos q (ST)"
     >
       <mwc-icon-button
@@ -872,7 +872,7 @@ snapshots["fcda-binding-list with a GSEControl doc loaded looks like the latest 
         Pos.stVal
       </span>
       <span slot="secondary">
-        QB1_Disconnector /  CSWI 1
+        QB1_Disconnector / CSWI 1
       </span>
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
@@ -892,7 +892,7 @@ snapshots["fcda-binding-list with a GSEControl doc loaded looks like the latest 
         Pos.q
       </span>
       <span slot="secondary">
-        QB1_Disconnector /  CSWI 1
+        QB1_Disconnector / CSWI 1
       </span>
       <mwc-icon slot="graphic">
         subdirectory_arrow_right

--- a/test/unit/editors/subscription/__snapshots__/fcda-binding-list.test.snap.js
+++ b/test/unit/editors/subscription/__snapshots__/fcda-binding-list.test.snap.js
@@ -685,13 +685,13 @@ snapshots["fcda-binding-list with a GSEControl doc loaded looks like the latest 
                         QB2_Disconnector /  CSWI 1
                         GOOSE_Publisher>>QB2_Disconnector>GOOSE2sDataSet>QB2_Disconnector/ CSWI 1.Pos q (ST)
                         EnaOpn.stVal
-                        QB1_Disconnector  null CILO 1
+                        QB1_Disconnector /  CILO 1
                         GOOSE_Publisher>>QB2_Disconnector>GOOSE2sDataSet>QB1_Disconnector/ CILO 1.EnaOpn stVal (ST)
                         EnaCls.stVal
                         QB1_Disconnector /  CILO 1
                         GOOSE_Publisher>>QB2_Disconnector>GOOSE2sDataSet>QB1_Disconnector/ CILO 1.EnaCls stVal (ST)
                         EnaOpn.stVal
-                        QB2_Disconnector  null CILO 1
+                        QB2_Disconnector /  CILO 1
                         GOOSE_Publisher>>QB2_Disconnector>GOOSE2sDataSet>QB2_Disconnector/ CILO 1.EnaOpn stVal (ST)"
     >
       <mwc-icon-button
@@ -776,7 +776,7 @@ snapshots["fcda-binding-list with a GSEControl doc loaded looks like the latest 
         EnaOpn.stVal
       </span>
       <span slot="secondary">
-        QB1_Disconnector  null CILO 1
+        QB1_Disconnector /  CILO 1
       </span>
       <mwc-icon slot="graphic">
         subdirectory_arrow_right
@@ -816,7 +816,7 @@ snapshots["fcda-binding-list with a GSEControl doc loaded looks like the latest 
         EnaOpn.stVal
       </span>
       <span slot="secondary">
-        QB2_Disconnector  null CILO 1
+        QB2_Disconnector /  CILO 1
       </span>
       <mwc-icon slot="graphic">
         subdirectory_arrow_right


### PR DESCRIPTION
Closes #1076

The code I am touching was only added recently so the reason may be nearby

I think `ldInst` is almost always part of an FCDA (GSSE being mostly dead/unused) but prefix maybe not, it is optional in Table 22 of IEC 61850-6 Ed 2.1

So I don't fully understand this code path but this should get rid of the word null.

