### PR TITLE
refactor(foundation): substitute find() for selector()

### DIFF
--- a/src/editors/protocol104/wizards/selectDo.ts
+++ b/src/editors/protocol104/wizards/selectDo.ts
@@ -13,7 +13,7 @@ import {
   getNameAttribute,
   identity,
   newSubWizardEvent,
-  selector,
+  find,
   Wizard,
   WizardActor,
   WizardInputElement,
@@ -158,7 +158,7 @@ function checkAndGetLastElementFromPath(
   const [tagName, id] = path.pop()!.split(': ');
   if (!expectedTag.includes(tagName)) return null;
 
-  return doc.querySelector(selector(tagName, id));
+  return find(doc, tagName, id);
 }
 
 /**

--- a/src/editors/publisher/data-set-editor.ts
+++ b/src/editors/publisher/data-set-editor.ts
@@ -19,7 +19,7 @@ import './data-set-element-editor.js';
 import '../../filtered-list.js';
 import { FilteredList } from '../../filtered-list.js';
 
-import { compareNames, identity, selector } from '../../foundation.js';
+import { compareNames, identity, find } from '../../foundation.js';
 import { styles, updateElementReference } from './foundation.js';
 
 @customElement('data-set-editor')
@@ -50,7 +50,7 @@ export class DataSetEditor extends LitElement {
 
   private selectDataSet(evt: Event): void {
     const id = ((evt.target as FilteredList).selected as ListItem).value;
-    const dataSet = this.doc.querySelector(selector('DataSet', id));
+    const dataSet = find(this.doc, 'DataSet', id);
 
     if (dataSet) {
       this.selectedDataSet = dataSet;

--- a/src/editors/publisher/foundation.ts
+++ b/src/editors/publisher/foundation.ts
@@ -1,6 +1,6 @@
 import { css } from 'lit-element';
 
-import { identity, selector } from '../../foundation.js';
+import { identity, find } from '../../foundation.js';
 
 export function updateElementReference(
   newDoc: XMLDocument,
@@ -9,7 +9,7 @@ export function updateElementReference(
   if (!oldElement || !oldElement.closest('SCL')) return null;
 
   const id = identity(oldElement);
-  const newElement = newDoc.querySelector(selector(oldElement.tagName, id));
+  const newElement = find(newDoc, oldElement.tagName, id);
 
   return newElement;
 }

--- a/src/editors/publisher/gse-control-editor.ts
+++ b/src/editors/publisher/gse-control-editor.ts
@@ -21,7 +21,7 @@ import '../../filtered-list.js';
 import { FilteredList } from '../../filtered-list.js';
 
 import { gooseIcon } from '../../icons/icons.js';
-import { compareNames, identity, selector } from '../../foundation.js';
+import { compareNames, identity, find } from '../../foundation.js';
 import { styles, updateElementReference } from './foundation.js';
 
 @customElement('gse-control-editor')
@@ -62,7 +62,7 @@ export class GseControlEditor extends LitElement {
 
   private selectGSEControl(evt: Event): void {
     const id = ((evt.target as FilteredList).selected as ListItem).value;
-    const gseControl = this.doc.querySelector(selector('GSEControl', id));
+    const gseControl = find(this.doc, 'GSEControl', id);
     if (!gseControl) return;
 
     this.selectedGseControl = gseControl;

--- a/src/editors/publisher/report-control-editor.ts
+++ b/src/editors/publisher/report-control-editor.ts
@@ -20,7 +20,7 @@ import './report-control-element-editor.js';
 import '../../filtered-list.js';
 import { FilteredList } from '../../filtered-list.js';
 
-import { compareNames, identity, selector } from '../../foundation.js';
+import { compareNames, identity, find } from '../../foundation.js';
 import { reportIcon } from '../../icons/icons.js';
 import { styles, updateElementReference } from './foundation.js';
 
@@ -66,7 +66,7 @@ export class ReportControlEditor extends LitElement {
 
   private selectReportControl(evt: Event): void {
     const id = ((evt.target as FilteredList).selected as ListItem).value;
-    const reportControl = this.doc.querySelector(selector('ReportControl', id));
+    const reportControl = find(this.doc, 'ReportControl', id);
     if (!reportControl) return;
 
     this.selectedReportControl = reportControl;

--- a/src/editors/publisher/sampled-value-control-editor.ts
+++ b/src/editors/publisher/sampled-value-control-editor.ts
@@ -20,7 +20,7 @@ import '../../filtered-list.js';
 import './sampled-value-control-element-editor.js';
 import { FilteredList } from '../../filtered-list.js';
 
-import { compareNames, identity, selector } from '../../foundation.js';
+import { compareNames, identity, find } from '../../foundation.js';
 import { smvIcon } from '../../icons/icons.js';
 import { styles, updateElementReference } from './foundation.js';
 
@@ -29,7 +29,7 @@ export class SampledValueControlEditor extends LitElement {
   /** The document being edited as provided to plugins by [[`OpenSCD`]]. */
   @property({ attribute: false })
   doc!: XMLDocument;
-  @property({type: Number})
+  @property({ type: Number })
   editCount = -1;
 
   @state()
@@ -66,9 +66,7 @@ export class SampledValueControlEditor extends LitElement {
 
   private selectSMVControl(evt: Event): void {
     const id = ((evt.target as FilteredList).selected as ListItem).value;
-    const smvControl = this.doc.querySelector(
-      selector('SampledValueControl', id)
-    );
+    const smvControl = find(this.doc, 'SampledValueControl', id);
     if (!smvControl) return;
 
     this.selectedSampledValueControl = smvControl;

--- a/src/editors/templates/datype-wizards.ts
+++ b/src/editors/templates/datype-wizards.ts
@@ -16,6 +16,7 @@ import {
   Create,
   createElement,
   EditorAction,
+  find,
   getValue,
   identity,
   newActionEvent,
@@ -23,7 +24,6 @@ import {
   newWizardEvent,
   patterns,
   Replace,
-  selector,
   Wizard,
   WizardActor,
   WizardInputElement,
@@ -89,7 +89,7 @@ export function editDaTypeWizard(
   dATypeIdentity: string,
   doc: XMLDocument
 ): Wizard | undefined {
-  const datype = doc.querySelector(selector('DAType', dATypeIdentity));
+  const datype = find(doc, 'DAType', dATypeIdentity);
   if (!datype) return undefined;
 
   const id = datype.getAttribute('id');
@@ -138,7 +138,7 @@ export function editDaTypeWizard(
           style="margin-top: 0px;"
           @selected=${(e: SingleSelectedEvent) => {
             const bdaIdentity = (<ListItem>(<List>e.target).selected).value;
-            const bda = doc.querySelector(selector('BDA', bdaIdentity));
+            const bda = find(doc, 'BDA', bdaIdentity);
 
             if (bda)
               e.target!.dispatchEvent(newSubWizardEvent(editBDAWizard(bda)));

--- a/src/editors/templates/dotype-wizards.ts
+++ b/src/editors/templates/dotype-wizards.ts
@@ -16,6 +16,7 @@ import {
   Create,
   createElement,
   EditorAction,
+  find,
   getValue,
   identity,
   isPublic,
@@ -23,7 +24,6 @@ import {
   newSubWizardEvent,
   newWizardEvent,
   Replace,
-  selector,
   Wizard,
   WizardActor,
   WizardInputElement,
@@ -99,12 +99,7 @@ function sDOWizard(options: WizardOptions): Wizard | undefined {
   const doc = (<UpdateOptions>options).doc
     ? (<UpdateOptions>options).doc
     : (<CreateOptions>options).parent.ownerDocument;
-  const sdo =
-    Array.from(
-      doc.querySelectorAll(
-        selector('SDO', (<UpdateOptions>options).identity ?? NaN)
-      )
-    ).find(isPublic) ?? null;
+  const sdo = find(doc, 'SDO', (<UpdateOptions>options).identity ?? NaN);
 
   const [title, action, type, menuActions, name, desc] = sdo
     ? [
@@ -351,7 +346,7 @@ export function dOTypeWizard(
   dOTypeIdentity: string,
   doc: XMLDocument
 ): Wizard | undefined {
-  const dotype = doc.querySelector(selector('DOType', dOTypeIdentity));
+  const dotype = find(doc, 'DOType', dOTypeIdentity);
   if (!dotype) return undefined;
 
   return [
@@ -411,7 +406,7 @@ export function dOTypeWizard(
               const item = <ListItem>(<List>e.target).selected;
 
               const daIdentity = (<ListItem>(<List>e.target).selected).value;
-              const da = doc.querySelector(selector('DA', daIdentity));
+              const da = find(doc, 'DA', daIdentity);
 
               const wizard = item.classList.contains('DA')
                 ? da

--- a/src/editors/templates/enumtype-wizard.ts
+++ b/src/editors/templates/enumtype-wizard.ts
@@ -15,6 +15,7 @@ import {
   cloneElement,
   createElement,
   EditorAction,
+  find,
   getValue,
   identity,
   isPublic,
@@ -23,7 +24,6 @@ import {
   newWizardEvent,
   patterns,
   Replace,
-  selector,
   Wizard,
   WizardActor,
   WizardInputElement,
@@ -101,12 +101,11 @@ function eNumValWizard(options: WizardOptions): Wizard {
   const doc = (<UpdateOptions>options).doc
     ? (<UpdateOptions>options).doc
     : (<CreateOptions>options).parent.ownerDocument;
-  const enumval =
-    Array.from(
-      doc.querySelectorAll(
-        selector('EnumVal', (<UpdateOptions>options).identity ?? NaN)
-      )
-    ).find(isPublic) ?? null;
+  const enumval = find(
+    doc,
+    'EnumVal',
+    (<UpdateOptions>options).identity ?? NaN
+  );
 
   const [title, action, ord, desc, value, menuActions] = enumval
     ? [
@@ -295,7 +294,7 @@ export function eNumTypeEditWizard(
   eNumTypeIdentity: string,
   doc: XMLDocument
 ): Wizard | undefined {
-  const enumtype = doc.querySelector(selector('EnumType', eNumTypeIdentity));
+  const enumtype = find(doc, 'EnumType', eNumTypeIdentity);
   if (!enumtype) return undefined;
 
   return [

--- a/src/editors/templates/lnodetype-wizard.ts
+++ b/src/editors/templates/lnodetype-wizard.ts
@@ -18,6 +18,7 @@ import {
   Create,
   createElement,
   EditorAction,
+  find,
   getChildElementsByTagName,
   getValue,
   identity,
@@ -27,7 +28,6 @@ import {
   newWizardEvent,
   patterns,
   Replace,
-  selector,
   Wizard,
   WizardActor,
   WizardInputElement,
@@ -130,12 +130,7 @@ function dOWizard(options: WizardOptions): Wizard | undefined {
   const doc = (<UpdateOptions>options).doc
     ? (<UpdateOptions>options).doc
     : (<CreateOptions>options).parent.ownerDocument;
-  const DO =
-    Array.from(
-      doc.querySelectorAll(
-        selector('DO', (<UpdateOptions>options).identity ?? NaN)
-      )
-    ).find(isPublic) ?? null;
+  const DO = find(doc, 'DO', (<UpdateOptions>options).identity ?? NaN);
 
   const [
     title,
@@ -412,7 +407,7 @@ function startLNodeTypeCreate(
     const value = (<Select>inputs.find(i => i.label === 'lnClass'))?.selected
       ?.value;
     const templateLNodeType = value
-      ? templates.querySelector(selector('LNodeType', value))
+      ? find(templates, 'LNodeType', value)
       : null;
 
     const newLNodeType = templateLNodeType
@@ -439,9 +434,7 @@ function startLNodeTypeCreate(
 
 function onLnClassChange(e: Event, templates: XMLDocument): void {
   const identity = (<Select>e.target).selected?.value;
-  const lnodetype = identity
-    ? templates.querySelector(selector('LNodeType', identity))
-    : null;
+  const lnodetype = identity ? find(templates, 'LNodeType', identity) : null;
 
   const primaryAction =
     (<Element>e.target)
@@ -606,7 +599,7 @@ export function lNodeTypeWizard(
   lNodeTypeIdentity: string,
   doc: XMLDocument
 ): Wizard | undefined {
-  const lnodetype = doc.querySelector(selector('LNodeType', lNodeTypeIdentity));
+  const lnodetype = find(doc, 'LNodeType', lNodeTypeIdentity);
   if (!lnodetype) return undefined;
 
   return [

--- a/src/foundation.ts
+++ b/src/foundation.ts
@@ -2505,12 +2505,30 @@ export function getReference(parent: Element, tag: SCLTag): Element | null {
   return nextSibling ?? null;
 }
 
-export function selector(tagName: string, identity: string | number): string {
+function selector(tagName: string, identity: string | number): string {
   if (typeof identity !== 'string') return voidSelector;
 
   if (isSCLTag(tagName)) return tags[tagName].selector(tagName, identity);
 
   return tagName;
+}
+
+export function find(
+  root: XMLDocument | Element | DocumentFragment,
+  tagName: string,
+  identity: string | number
+): Element | null {
+  if (typeof identity !== 'string' || !isSCLTag(tagName)) return null;
+
+  const element = root.querySelector(tags[tagName].selector(tagName, identity));
+
+  if (element === null || isPublic(element)) return element;
+
+  return (
+    Array.from(
+      root.querySelectorAll(tags[tagName].selector(tagName, identity))
+    ).find(isPublic) ?? null
+  );
 }
 
 /** @returns a string uniquely identifying `e` in its document, or NaN if `e`

--- a/src/foundation/ied.ts
+++ b/src/foundation/ied.ts
@@ -1,4 +1,4 @@
-import { Delete, identity, selector } from '../foundation.js';
+import { Delete, find, identity } from '../foundation.js';
 
 /**
  * All available FCDA references that are used to link ExtRefs.
@@ -94,7 +94,7 @@ export function emptyInputsDeleteActions(
   Object.entries(inputsMap).forEach(([key, value]) => {
     if (value.children.length! == 0) {
       const doc = extRefDeleteActions[0].old.parent.ownerDocument!;
-      const inputs = doc.querySelector(selector('Inputs', key));
+      const inputs = find(doc, 'Inputs', key);
 
       if (inputs && inputs.parentElement) {
         inputDeleteActions.push({

--- a/src/menu/CompareIED.ts
+++ b/src/menu/CompareIED.ts
@@ -22,11 +22,11 @@ import '../plain-compare-list.js';
 
 import {
   compareNames,
+  find,
   getNameAttribute,
   identity,
   isPublic,
   newPendingStateEvent,
-  selector,
 } from '../foundation.js';
 import { DiffFilter } from '../foundation/compare.js';
 
@@ -137,7 +137,7 @@ export default class CompareIEDPlugin extends LitElement {
     );
     const identity = selectListItem?.value;
     if (identity) {
-      return doc.querySelector(selector('IED', identity)) ?? undefined;
+      return find(doc, 'IED', identity) ?? undefined;
     }
     return undefined;
   }

--- a/src/menu/ImportIEDs.ts
+++ b/src/menu/ImportIEDs.ts
@@ -19,11 +19,11 @@ import { ListItemBase } from '@material/mwc-list/mwc-list-item-base';
 import '../filtered-list.js';
 import {
   createElement,
+  find,
   identity,
   isPublic,
   newActionEvent,
   newLogEvent,
-  selector,
   SimpleAction,
 } from '../foundation.js';
 
@@ -456,7 +456,7 @@ export default class ImportingIedPlugin extends LitElement {
 
     const ieds = selectedItems
       .map(item => {
-        return importDoc!.querySelector(selector('IED', item.value));
+        return find(importDoc, 'IED', item.value);
       })
       .filter(ied => ied) as Element[];
 

--- a/src/menu/UpdateDescriptionABB.ts
+++ b/src/menu/UpdateDescriptionABB.ts
@@ -8,11 +8,11 @@ import { ListItemBase } from '@material/mwc-list/mwc-list-item-base';
 import '../filtered-list.js';
 import {
   cloneElement,
+  find,
   identity,
   isPublic,
   newWizardEvent,
   SCLTag,
-  selector,
   Wizard,
   WizardAction,
   WizardActor,
@@ -37,7 +37,7 @@ function addDescriptionAction(doc: XMLDocument): WizardActor {
       const desc = (<Element>item.querySelector('span')).textContent;
       const [tag, identity] = item.value.split(' | ');
 
-      const oldElement = doc.querySelector(selector(tag, identity))!;
+      const oldElement = find(doc, tag, identity)!;
       const newElement = cloneElement(oldElement, { desc });
       return { old: { element: oldElement }, new: { element: newElement } };
     });

--- a/src/menu/UpdateDescriptionSEL.ts
+++ b/src/menu/UpdateDescriptionSEL.ts
@@ -8,11 +8,11 @@ import { ListItemBase } from '@material/mwc-list/mwc-list-item-base';
 import '../filtered-list.js';
 import {
   cloneElement,
+  find,
   identity,
   isPublic,
   newWizardEvent,
   SCLTag,
-  selector,
   Wizard,
   WizardAction,
   WizardActor,
@@ -71,7 +71,7 @@ function addDescriptionAction(doc: XMLDocument): WizardActor {
       const desc = (<Element>item.querySelector('span')).textContent;
       const [tag, identity] = item.value.split(' | ');
 
-      const oldElement = doc.querySelector(selector(tag, identity))!;
+      const oldElement = find(doc, tag, identity)!;
       const newElement = cloneElement(oldElement, { desc });
       return { old: { element: oldElement }, new: { element: newElement } };
     });

--- a/src/menu/UpdateSubstation.ts
+++ b/src/menu/UpdateSubstation.ts
@@ -3,10 +3,10 @@ import { get } from 'lit-translate';
 
 import {
   crossProduct,
+  find,
   identity,
   newWizardEvent,
   SCLTag,
-  selector,
   tags,
 } from '../foundation.js';
 import { Diff, mergeWizard } from '../wizards.js';
@@ -101,10 +101,8 @@ export default class UpdateSubstationPlugin extends LitElement {
                 selected: (diff: Diff<Element | string>): boolean =>
                   diff.theirs instanceof Element
                     ? diff.theirs.tagName === 'LNode'
-                      ? this.doc.querySelector(
-                          selector('LNode', identity(diff.theirs))
-                        ) === null &&
-                        isValidReference(doc, identity(diff.theirs))
+                      ? find(this.doc, 'LNode', identity(diff.theirs)) ===
+                          null && isValidReference(doc, identity(diff.theirs))
                       : diff.theirs.tagName === 'Substation' ||
                         !tags['SCL'].children.includes(
                           <SCLTag>diff.theirs.tagName
@@ -113,9 +111,7 @@ export default class UpdateSubstationPlugin extends LitElement {
                 disabled: (diff: Diff<Element | string>): boolean =>
                   diff.theirs instanceof Element &&
                   diff.theirs.tagName === 'LNode' &&
-                  (this.doc.querySelector(
-                    selector('LNode', identity(diff.theirs))
-                  ) !== null ||
+                  (find(this.doc, 'LNode', identity(diff.theirs)) !== null ||
                     !isValidReference(doc, identity(diff.theirs))),
                 auto: (): boolean => true,
               }

--- a/src/menu/VirtualTemplateIED.ts
+++ b/src/menu/VirtualTemplateIED.ts
@@ -21,10 +21,10 @@ import { Select } from '@material/mwc-select';
 
 import '../filtered-list.js';
 import {
+  find,
   getChildElementsByTagName,
   identity,
   newActionEvent,
-  selector,
 } from '../foundation.js';
 import { WizardTextField } from '../wizard-textfield.js';
 import {
@@ -164,10 +164,7 @@ export default class VirtualTemplateIED extends LitElement {
       this.dialog.querySelectorAll<CheckListItem>(
         'mwc-check-list-item[selected]:not([disabled])'
       ) ?? []
-    ).map(
-      selectedItem =>
-        this.doc.querySelector(selector('LNode', selectedItem.value))!
-    );
+    ).map(selectedItem => find(this.doc, 'LNode', selectedItem.value)!);
     if (!selectedLNode.length) return;
 
     const selectedLLN0s = Array.from(

--- a/src/wizards/clientln.ts
+++ b/src/wizards/clientln.ts
@@ -9,9 +9,9 @@ import { ListItemBase } from '@material/mwc-list/mwc-list-item-base';
 import '../filtered-list.js';
 import {
   createElement,
+  find,
   identity,
   pathParts,
-  selector,
   Wizard,
   WizardAction,
   WizardActor,
@@ -34,16 +34,16 @@ function getElement(identity: string | number): string {
 
 function getLogicalNode(doc: XMLDocument, identity: string): Element | null {
   if (identity.split('>').length === 4) {
-    return doc.querySelector(selector('LN', identity));
+    return find(doc, 'LN', identity);
   }
 
   if (identity.split('>').length === 3) {
     if (getElement(identity).split(' ').length > 1) {
-      return doc.querySelector(selector('LN', identity));
+      return find(doc, 'LN', identity);
     }
 
     if (getElement(identity).split(' ').length === 1) {
-      return doc.querySelector(selector('LN0', identity));
+      return find(doc, 'LN0', identity);
     }
   }
 
@@ -128,7 +128,7 @@ function addClientLnAction(doc: XMLDocument): WizardActor {
 
       const reportCbs = <Element[]>cbSelected
         .map(cb => cb.value)
-        .map(cbValue => doc.querySelector(selector('ReportControl', cbValue)))
+        .map(cbValue => find(doc, 'ReportControl', cbValue))
         .filter(cb => cb !== null);
 
       reportCbs.forEach(cb => {

--- a/src/wizards/commmap-wizards.ts
+++ b/src/wizards/commmap-wizards.ts
@@ -7,11 +7,11 @@ import { SingleSelectedEvent } from '@material/mwc-list/mwc-list-foundation';
 
 import '../filtered-list.js';
 import {
+  find,
   findControlBlocks,
   identity,
   isPublic,
   newWizardEvent,
-  selector,
   Wizard,
   WizardActor,
 } from '../foundation.js';
@@ -90,9 +90,7 @@ export function communicationMappingWizard(
           >${Array.from(connections.keys()).map(key => {
             const elements = connections.get(key)!;
             const [cbId, cbTag, sinkIED] = key.split(' | ');
-            const cbElement = ownerDocument.querySelector(
-              selector(cbTag, cbId)
-            );
+            const cbElement = find(ownerDocument, cbTag, cbId);
             const [_, sourceIED, controlBlock] = cbId.match(/^(.+)>>(.*)$/)!;
 
             return html`<mwc-list-item

--- a/src/wizards/dataset.ts
+++ b/src/wizards/dataset.ts
@@ -9,9 +9,9 @@ import '../wizard-textfield.js';
 import '../filtered-list.js';
 import {
   cloneElement,
+  find,
   getValue,
   identity,
-  selector,
   Replace,
   Wizard,
   WizardAction,
@@ -61,9 +61,7 @@ function updateDataSetAction(element: Element): WizardActor {
         'filtered-list > mwc-check-list-item:not([selected])'
       )
     )
-      .map(listItem =>
-        element.querySelector(selector('FCDA', (<CheckListItem>listItem).value))
-      )
+      .map(listItem => find(element, 'FCDA', (<CheckListItem>listItem).value))
       .filter(fcda => fcda)
       .map(fcda => {
         return {

--- a/src/wizards/fcda.ts
+++ b/src/wizards/fcda.ts
@@ -3,7 +3,7 @@ import { get } from 'lit-translate';
 
 import {
   createElement,
-  selector,
+  find,
   Wizard,
   WizardAction,
   WizardActor,
@@ -17,7 +17,7 @@ import {
 
 export function newFCDA(parent: Element, path: string[]): Element | undefined {
   const [leafTag, leafId] = path[path.length - 1].split(': ');
-  const leaf = parent.ownerDocument.querySelector(selector(leafTag, leafId));
+  const leaf = find(parent.ownerDocument, leafTag, leafId);
   if (!leaf || getDataModelChildren(leaf).length > 0) return;
 
   const lnSegment = path.find(segment => segment.startsWith('LN'));
@@ -25,7 +25,7 @@ export function newFCDA(parent: Element, path: string[]): Element | undefined {
 
   const [lnTag, lnId] = lnSegment.split(': ');
 
-  const ln = parent.ownerDocument.querySelector(selector(lnTag, lnId));
+  const ln = find(parent.ownerDocument, lnTag, lnId);
   if (!ln) return;
 
   const ldInst = ln.closest('LDevice')?.getAttribute('inst');
@@ -44,7 +44,7 @@ export function newFCDA(parent: Element, path: string[]): Element | undefined {
     const [tagName, id] = segment.split(': ');
     if (!['DO', 'DA', 'SDO', 'BDA'].includes(tagName)) continue;
 
-    const element = parent.ownerDocument.querySelector(selector(tagName, id));
+    const element = find(parent.ownerDocument, tagName, id);
 
     if (!element) return;
 

--- a/src/wizards/foundation/finder.ts
+++ b/src/wizards/foundation/finder.ts
@@ -3,7 +3,7 @@ import { translate } from 'lit-translate';
 
 import '../../finder-list.js';
 import { Directory } from '../../finder-list.js';
-import { identity, isPublic, selector } from '../../foundation.js';
+import { find, identity, isPublic } from '../../foundation.js';
 
 export function getDisplayString(entry: string): string {
   if (entry.startsWith('IED:')) return entry.replace(/^.*:/, '').trim();
@@ -17,7 +17,7 @@ export function getReader(
 ): (path: string[]) => Promise<Directory> {
   return async (path: string[]) => {
     const [tagName, id] = path[path.length - 1]?.split(': ', 2);
-    const element = doc.querySelector(selector(tagName, id));
+    const element = find(doc, tagName, id);
 
     if (!element)
       return { path, header: html`<p>${translate('error')}</p>`, entries: [] };

--- a/src/wizards/gsecontrol.ts
+++ b/src/wizards/gsecontrol.ts
@@ -18,6 +18,7 @@ import {
   createElement,
   Delete,
   EditorAction,
+  find,
   getUniqueElementName,
   getValue,
   identity,
@@ -26,7 +27,6 @@ import {
   newActionEvent,
   newSubWizardEvent,
   newWizardEvent,
-  selector,
   SimpleAction,
   Wizard,
   WizardActor,
@@ -335,7 +335,7 @@ function openGseControlCreateWizard(doc: XMLDocument): WizardActor {
     const [tagName, id] = path.pop()!.split(': ');
     if (tagName !== 'IED') return [];
 
-    const ied = doc.querySelector(selector(tagName, id));
+    const ied = find(doc, tagName, id);
     if (!ied) return [];
 
     const ln0 = ied.querySelector('LN0');
@@ -562,9 +562,7 @@ export function selectGseControlWizard(element: Element): Wizard {
           @selected=${(e: SingleSelectedEvent) => {
             const gseControlIndentity = (<ListItem>(<List>e.target).selected)
               .value;
-            const gseControl = element.querySelector<Element>(
-              selector('GSEControl', gseControlIndentity)
-            );
+            const gseControl = find(element, 'GSEControl', gseControlIndentity);
             if (gseControl) {
               e.target!.dispatchEvent(
                 newSubWizardEvent(() => editGseControlWizard(gseControl))

--- a/src/wizards/lnode.ts
+++ b/src/wizards/lnode.ts
@@ -15,6 +15,7 @@ import {
   cloneElement,
   createElement,
   EditorAction,
+  find,
   getChildElementsByTagName,
   getValue,
   identity,
@@ -22,7 +23,6 @@ import {
   newLogEvent,
   newWizardEvent,
   referencePath,
-  selector,
   Wizard,
   WizardActor,
   WizardInputElement,
@@ -40,11 +40,7 @@ function createLNodeAction(parent: Element): WizardActor {
     const selectedLNodeTypes = <Element[]>list!.items
       .filter(item => item.selected)
       .map(item => item.value)
-      .map(identity => {
-        return parent.ownerDocument.querySelector(
-          selector('LNodeType', identity)
-        );
-      })
+      .map(identity => find(parent.ownerDocument, 'LNodeType', identity))
       .filter(item => item !== null);
 
     const lnInstGenerator = newLnInstGenerator(parent);
@@ -279,9 +275,9 @@ export function lNodeWizardAction(parent: Element): WizardActor {
       .filter(item => item.selected)
       .map(item => item.value)
       .map(identity => {
-        return parent.ownerDocument.querySelector(selector('LN0', identity))
-          ? parent.ownerDocument.querySelector(selector('LN0', identity))
-          : parent.ownerDocument.querySelector(selector('LN', identity));
+        const ln0 = find(parent.ownerDocument, 'LN0', identity);
+        if (ln0) return ln0;
+        return find(parent.ownerDocument, 'LN', identity);
       })
       .filter(item => item !== null);
 

--- a/src/wizards/reportcontrol.ts
+++ b/src/wizards/reportcontrol.ts
@@ -16,12 +16,12 @@ import {
   cloneElement,
   createElement,
   EditorAction,
+  find,
   getReference,
   getValue,
   identity,
   isPublic,
   newSubWizardEvent,
-  selector,
   SimpleAction,
   Wizard,
   WizardActor,
@@ -307,7 +307,7 @@ function openReportControlCreateWizard(doc: XMLDocument): WizardActor {
     const [tagName, id] = path.pop()!.split(': ');
     if (tagName !== 'IED') return [];
 
-    const ied = doc.querySelector(selector(tagName, id));
+    const ied = find(doc, tagName, id);
     if (!ied) return [];
 
     const ln0 = ied.querySelector('LN0');
@@ -421,7 +421,7 @@ function copyReportControlActions(element: Element): WizardActor {
 
     const complexActions: ComplexAction[] = [];
     iedItems.forEach(iedItem => {
-      const ied = doc.querySelector(selector('IED', iedItem.value));
+      const ied = find(doc, 'IED', iedItem.value);
       if (!ied) return;
 
       const sinkLn0 = ied.querySelector('LN0');
@@ -738,9 +738,7 @@ export function selectReportControlWizard(element: Element): Wizard {
         html`<filtered-list
           @selected=${(e: SingleSelectedEvent) => {
             const identity = (<ListItemBase>(<List>e.target).selected).value;
-            const reportControl = element.querySelector(
-              selector('ReportControl', identity)
-            );
+            const reportControl = find(element, 'ReportControl', identity);
             if (!reportControl) return;
 
             e.target?.dispatchEvent(

--- a/src/wizards/sampledvaluecontrol.ts
+++ b/src/wizards/sampledvaluecontrol.ts
@@ -17,6 +17,7 @@ import {
   createElement,
   Delete,
   EditorAction,
+  find,
   getUniqueElementName,
   getValue,
   identity,
@@ -25,7 +26,6 @@ import {
   newActionEvent,
   newSubWizardEvent,
   newWizardEvent,
-  selector,
   Wizard,
   WizardActor,
   WizardInputElement,
@@ -455,7 +455,7 @@ function openSampledValueControlCreateWizard(doc: XMLDocument): WizardActor {
     const [tagName, id] = path.pop()!.split(': ');
     if (tagName !== 'IED') return [];
 
-    const ied = doc.querySelector(selector(tagName, id));
+    const ied = find(doc, tagName, id);
     if (!ied) return [];
 
     const ln0 = ied.querySelector('LN0');
@@ -652,8 +652,10 @@ export function selectSampledValueControlWizard(element: Element): Wizard {
         html`<filtered-list
           @selected=${(e: SingleSelectedEvent) => {
             const identity = (<ListItemBase>(<List>e.target).selected).value;
-            const sampledValueControl = element.querySelector(
-              selector('SampledValueControl', identity)
+            const sampledValueControl = find(
+              element,
+              'SampledValueControl',
+              identity
             );
             if (!sampledValueControl) return;
 

--- a/test/unit/foundation.test.ts
+++ b/test/unit/foundation.test.ts
@@ -5,6 +5,7 @@ import {
   ComplexAction,
   depth,
   EditorAction,
+  find,
   findControlBlocks,
   findFCDAs,
   getChildElementsByTagName,
@@ -26,7 +27,6 @@ import {
   newPendingStateEvent,
   newWizardEvent,
   SCLTag,
-  selector,
   tags,
   minAvailableLogicalNodeInstance,
 } from '../../src/foundation.js';
@@ -320,23 +320,23 @@ describe('foundation', () => {
     });
   });
 
-  describe('selector', () => {
-    it('returns negation pseudo-class for identity of type NaN', () => {
+  describe('find', () => {
+    it('returns null for the identity NaN', () => {
       const element = scl1.querySelector('Assotiation');
       const ident = identity(element!);
-      expect(selector('Assotiation', ident)).to.equal(':not(*)');
+      expect(find(scl1, 'Assotiation', ident)).to.equal(null);
     });
-    it('returns correct selector for all tags except IEDName and ProtNs', () => {
+    it('returns correct element for all tags except IEDName and ProtNs', () => {
       Object.keys(tags).forEach(tag => {
         const element = Array.from(scl1.querySelectorAll(tag)).filter(
           item => !item.closest('Private')
         )[0];
         if (element && tag !== 'IEDName' && tag !== 'ProtNs')
-          expect(element).to.satisfy((element: Element) =>
-            element.isEqualNode(
-              scl1.querySelector(selector(tag, identity(element)))
+          expect(element)
+            .to.satisfy((element: Element) =>
+              element.isEqualNode(find(scl1, tag, identity(element)))
             )
-          );
+            .and.to.equal(find(scl1, tag, identity(element)));
       });
     });
   });


### PR DESCRIPTION
In the course of some `identity`/`selector` bug fixes in `foundation.ts` (e.g. an ExtRef selector issue introduced in #1179 ) , @JakobVogelsang has identified some fundamental shortcomings of our current identities (e.g. `IEDName` identities not including the element's `textContent`) which are impossible to fix while keeping with the `selector` API.

Since we have been looking forward to moving to the `find` API from the `selector` API for a long time anyway for performance reasons (this API allows us to bypass querySelector entirely in the future and switch to much more performant SCL specific search implementations), we propose to make this switch now, before factoring out individual plugins that depend on the legacy `selector` API.