### PR TITLE
feat(filtered-list) Allow quoting for exact values in filtered list

### DIFF
--- a/src/filtered-list.ts
+++ b/src/filtered-list.ts
@@ -38,21 +38,22 @@ function hideFiltered(item: ListItemBase, searchText: string): void {
     value
   ).toUpperCase();
 
-  const terms: string[] = searchText
-    .toUpperCase()
-    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
-    .trim()
-    .split(/\s+/g);
+  const terms: string[] =
+    searchText
+      .toUpperCase()
+      .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+      .trim()
+      .match(/(?:[^\s"']+|['"][^'"]*["'])+/g) || [];
 
-  (terms.length === 1 && terms[0] === '') ||
-    terms.every(term => {
-      // regexp escape
-      const reTerm = new RegExp(
-        `*${term}*`.replace(/\*/g, '.*').replace(/\?/g, '.{1}'),
-        'i'
-      );
-      return reTerm.test(filterTarget);
-    })
+  terms.every(term => {
+    // regexp escape
+    term = term.replace(/["']/g, '');
+    const reTerm = new RegExp(
+      `*${term}*`.replace(/\*/g, '.*').replace(/\?/g, '.{1}'),
+      'i'
+    );
+    return reTerm.test(filterTarget);
+  })
     ? slotItem(item).classList.remove('hidden')
     : slotItem(item).classList.add('hidden');
 }
@@ -136,8 +137,8 @@ export class FilteredList extends ListBase {
             ?indeterminate=${!this.isAllSelected && this.isSomeSelected}
             ?checked=${this.isAllSelected}
             @change=${() => {
-          this.onCheckAll();
-        }}
+              this.onCheckAll();
+            }}
           ></mwc-checkbox
         ></mwc-formfield>`
       : html``;

--- a/test/unit/filtered-list.test.ts
+++ b/test/unit/filtered-list.test.ts
@@ -32,6 +32,8 @@ describe('filtered-list', () => {
             <mwc-radio-list-item><span>nestedItem6</span></mwc-radio-list-item>
           </div></abbr
         ><mwc-list-item value="valueItem7"></mwc-list-item>
+        <mwc-list-item value="value Item 8 Randomly 9"></mwc-list-item>
+        <mwc-list-item value="value Item 9 Randomly 8"></mwc-list-item>
       </filtered-list>`
     );
   });
@@ -160,8 +162,9 @@ describe('filtered-list', () => {
       expect(element.children[6].classList.contains('hidden')).to.be.true;
     });
 
