### PR TITLE
feat(wizards): Pretty print XML inside code editor, closes #895

### DIFF
--- a/src/wizard-dialog.ts
+++ b/src/wizard-dialog.ts
@@ -42,6 +42,7 @@ import {
   identity,
   WizardInput,
   WizardMenuActor,
+  formatXml,
 } from './foundation.js';
 
 function renderWizardInput(
@@ -325,7 +326,9 @@ export class WizardDialog extends LitElement {
               style="width: 80vw; height: calc(100vh - 240px);"
               theme="ace/theme/solarized_${localStorage.getItem('theme')}"
               mode="ace/mode/xml"
-              value="${new XMLSerializer().serializeToString(page.element)}"
+              value="${formatXml(
+                new XMLSerializer().serializeToString(page.element)
+              )}"
             ></ace-editor>`
           : page.content?.map(renderWizardInput)}
       </div>


### PR DESCRIPTION
Closes #895

We use `formatXml` to save documents.

Is it dangerous to use it here? Perhaps a little bit.

When OpenSCD modifies elements e.g. datasets, subscriptions or supervision elements, the XML it produces is difficult to view in the Ace editor without manually adding linebreaks. This resolves that.