### PR TITLE
fix(substation/guess-wizard): guessed content is added to the substation

### DIFF
--- a/src/wizards/substation.ts
+++ b/src/wizards/substation.ts
@@ -7,15 +7,14 @@ import '@material/mwc-formfield';
 import '../wizard-textfield.js';
 import {
   createElement,
-  EditorAction,
   getValue,
-  newWizardEvent,
   Wizard,
+  WizardAction,
   WizardActor,
   WizardInputElement,
 } from '../foundation.js';
 import { guessVoltageLevel } from '../editors/substation/guess-wizard.js';
-import { updateNamingAttributeWithReferencesAction } from "./foundation/actions.js";
+import { updateNamingAttributeWithReferencesAction } from './foundation/actions.js';
 
 function render(
   name: string,
@@ -46,29 +45,20 @@ function render(
 }
 
 export function createAction(parent: Element): WizardActor {
-  return (inputs: WizardInputElement[], wizard: Element): EditorAction[] => {
+  return (inputs: WizardInputElement[], wizard: Element): WizardAction[] => {
     const name = getValue(inputs.find(i => i.label === 'name')!);
     const desc = getValue(inputs.find(i => i.label === 'desc')!);
     const guess = wizard.shadowRoot?.querySelector('mwc-checkbox')?.checked;
     parent.ownerDocument.createElement('Substation');
-    const element = createElement(parent.ownerDocument, 'Substation', {
+    const substation = createElement(parent.ownerDocument, 'Substation', {
       name,
       desc,
     });
 
-    const action = {
-      new: {
-        parent,
-        element,
-      },
-    };
-
     if (guess)
-      wizard.dispatchEvent(
-        newWizardEvent(guessVoltageLevel(parent.ownerDocument))
-      );
+      return [() => guessVoltageLevel(parent.ownerDocument, substation)];
 
-    return [action];
+    return [{ new: { parent, element: substation } }];
   };
 }
 
@@ -97,7 +87,10 @@ export function substationEditWizard(element: Element): Wizard {
       primary: {
         icon: 'edit',
         label: get('save'),
-        action: updateNamingAttributeWithReferencesAction(element, 'substation.action.updatesubstation'),
+        action: updateNamingAttributeWithReferencesAction(
+          element,
+          'substation.action.updatesubstation'
+        ),
       },
       content: render(
         element.getAttribute('name') ?? '',

--- a/test/integration/editors/substation/guess-wizarding-editing.test.ts
+++ b/test/integration/editors/substation/guess-wizarding-editing.test.ts
@@ -14,10 +14,12 @@ describe('guess-wizard-integration', () => {
     validSCL = await fetch('/test/testfiles/valid2007B4.scd')
       .then(response => response.text())
       .then(str => new DOMParser().parseFromString(str, 'application/xml'));
-    validSCL.querySelector('Substation')!.innerHTML = '';
+
+    const substation = validSCL.querySelector('Substation')!;
+    substation.innerHTML = '';
     element = <MockWizard>await fixture(html`<mock-wizard></mock-wizard>`);
 
-    const wizard = guessVoltageLevel(validSCL);
+    const wizard = guessVoltageLevel(validSCL, substation);
     element.workflow.push(() => wizard);
     await element.requestUpdate();
   });
@@ -31,6 +33,7 @@ describe('guess-wizard-integration', () => {
         ).length
       ).to.equal(5);
     });
+
     it('the first one being status-only', async () => {
       expect(
         element.wizardUI.dialog!.querySelector(
@@ -38,6 +41,7 @@ describe('guess-wizard-integration', () => {
         )?.innerHTML
       ).to.equal('status-only');
     });
+
     it('the second one being direct-with-normal-security', async () => {
       expect(
         element.wizardUI.dialog!.querySelector(
@@ -45,6 +49,7 @@ describe('guess-wizard-integration', () => {
         )?.innerHTML
       ).to.equal('direct-with-normal-security');
     });
+
     it('the second one being direct-with-enhanced-security', async () => {
       expect(
         element.wizardUI.dialog!.querySelector(
@@ -52,6 +57,7 @@ describe('guess-wizard-integration', () => {
         )?.innerHTML
       ).to.equal('direct-with-enhanced-security');
     });
+
     it('the second one being sbo-with-normal-security', async () => {
       expect(
         element.wizardUI.dialog!.querySelector(
@@ -59,6 +65,7 @@ describe('guess-wizard-integration', () => {
         )?.innerHTML
       ).to.equal('sbo-with-normal-security');
     });
+
     it('the second one being sbo-with-enhanced-security', async () => {
       expect(
         element.wizardUI.dialog!.querySelector(
@@ -76,12 +83,14 @@ describe('guess-wizarding-editing-integration', () => {
     validSCL = await fetch('/test/testfiles/valid2007B4.scd')
       .then(response => response.text())
       .then(str => new DOMParser().parseFromString(str, 'application/xml'));
-    validSCL.querySelector('Substation')!.innerHTML = '';
+
+    const substation = validSCL.querySelector('Substation')!;
+    substation.innerHTML = '';
     element = <MockWizardEditor>(
       await fixture(html`<mock-wizard-editor></mock-wizard-editor>`)
     );
 
-    const wizard = guessVoltageLevel(validSCL);
+    const wizard = guessVoltageLevel(validSCL, substation);
     element.workflow.push(() => wizard);
     await element.requestUpdate();
 


### PR DESCRIPTION
Closes #1147 

With the change from async to sync plugin loading that triggered to pass a new doc after every action event. This bug was introduced. The guess function first adds a `Substation` element then the content of the substation itself.

I changed it now to only send one complex action event instead of two. 