### PR TITLE
fix: styling issue with SubEquipment editor

### DIFF
--- a/src/editors/substation/conducting-equipment-editor.ts
+++ b/src/editors/substation/conducting-equipment-editor.ts
@@ -21,6 +21,7 @@ import '../../action-icon.js';
 import '../../action-pane.js';
 import './eq-function-editor.js';
 import './l-node-editor.js';
+import './sub-equipment-editor.js';
 import { startMove, getIcon, styles } from './foundation.js';
 import {
   getChildElementsByTagName,
@@ -31,8 +32,6 @@ import {
 } from '../../foundation.js';
 import { BayEditor } from './bay-editor.js';
 import { emptyWizard, wizards } from '../../wizards/wizard-library.js';
-
-import './sub-equipment-editor.js';
 
 function childTags(element: Element | null | undefined): SCLTag[] {
   if (!element) return [];
@@ -124,6 +123,23 @@ export class ConductingEquipmentEditor extends LitElement {
           .element=${eqFunction}
           ?showfunctions=${this.showfunctions}
         ></eq-function-editor>`
+    )}`;
+  }
+
+  private renderSubEquipments(): TemplateResult {
+    if (!this.showfunctions) return html``;
+
+    const subEquipments = getChildElementsByTagName(
+      this.element,
+      'SubEquipment'
+    );
+
+    return html` ${subEquipments.map(
+      subEquipment =>
+        html`<sub-equipment-editor
+          .doc=${this.doc}
+          .element=${subEquipment}
+        ></sub-equipment-editor>`
     )}`;
   }
 
@@ -220,27 +236,6 @@ export class ConductingEquipmentEditor extends LitElement {
         icon="delete"
         @click="${() => this.remove()}}"
       ></mwc-fab>`;
-  }
-
-  private renderSubEquipments(): TemplateResult {
-    if (!this.showfunctions) return html``;
-
-    const subEquipments = getChildElementsByTagName(
-      this.element,
-      'SubEquipment'
-    );
-
-    return subEquipments.length
-      ? html`<div class="container subequipment">
-          ${subEquipments.map(
-            subEquipment =>
-              html`<sub-equipment-editor
-                .doc=${this.doc}
-                .element=${subEquipment}
-              ></sub-equipment-editor>`
-          )}
-        </div>`
-      : html``;
   }
 
   render(): TemplateResult {

--- a/src/editors/substation/foundation.ts
+++ b/src/editors/substation/foundation.ts
@@ -659,14 +659,6 @@ export const styles = css`
     grid-template-columns: repeat(auto-fit, minmax(64px, auto));
   }
 
-  .container.subequipment {
-    display: grid;
-    grid-gap: 12px;
-    padding: 8px 12px 16px;
-    box-sizing: border-box;
-    grid-template-columns: repeat(auto-fit, minmax(64px, auto));
-  }
-
   mwc-dialog {
     display: flex;
     flex-direction: column;

--- a/src/editors/substation/powertransformer-editor.ts
+++ b/src/editors/substation/powertransformer-editor.ts
@@ -19,6 +19,9 @@ import { Menu } from '@material/mwc-menu';
 
 import '../../action-icon.js';
 import '../../action-pane.js';
+import './sub-equipment-editor.js';
+import './eq-function-editor.js';
+import './transformer-winding-editor.js';
 import { powerTransformerTwoWindingIcon } from '../../icons/icons.js';
 import { emptyWizard, wizards } from '../../wizards/wizard-library.js';
 import {
@@ -32,9 +35,6 @@ import { startMove, styles } from './foundation.js';
 import { SubstationEditor } from './substation-editor.js';
 import { BayEditor } from './bay-editor.js';
 import { VoltageLevelEditor } from './voltage-level-editor.js';
-
-import './sub-equipment-editor.js';
-import './transformer-winding-editor.js';
 
 function childTags(element: Element | null | undefined): SCLTag[] {
   if (!element) return [];
@@ -130,6 +130,22 @@ export class PowerTransformerEditor extends LitElement {
     )}`;
   }
 
+  private renderSubEquipments(): TemplateResult {
+    if (!this.showfunctions) return html``;
+    const subEquipments = getChildElementsByTagName(
+      this.element,
+      'SubEquipment'
+    );
+
+    return html` ${subEquipments.map(
+      subEquipment =>
+        html`<sub-equipment-editor
+          .doc=${this.doc}
+          .element=${subEquipment}
+        ></sub-equipment-editor>`
+    )}`;
+  }
+
   private renderAddButtons(): TemplateResult[] {
     return childTags(this.element).map(
       child =>
@@ -199,26 +215,6 @@ export class PowerTransformerEditor extends LitElement {
           >${this.renderAddButtons()}</mwc-menu
         >
       </abbr>`;
-  }
-
-  private renderSubEquipments(): TemplateResult {
-    if (!this.showfunctions) return html``;
-    const subEquipments = getChildElementsByTagName(
-      this.element,
-      'SubEquipment'
-    );
-
-    return subEquipments.length
-      ? html`<div class="container subequipment">
-          ${subEquipments.map(
-            subEquipment =>
-              html`<sub-equipment-editor
-                .doc=${this.doc}
-                .element=${subEquipment}
-              ></sub-equipment-editor>`
-          )}
-        </div>`
-      : html``;
   }
 
   private renderTransformerWinding(): TemplateResult {

--- a/src/editors/substation/sub-equipment-editor.ts
+++ b/src/editors/substation/sub-equipment-editor.ts
@@ -19,8 +19,8 @@ import { Menu } from '@material/mwc-menu';
 
 import '../../action-icon.js';
 import '../../action-pane.js';
-
-import { styles } from './foundation.js';
+import './l-node-editor.js';
+import './eq-function-editor.js';
 import {
   getChildElementsByTagName,
   newWizardEvent,
@@ -178,15 +178,17 @@ export class SubEquipmentEditor extends LitElement {
   }
 
   static styles = css`
-    ${styles}
-
-    :host(.moving) {
-      opacity: 0.3;
-    }
-
     abbr {
       text-decoration: none;
       border-bottom: none;
+    }
+
+    .container.lnode {
+      display: grid;
+      grid-gap: 12px;
+      padding: 8px 12px 16px;
+      box-sizing: border-box;
+      grid-template-columns: repeat(auto-fit, minmax(64px, auto));
     }
   `;
 }

--- a/test/unit/editors/substation/__snapshots__/conducting-equipment-editor.test.snap.js
+++ b/test/unit/editors/substation/__snapshots__/conducting-equipment-editor.test.snap.js
@@ -458,16 +458,14 @@ snapshots["conducting-equipment-editor rendered as action pane with SubEquipment
       </mwc-list-item>
     </mwc-menu>
   </abbr>
-  <div class="container subequipment">
-    <sub-equipment-editor>
-    </sub-equipment-editor>
-    <sub-equipment-editor>
-    </sub-equipment-editor>
-    <sub-equipment-editor>
-    </sub-equipment-editor>
-    <sub-equipment-editor>
-    </sub-equipment-editor>
-  </div>
+  <sub-equipment-editor>
+  </sub-equipment-editor>
+  <sub-equipment-editor>
+  </sub-equipment-editor>
+  <sub-equipment-editor>
+  </sub-equipment-editor>
+  <sub-equipment-editor>
+  </sub-equipment-editor>
 </action-pane>
 `;
 /* end snapshot conducting-equipment-editor rendered as action pane with SubEquipment children looks like the latest snapshot */

--- a/test/unit/editors/substation/__snapshots__/powertransformer-editor.test.snap.js
+++ b/test/unit/editors/substation/__snapshots__/powertransformer-editor.test.snap.js
@@ -461,14 +461,12 @@ snapshots["powertransformer-editor rendered as action pane with SubEquipment chi
       </mwc-list-item>
     </mwc-menu>
   </abbr>
-  <div class="container subequipment">
-    <sub-equipment-editor>
-    </sub-equipment-editor>
-    <sub-equipment-editor>
-    </sub-equipment-editor>
-    <sub-equipment-editor>
-    </sub-equipment-editor>
-  </div>
+  <sub-equipment-editor>
+  </sub-equipment-editor>
+  <sub-equipment-editor>
+  </sub-equipment-editor>
+  <sub-equipment-editor>
+  </sub-equipment-editor>
 </action-pane>
 `;
 /* end snapshot powertransformer-editor rendered as action pane with SubEquipment children looks like the latest snapshot */


### PR DESCRIPTION
Closes #1129 

Two things that have been fixed
1. by mistake, the container for sub-equipment-editors was declared min size 64px. That is why it looked too strange. This declaration is only necessary for icon type components. `SubEquipment` is never rendered as icon.
2. sub-equipment-editor do not need to be within a container. That is only necessary when grid type display is used. E.g. Bay within VoltageLevel or ConductingEquipment as icon within Bay. In all other cases, just adding it as child editor is enough. `action-pane` will do all the styling.

There is no regression test as I only touched CSS. Just updated snapshots due to the changes html