### PR TITLE
fix(editors/IED): Allow IEDs to be deleted after edit count change

### DIFF
--- a/src/editors/IED.ts
+++ b/src/editors/IED.ts
@@ -96,7 +96,11 @@ export default class IedPlugin extends LitElement {
     super.updated(_changedProperties);
 
     // When the document is updated, we reset the selected IED.
-    if (_changedProperties.has('doc') || _changedProperties.has('nsdoc')) {
+    if (
+      _changedProperties.has('doc') ||
+      _changedProperties.has('editCount') ||
+      _changedProperties.has('nsdoc')
+    ) {
       this.selectedIEDs = [];
       this.selectedLNClasses = [];
 


### PR DESCRIPTION
Closes #1272

Now that we are using the `editCount`  property we must make sure that plugins are not relying on the old behaviour, like this one. As the `doc` is no longer exchanged on each edit we also need to to look for `editCount` in the `updated` method.

For now I just fix this problem, I hope to have a look through other editors where I suspect similar issues may occur and may not be very visible in our test coverage.