-    it('uses space as logic AND ', async () => {
+    it('uses space as logical AND', async () => {
       element.searchField.value = 'item item3sec';
+      // debugger;
       element.onFilterInput();
       element.requestUpdate();
       await element.updateComplete;
@@ -266,6 +269,102 @@ describe('filtered-list', () => {
       expect(element.children[3].classList.contains('hidden')).to.be.true;
       expect(element.children[4].classList.contains('hidden')).to.be.false;
       expect(element.children[5].classList.contains('hidden')).to.be.false;
+    });
+
+    it('allows filtering with a double quoted item with spaces', async () => {
+      element.searchField.value = '"Item 8"';
+      element.onFilterInput();
+      element.requestUpdate();
+      await element.updateComplete;
+      expect(element.children[0].classList.contains('hidden')).to.be.true;
+      expect(element.children[1].classList.contains('hidden')).to.be.true;
+      expect(element.children[2].classList.contains('hidden')).to.be.true;
+      expect(element.children[3].classList.contains('hidden')).to.be.true;
+      expect(element.children[4].classList.contains('hidden')).to.be.true;
+      expect(element.children[5].classList.contains('hidden')).to.be.true;
+      expect(element.children[6].classList.contains('hidden')).to.be.true;
+      expect(element.children[7].classList.contains('hidden')).to.be.false;
+      expect(element.children[8].classList.contains('hidden')).to.be.true;
+    });
+
+    it('allows filtering with a single quoted item with spaces', async () => {
+      element.searchField.value = "'Item 8'";
+      element.onFilterInput();
+      element.requestUpdate();
+      await element.updateComplete;
+      expect(element.children[0].classList.contains('hidden')).to.be.true;
+      expect(element.children[1].classList.contains('hidden')).to.be.true;
+      expect(element.children[2].classList.contains('hidden')).to.be.true;
+      expect(element.children[3].classList.contains('hidden')).to.be.true;
+      expect(element.children[4].classList.contains('hidden')).to.be.true;
+      expect(element.children[5].classList.contains('hidden')).to.be.true;
+      expect(element.children[6].classList.contains('hidden')).to.be.true;
+      expect(element.children[7].classList.contains('hidden')).to.be.false;
+      expect(element.children[8].classList.contains('hidden')).to.be.true;
+    });
+
+    it('allows filtering with a single and double quoted items with spaces', async () => {
+      element.searchField.value = `'Item 9' "Randomly 8"`;
+      element.onFilterInput();
+      element.requestUpdate();
+      await element.updateComplete;
+      expect(element.children[0].classList.contains('hidden')).to.be.true;
+      expect(element.children[1].classList.contains('hidden')).to.be.true;
+      expect(element.children[2].classList.contains('hidden')).to.be.true;
+      expect(element.children[3].classList.contains('hidden')).to.be.true;
+      expect(element.children[4].classList.contains('hidden')).to.be.true;
+      expect(element.children[5].classList.contains('hidden')).to.be.true;
+      expect(element.children[6].classList.contains('hidden')).to.be.true;
+      expect(element.children[7].classList.contains('hidden')).to.be.true;
+      expect(element.children[8].classList.contains('hidden')).to.be.false;
+    });
+
+    it('allows filtering with a single and double quoted items with ? wildcard', async () => {
+      element.searchField.value = "'Item ? Randomly'";
+      element.onFilterInput();
+      element.requestUpdate();
+      await element.updateComplete;
+      expect(element.children[0].classList.contains('hidden')).to.be.true;
+      expect(element.children[1].classList.contains('hidden')).to.be.true;
+      expect(element.children[2].classList.contains('hidden')).to.be.true;
+      expect(element.children[3].classList.contains('hidden')).to.be.true;
+      expect(element.children[4].classList.contains('hidden')).to.be.true;
+      expect(element.children[5].classList.contains('hidden')).to.be.true;
+      expect(element.children[6].classList.contains('hidden')).to.be.true;
+      expect(element.children[7].classList.contains('hidden')).to.be.false;
+      expect(element.children[8].classList.contains('hidden')).to.be.false;
+    });
+
+    it('allows filtering with a single and double quoted items with * wildcard', async () => {
+      element.searchField.value = "'Item ? Ra*ly'";
+      element.onFilterInput();
+      element.requestUpdate();
+      await element.updateComplete;
+      expect(element.children[0].classList.contains('hidden')).to.be.true;
+      expect(element.children[1].classList.contains('hidden')).to.be.true;
+      expect(element.children[2].classList.contains('hidden')).to.be.true;
+      expect(element.children[3].classList.contains('hidden')).to.be.true;
+      expect(element.children[4].classList.contains('hidden')).to.be.true;
+      expect(element.children[5].classList.contains('hidden')).to.be.true;
+      expect(element.children[6].classList.contains('hidden')).to.be.true;
+      expect(element.children[7].classList.contains('hidden')).to.be.false;
+      expect(element.children[8].classList.contains('hidden')).to.be.false;
+    });
+
+    it('allows filtering with quoted and non-quoted values', async () => {
+      element.searchField.value = "'Item 8' value";
+      element.onFilterInput();
+      element.requestUpdate();
+      await element.updateComplete;
+      expect(element.children[0].classList.contains('hidden')).to.be.true;
+      expect(element.children[1].classList.contains('hidden')).to.be.true;
+      expect(element.children[2].classList.contains('hidden')).to.be.true;
+      expect(element.children[3].classList.contains('hidden')).to.be.true;
+      expect(element.children[4].classList.contains('hidden')).to.be.true;
+      expect(element.children[5].classList.contains('hidden')).to.be.true;
+      expect(element.children[6].classList.contains('hidden')).to.be.true;
+      expect(element.children[7].classList.contains('hidden')).to.be.false;
+      expect(element.children[8].classList.contains('hidden')).to.be.true;
     });
   });
 });


### PR DESCRIPTION
To allow exact quoting of values including spaces, e.g. "This thing" or 'this thing'

What I like about the implementation is that you can go back and add the quotes without the filter clearing.

I'm somewhat optimistic that with wildcards and quotes, there is not much more I would want in the filtered list for a text entry search (unless we did a full regex search) for "narrowing of the search"

Closes #1158