### PR TITLE
fix: add missing code editor to edit wizards

### DIFF
--- a/src/wizards/eqfunction.ts
+++ b/src/wizards/eqfunction.ts
@@ -50,6 +50,7 @@ export function editEqFunctionWizard(element: Element): Wizard {
   return [
     {
       title: get('wizard.title.edit', { tagName: 'EqFunction' }),
+      element: element,
       primary: {
         icon: 'save',
         label: get('save'),

--- a/src/wizards/eqsubfunction.ts
+++ b/src/wizards/eqsubfunction.ts
@@ -50,6 +50,7 @@ export function editEqSubFunctionWizard(element: Element): Wizard {
   return [
     {
       title: get('wizard.title.edit', { tagName: 'EqSubFunction' }),
+      element: element,
       primary: {
         icon: 'save',
         label: get('save'),


### PR DESCRIPTION
Closes #1133 

No test adoption needed as we do not screenshot test wizards. This is once more am argument to do that when we move plungins.