### PR TITLE
fix(open-scd): Make linear progress bar Github stylez, closes #1269

### DIFF
--- a/src/open-scd.ts
+++ b/src/open-scd.ts
@@ -121,17 +121,13 @@ export class OpenSCD extends Waiting(
 
     mwc-linear-progress {
       position: fixed;
+      --mdc-linear-progress-buffer-color: var(--primary);
       --mdc-theme-primary: var(--mdc-theme-secondary);
       left: 0px;
-      top: 112px;
+      top: 0px;
       width: 100%;
       pointer-events: none;
-    }
-
-    @media (max-width: 599px) {
-      mwc-linear-progress {
-        top: 104px;
-      }
+      z-index: 10;
     }
 
     tt {

--- a/src/open-scd.ts
+++ b/src/open-scd.ts
@@ -122,12 +122,12 @@ export class OpenSCD extends Waiting(
     mwc-linear-progress {
       position: fixed;
       --mdc-linear-progress-buffer-color: var(--primary);
-      --mdc-theme-primary: var(--mdc-theme-secondary);
+      --mdc-theme-primary: var(--secondary);
       left: 0px;
       top: 0px;
       width: 100%;
       pointer-events: none;
-      z-index: 10;
+      z-index: 1000;
     }
 
     tt {


### PR DESCRIPTION
Closes #1269

I couldn't find a solution without changing the z-index without more serious DOM modifications.

I have to use `--primary` I think because I am overwriting `--mdc-theme-primary`.

I  quite like this.