### PR TITLE
feat(editing): add open-scd-core Edit API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@material/mwc-textarea": "0.22.1",
         "@material/mwc-textfield": "0.22.1",
         "@material/mwc-top-app-bar-fixed": "0.22.1",
+        "@openscd/open-scd-core": "^0.0.2",
         "ace-custom-element": "^1.6.5",
         "lit-element": "2.5.1",
         "lit-html": "1.4.1",
@@ -2308,6 +2309,28 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.1.tgz",
+      "integrity": "sha512-kXOeFbfCm4fFf2A3WwVEeQj55tMZa8c8/f9AKHMobQMkzNUfUj+antR3fRPaZJawsa1aZiP/Da3ndpZrwEe4rQ=="
+    },
+    "node_modules/@lit/localize": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/@lit/localize/-/localize-0.11.4.tgz",
+      "integrity": "sha512-RRIwIX2tAm3+DuEndoXSJrFjGrAK5cb5IXo5K6jcJ6sbgD829B8rSqHC5MaKVUmXTVLIR1bk5IZOZDf9wFereA==",
+      "dependencies": {
+        "@lit/reactive-element": "^1.4.0",
+        "lit": "^2.3.0"
+      }
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
+      }
+    },
     "node_modules/@material/animation": {
       "version": "12.0.0-canary.22d29cbb4.0",
       "resolved": "https://registry.npmjs.org/@material/animation/-/animation-12.0.0-canary.22d29cbb4.0.tgz",
@@ -2431,6 +2454,51 @@
         "@material/rtl": "12.0.0-canary.22d29cbb4.0",
         "@material/theme": "12.0.0-canary.22d29cbb4.0",
         "@material/typography": "12.0.0-canary.22d29cbb4.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/focus-ring": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/focus-ring/-/focus-ring-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-exPX5VrjQimipBwgcFDGRiEE783sOBgpkFui59A6i6iGvS2UrLHlYY2E65fyyyQnD1f/rv4Po1OOnCesE1kulg==",
+      "dependencies": {
+        "@material/dom": "14.0.0-canary.53b3cad2f.0",
+        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+        "@material/rtl": "14.0.0-canary.53b3cad2f.0"
+      }
+    },
+    "node_modules/@material/focus-ring/node_modules/@material/dom": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/dom/-/dom-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-aR+rfncF6oi2ivdOlKSJI4UXwNzWV5rXM88MLDoSJF1D7lXxhAKhge+tMUBodWGV/q0+FnXLuVAa0WYTrKjo+A==",
+      "dependencies": {
+        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/focus-ring/node_modules/@material/feature-targeting": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-fn7Af3PRyARtNeYqtjxXmE3Y/dCpnpQVWWys57MqiGR/nvc6qpgOfJ6rOdcu/MrOysOE/oebTUDmDnTmwpe9Hw==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/focus-ring/node_modules/@material/rtl": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-f08LT0HSa0WYU+4Jz/tbm1TQ9Fcf2k+H6dPPYv0J1sZmX6hMgCEmNiUdUFLQFvszoXx2XrRi1/hIFjbz2e69Yg==",
+      "dependencies": {
+        "@material/theme": "14.0.0-canary.53b3cad2f.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/focus-ring/node_modules/@material/theme": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/theme/-/theme-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-S06XAevDCDWMe+GgsEpITMS07imUidzadNaTbJsqssFajBLr53QWVZsG84BpjXKXoYvyEJvb0hX5U0lq6ip9UQ==",
+      "dependencies": {
+        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
         "tslib": "^2.1.0"
       }
     },
@@ -3134,6 +3202,69 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@material/tokens": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/tokens/-/tokens-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-myHFB7vac8zErA3qgkqmV+kpE+i9JEwc/6Yf0MOumDSpylJGw28QikpNC6eAVBK2EmPQTaFn20mqUxyud8dGqw==",
+      "dependencies": {
+        "@material/elevation": "14.0.0-canary.53b3cad2f.0"
+      }
+    },
+    "node_modules/@material/tokens/node_modules/@material/animation": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/animation/-/animation-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-GBuR4VmcTQW1D0lPXEosf5Giho72LLbyGIydWGtaEUtLJoive/D9kFkwTN4Fsyt9Kkl7hbhs35vrNe6QkAH4/Q==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/tokens/node_modules/@material/base": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/base/-/base-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-UJKbXwZtkrA3sfQDmj8Zbw1Q3Tqtl6KdfVFws95Yf7TCUgTFzbZI/FSx1w7dVugQPOEnIBuZnzqZam/MtHkx4w==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/tokens/node_modules/@material/elevation": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-3h+EkR588RMZ5TSNQ4UeXD1FOBnL3ABQix0DQIGwtNJCqSMoPndT/oJEFvwQbTkZNDbFIKN9p1Q7/KuFPVY8Pw==",
+      "dependencies": {
+        "@material/animation": "14.0.0-canary.53b3cad2f.0",
+        "@material/base": "14.0.0-canary.53b3cad2f.0",
+        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+        "@material/rtl": "14.0.0-canary.53b3cad2f.0",
+        "@material/theme": "14.0.0-canary.53b3cad2f.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/tokens/node_modules/@material/feature-targeting": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-fn7Af3PRyARtNeYqtjxXmE3Y/dCpnpQVWWys57MqiGR/nvc6qpgOfJ6rOdcu/MrOysOE/oebTUDmDnTmwpe9Hw==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/tokens/node_modules/@material/rtl": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-f08LT0HSa0WYU+4Jz/tbm1TQ9Fcf2k+H6dPPYv0J1sZmX6hMgCEmNiUdUFLQFvszoXx2XrRi1/hIFjbz2e69Yg==",
+      "dependencies": {
+        "@material/theme": "14.0.0-canary.53b3cad2f.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@material/tokens/node_modules/@material/theme": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/theme/-/theme-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-S06XAevDCDWMe+GgsEpITMS07imUidzadNaTbJsqssFajBLr53QWVZsG84BpjXKXoYvyEJvb0hX5U0lq6ip9UQ==",
+      "dependencies": {
+        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/@material/top-app-bar": {
       "version": "12.0.0-canary.22d29cbb4.0",
       "resolved": "https://registry.npmjs.org/@material/top-app-bar/-/top-app-bar-12.0.0-canary.22d29cbb4.0.tgz",
@@ -3619,6 +3750,522 @@
         "@open-wc/scoped-elements": "^1.2.4",
         "lit-element": "^2.2.1",
         "lit-html": "^1.0.0"
+      }
+    },
+    "node_modules/@openscd/open-scd-core": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@openscd/open-scd-core/-/open-scd-core-0.0.2.tgz",
+      "integrity": "sha512-GIXLFo5c4YvhTwZRhofB9rR9gftfCEHM7iEraQj+tqoMw7NChvbQUfpo6kPvNXnB7RElreRNdPQG2TaHqA6xAQ==",
+      "dependencies": {
+        "@lit/localize": "^0.11.4",
+        "@material/mwc-button": "^0.27.0",
+        "@material/mwc-dialog": "^0.27.0",
+        "@material/mwc-drawer": "^0.27.0",
+        "@material/mwc-icon": "^0.27.0",
+        "@material/mwc-icon-button": "^0.27.0",
+        "@material/mwc-list": "^0.27.0",
+        "@material/mwc-tab-bar": "^0.27.0",
+        "@material/mwc-top-app-bar-fixed": "^0.27.0",
+        "lit": "^2.2.7"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/animation": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/animation/-/animation-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-GBuR4VmcTQW1D0lPXEosf5Giho72LLbyGIydWGtaEUtLJoive/D9kFkwTN4Fsyt9Kkl7hbhs35vrNe6QkAH4/Q==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/base": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/base/-/base-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-UJKbXwZtkrA3sfQDmj8Zbw1Q3Tqtl6KdfVFws95Yf7TCUgTFzbZI/FSx1w7dVugQPOEnIBuZnzqZam/MtHkx4w==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/button": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/button/-/button-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-IPBAByKpQjrWNVmAWx5VCTCLnOw4ymbLsbHmBkLiDgcLPs1EtwYnKKIwQ+/t3bV02OShUdMiyboL8V/C0gMS1A==",
+      "dependencies": {
+        "@material/density": "14.0.0-canary.53b3cad2f.0",
+        "@material/dom": "14.0.0-canary.53b3cad2f.0",
+        "@material/elevation": "14.0.0-canary.53b3cad2f.0",
+        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+        "@material/focus-ring": "14.0.0-canary.53b3cad2f.0",
+        "@material/ripple": "14.0.0-canary.53b3cad2f.0",
+        "@material/rtl": "14.0.0-canary.53b3cad2f.0",
+        "@material/shape": "14.0.0-canary.53b3cad2f.0",
+        "@material/theme": "14.0.0-canary.53b3cad2f.0",
+        "@material/tokens": "14.0.0-canary.53b3cad2f.0",
+        "@material/touch-target": "14.0.0-canary.53b3cad2f.0",
+        "@material/typography": "14.0.0-canary.53b3cad2f.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/density": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/density/-/density-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-Eh/vZ3vVyqtpylg5Ci33qlgtToS4H1/ppd450Ib3tcdISIoodgijYY0w4XsRvrnZgbI/h/1STFdLxdzS0UNuFw==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/dialog": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/dialog/-/dialog-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-yiG2nlVKTW0Ro3CF8Z/MVpTwSyG/8Kio3AaTUbeQdbjt5r692s4x5Yhd8m1IjEQKUeulY4CndvIbCUwZ8/G2PA==",
+      "dependencies": {
+        "@material/animation": "14.0.0-canary.53b3cad2f.0",
+        "@material/base": "14.0.0-canary.53b3cad2f.0",
+        "@material/button": "14.0.0-canary.53b3cad2f.0",
+        "@material/dom": "14.0.0-canary.53b3cad2f.0",
+        "@material/elevation": "14.0.0-canary.53b3cad2f.0",
+        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+        "@material/icon-button": "14.0.0-canary.53b3cad2f.0",
+        "@material/ripple": "14.0.0-canary.53b3cad2f.0",
+        "@material/rtl": "14.0.0-canary.53b3cad2f.0",
+        "@material/shape": "14.0.0-canary.53b3cad2f.0",
+        "@material/theme": "14.0.0-canary.53b3cad2f.0",
+        "@material/tokens": "14.0.0-canary.53b3cad2f.0",
+        "@material/touch-target": "14.0.0-canary.53b3cad2f.0",
+        "@material/typography": "14.0.0-canary.53b3cad2f.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/dom": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/dom/-/dom-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-aR+rfncF6oi2ivdOlKSJI4UXwNzWV5rXM88MLDoSJF1D7lXxhAKhge+tMUBodWGV/q0+FnXLuVAa0WYTrKjo+A==",
+      "dependencies": {
+        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/drawer": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/drawer/-/drawer-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-MXzRGq7NoONgbHa+AhAu4HvOUA9V37nSsY4g4Alita08UqRAvvFFr4K1CF9GI2K9pLCpyQv1UbN0Lw5b78HrVQ==",
+      "dependencies": {
+        "@material/animation": "14.0.0-canary.53b3cad2f.0",
+        "@material/base": "14.0.0-canary.53b3cad2f.0",
+        "@material/dom": "14.0.0-canary.53b3cad2f.0",
+        "@material/elevation": "14.0.0-canary.53b3cad2f.0",
+        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+        "@material/list": "14.0.0-canary.53b3cad2f.0",
+        "@material/ripple": "14.0.0-canary.53b3cad2f.0",
+        "@material/rtl": "14.0.0-canary.53b3cad2f.0",
+        "@material/shape": "14.0.0-canary.53b3cad2f.0",
+        "@material/theme": "14.0.0-canary.53b3cad2f.0",
+        "@material/typography": "14.0.0-canary.53b3cad2f.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/elevation": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-3h+EkR588RMZ5TSNQ4UeXD1FOBnL3ABQix0DQIGwtNJCqSMoPndT/oJEFvwQbTkZNDbFIKN9p1Q7/KuFPVY8Pw==",
+      "dependencies": {
+        "@material/animation": "14.0.0-canary.53b3cad2f.0",
+        "@material/base": "14.0.0-canary.53b3cad2f.0",
+        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+        "@material/rtl": "14.0.0-canary.53b3cad2f.0",
+        "@material/theme": "14.0.0-canary.53b3cad2f.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/feature-targeting": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-fn7Af3PRyARtNeYqtjxXmE3Y/dCpnpQVWWys57MqiGR/nvc6qpgOfJ6rOdcu/MrOysOE/oebTUDmDnTmwpe9Hw==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/icon-button": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/icon-button/-/icon-button-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-BFdj3CP0JXHC/F2bDmpmzWhum4fkzIDgCCavvnpE/KcCbr0AaoSULRde+LtqvbdLIYW20cXhvjinIOlRhSOshA==",
+      "dependencies": {
+        "@material/base": "14.0.0-canary.53b3cad2f.0",
+        "@material/density": "14.0.0-canary.53b3cad2f.0",
+        "@material/dom": "14.0.0-canary.53b3cad2f.0",
+        "@material/elevation": "14.0.0-canary.53b3cad2f.0",
+        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+        "@material/focus-ring": "14.0.0-canary.53b3cad2f.0",
+        "@material/ripple": "14.0.0-canary.53b3cad2f.0",
+        "@material/rtl": "14.0.0-canary.53b3cad2f.0",
+        "@material/theme": "14.0.0-canary.53b3cad2f.0",
+        "@material/touch-target": "14.0.0-canary.53b3cad2f.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/list": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/list/-/list-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-mkMpltSKAYLBtFnTTCk/mQIDzwxF/VLh1gh59ehOtmRXt7FvTz83RoAa4tqe53hpVrbX4HoLDBu+vILhq/wkjw==",
+      "dependencies": {
+        "@material/base": "14.0.0-canary.53b3cad2f.0",
+        "@material/density": "14.0.0-canary.53b3cad2f.0",
+        "@material/dom": "14.0.0-canary.53b3cad2f.0",
+        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+        "@material/ripple": "14.0.0-canary.53b3cad2f.0",
+        "@material/rtl": "14.0.0-canary.53b3cad2f.0",
+        "@material/shape": "14.0.0-canary.53b3cad2f.0",
+        "@material/theme": "14.0.0-canary.53b3cad2f.0",
+        "@material/typography": "14.0.0-canary.53b3cad2f.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/mwc-base": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-base/-/mwc-base-0.27.0.tgz",
+      "integrity": "sha512-oCWWtjbyQ52AaUbzINLGBKScIPyqhps2Y7c8t6Gu6fcFeDxhKXMV1Cqvtj/OMhtAt53XjHfD2XruWwYv3cYYUA==",
+      "dependencies": {
+        "@material/base": "=14.0.0-canary.53b3cad2f.0",
+        "@material/dom": "=14.0.0-canary.53b3cad2f.0",
+        "lit": "^2.0.0",
+        "tslib": "^2.0.1"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/mwc-button": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-button/-/mwc-button-0.27.0.tgz",
+      "integrity": "sha512-t5m2zfE93RNKHMjdsU67X6csFzuSG08VJKKvXVQ+BriGE3xBgzY5nZdmZXomFpaWjDENPAlyS4ppCFm6o+DILw==",
+      "dependencies": {
+        "@material/mwc-icon": "^0.27.0",
+        "@material/mwc-ripple": "^0.27.0",
+        "lit": "^2.0.0",
+        "tslib": "^2.0.1"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/mwc-checkbox": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-checkbox/-/mwc-checkbox-0.27.0.tgz",
+      "integrity": "sha512-EY0iYZLwo8qaqMwR5da4fdn0xI0BZNAvKTcwoubYWpDDHlGxDcqwvjp/40ChGo3Q/zv8/4/A0Qp7cwapI82EkA==",
+      "dependencies": {
+        "@material/mwc-base": "^0.27.0",
+        "@material/mwc-ripple": "^0.27.0",
+        "lit": "^2.0.0",
+        "tslib": "^2.0.1"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/mwc-dialog": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-dialog/-/mwc-dialog-0.27.0.tgz",
+      "integrity": "sha512-rkOEmCroVs0wBQbj87vH79SvSHHZ61QRCTUYsU2rHGZCvdzlmvHjWdoyKjJER6WwwM3rrT8xthfecmjICI28CA==",
+      "dependencies": {
+        "@material/dialog": "=14.0.0-canary.53b3cad2f.0",
+        "@material/dom": "=14.0.0-canary.53b3cad2f.0",
+        "@material/mwc-base": "^0.27.0",
+        "@material/mwc-button": "^0.27.0",
+        "blocking-elements": "^0.1.0",
+        "lit": "^2.0.0",
+        "tslib": "^2.0.1",
+        "wicg-inert": "^3.0.0"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/mwc-drawer": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-drawer/-/mwc-drawer-0.27.0.tgz",
+      "integrity": "sha512-dy/uwt+aI5aiUDqFcT6Z4GhGmLZR7fu3HMkfqtQDwoJShxnf5hHwk18fiD1VHHCDf9CZ5wjl7ug4fjpcs9r18A==",
+      "dependencies": {
+        "@material/drawer": "=14.0.0-canary.53b3cad2f.0",
+        "@material/mwc-base": "^0.27.0",
+        "blocking-elements": "^0.1.0",
+        "lit": "^2.0.0",
+        "tslib": "^2.0.1",
+        "wicg-inert": "^3.0.0"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/mwc-icon": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-icon/-/mwc-icon-0.27.0.tgz",
+      "integrity": "sha512-Sul44I37M9Ewynn0A9DjkEBrmll2VtNbth6Pxj7I1A/EAwEfaCrPvryyGqfIu1T2hTsRcaojzQx6QjF+B5QW9A==",
+      "dependencies": {
+        "lit": "^2.0.0",
+        "tslib": "^2.0.1"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/mwc-icon-button": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-icon-button/-/mwc-icon-button-0.27.0.tgz",
+      "integrity": "sha512-wReiPa1UkLaCSPtpkAs1OGKEBtvqPnz9kzuY+RvN5ZQnpo3Uh7n3plHV4y/stsUBfrWtBCcOgYnCdNRaR/r2nQ==",
+      "dependencies": {
+        "@material/mwc-ripple": "^0.27.0",
+        "lit": "^2.0.0",
+        "tslib": "^2.0.1"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/mwc-list": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-list/-/mwc-list-0.27.0.tgz",
+      "integrity": "sha512-oAhNQsBuAOgF3ENOIY8PeWjXsl35HoYaUkl0ixBQk8jJP2HIEf+MdbS5688y/UXxFbSjr0m//LfwR5gauEashg==",
+      "dependencies": {
+        "@material/base": "=14.0.0-canary.53b3cad2f.0",
+        "@material/dom": "=14.0.0-canary.53b3cad2f.0",
+        "@material/list": "=14.0.0-canary.53b3cad2f.0",
+        "@material/mwc-base": "^0.27.0",
+        "@material/mwc-checkbox": "^0.27.0",
+        "@material/mwc-radio": "^0.27.0",
+        "@material/mwc-ripple": "^0.27.0",
+        "lit": "^2.0.0",
+        "tslib": "^2.0.1"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/mwc-radio": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-radio/-/mwc-radio-0.27.0.tgz",
+      "integrity": "sha512-+rSO9a373BgyMgQOM0Z8vVkuieobBylPJ8qpltytM+yGPj8+n+MtwRZyg+ry3WwEjYYDMP6GxZPHwLgWs6lMpQ==",
+      "dependencies": {
+        "@material/mwc-base": "^0.27.0",
+        "@material/mwc-ripple": "^0.27.0",
+        "@material/radio": "=14.0.0-canary.53b3cad2f.0",
+        "lit": "^2.0.0",
+        "tslib": "^2.0.1"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/mwc-ripple": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-ripple/-/mwc-ripple-0.27.0.tgz",
+      "integrity": "sha512-by0O8d8g3Rd96/sUB8hxy6MrDx1QTstqOsA64vqypWd526hMTBGRik08jTNap5sVIyrN9Vq17jb4NJLWQLnNHQ==",
+      "dependencies": {
+        "@material/dom": "=14.0.0-canary.53b3cad2f.0",
+        "@material/mwc-base": "^0.27.0",
+        "@material/ripple": "=14.0.0-canary.53b3cad2f.0",
+        "lit": "^2.0.0",
+        "tslib": "^2.0.1"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/mwc-tab": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-tab/-/mwc-tab-0.27.0.tgz",
+      "integrity": "sha512-BhX6hZYjPL+d3Gcl6rVHNPiEAudgMHA+7mHo2keqbIiFRLKa2CU+omHZO/82+EBan/TPL6ZK39Oki8aIaAJcRQ==",
+      "dependencies": {
+        "@material/mwc-base": "^0.27.0",
+        "@material/mwc-ripple": "^0.27.0",
+        "@material/mwc-tab-indicator": "^0.27.0",
+        "@material/tab": "=14.0.0-canary.53b3cad2f.0",
+        "lit": "^2.0.0",
+        "tslib": "^2.0.1"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/mwc-tab-bar": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-tab-bar/-/mwc-tab-bar-0.27.0.tgz",
+      "integrity": "sha512-CqRZ38m8kOfSJo87Ek61eubO8AGR10Dp12c3pCyyy6mtK/0FSY+rfcmnMPxEzkxREqUnQPgw9lhqmGZXBSqzZQ==",
+      "dependencies": {
+        "@material/mwc-base": "^0.27.0",
+        "@material/mwc-tab": "^0.27.0",
+        "@material/mwc-tab-scroller": "^0.27.0",
+        "@material/tab": "=14.0.0-canary.53b3cad2f.0",
+        "@material/tab-bar": "=14.0.0-canary.53b3cad2f.0",
+        "lit": "^2.0.0",
+        "tslib": "^2.0.1"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/mwc-tab-indicator": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-tab-indicator/-/mwc-tab-indicator-0.27.0.tgz",
+      "integrity": "sha512-bdE5mYP2ze/8d8cGTTJUS0+ByzEK5tmWsXfphFr/Dyy9b+gOnIOt1iX8tmKTOpbYKsV43LxtSkumhTTPDXEJLg==",
+      "dependencies": {
+        "@material/mwc-base": "^0.27.0",
+        "@material/tab-indicator": "=14.0.0-canary.53b3cad2f.0",
+        "lit": "^2.0.0",
+        "tslib": "^2.0.1"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/mwc-tab-scroller": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-tab-scroller/-/mwc-tab-scroller-0.27.0.tgz",
+      "integrity": "sha512-WL/CYVx1cHjC1a/STIB/BaBfxGz3Rz4szNNX35FkYzm6GSGxUNkXZfKOAK7R8RdZOAETa8Gy5tTEhKZKKJ/aUA==",
+      "dependencies": {
+        "@material/dom": "=14.0.0-canary.53b3cad2f.0",
+        "@material/mwc-base": "^0.27.0",
+        "@material/tab-scroller": "=14.0.0-canary.53b3cad2f.0",
+        "lit": "^2.0.0",
+        "tslib": "^2.0.1"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/mwc-top-app-bar": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-top-app-bar/-/mwc-top-app-bar-0.27.0.tgz",
+      "integrity": "sha512-vHn10exeDhUVFpo4TgBsS8pta4AxZtjuuxrYFHMYxceGifEATvGbYoPyw1x7cCMcXMMIITElgfCURAbCmn3BgA==",
+      "dependencies": {
+        "@material/mwc-base": "^0.27.0",
+        "@material/top-app-bar": "=14.0.0-canary.53b3cad2f.0",
+        "lit": "^2.0.0",
+        "tslib": "^2.0.1"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/mwc-top-app-bar-fixed": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@material/mwc-top-app-bar-fixed/-/mwc-top-app-bar-fixed-0.27.0.tgz",
+      "integrity": "sha512-kU1RKmx8U7YCbsBuAXfNLtu+V/Jwos+o2mSY94tZpv36dIsvcsGQ4pB2zW0EaU8g9bQVdwLMVxj4oooxSmbZXw==",
+      "dependencies": {
+        "@material/mwc-top-app-bar": "^0.27.0",
+        "@material/top-app-bar": "=14.0.0-canary.53b3cad2f.0",
+        "lit": "^2.0.0",
+        "tslib": "^2.0.1"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/radio": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/radio/-/radio-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-V/AgWEOuHFoh9d4Gq1rqBZnKSGtMLQNh23Bwrv0c1FhPqFvUpwt9jR3SVwhJk5gvQQWGy9p3iiGc9QCJ+0+P8Q==",
+      "dependencies": {
+        "@material/animation": "14.0.0-canary.53b3cad2f.0",
+        "@material/base": "14.0.0-canary.53b3cad2f.0",
+        "@material/density": "14.0.0-canary.53b3cad2f.0",
+        "@material/dom": "14.0.0-canary.53b3cad2f.0",
+        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+        "@material/focus-ring": "14.0.0-canary.53b3cad2f.0",
+        "@material/ripple": "14.0.0-canary.53b3cad2f.0",
+        "@material/theme": "14.0.0-canary.53b3cad2f.0",
+        "@material/touch-target": "14.0.0-canary.53b3cad2f.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/ripple": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-6g2G62vd8DsMuIUSXlRrzb98qkZ4o8ZREknNwNP2zaLQEOkJ//4j9HaqDt98/3LIjUTY9UIVFTQENiMmlwKHYQ==",
+      "dependencies": {
+        "@material/animation": "14.0.0-canary.53b3cad2f.0",
+        "@material/base": "14.0.0-canary.53b3cad2f.0",
+        "@material/dom": "14.0.0-canary.53b3cad2f.0",
+        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+        "@material/rtl": "14.0.0-canary.53b3cad2f.0",
+        "@material/theme": "14.0.0-canary.53b3cad2f.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/rtl": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-f08LT0HSa0WYU+4Jz/tbm1TQ9Fcf2k+H6dPPYv0J1sZmX6hMgCEmNiUdUFLQFvszoXx2XrRi1/hIFjbz2e69Yg==",
+      "dependencies": {
+        "@material/theme": "14.0.0-canary.53b3cad2f.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/shape": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/shape/-/shape-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-RyjInLCNe+nI/ulKea0ZLHphXQDiDqYazS25SRn18g8Hoa5qGNaY5oOBncDXUYn3jm5oI5kFc9oif//kulkbjg==",
+      "dependencies": {
+        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+        "@material/rtl": "14.0.0-canary.53b3cad2f.0",
+        "@material/theme": "14.0.0-canary.53b3cad2f.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/tab": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/tab/-/tab-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-Vmjugm9TBF906pNE2kORSDcMUYXQXV+uspFdbyoSH3hVOTjX+Bw+ODL9agW+pDsJRqGMLO/BAoZ0YQDCrCNX/A==",
+      "dependencies": {
+        "@material/base": "14.0.0-canary.53b3cad2f.0",
+        "@material/elevation": "14.0.0-canary.53b3cad2f.0",
+        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+        "@material/focus-ring": "14.0.0-canary.53b3cad2f.0",
+        "@material/ripple": "14.0.0-canary.53b3cad2f.0",
+        "@material/rtl": "14.0.0-canary.53b3cad2f.0",
+        "@material/tab-indicator": "14.0.0-canary.53b3cad2f.0",
+        "@material/theme": "14.0.0-canary.53b3cad2f.0",
+        "@material/typography": "14.0.0-canary.53b3cad2f.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/tab-bar": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/tab-bar/-/tab-bar-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-qLTxl0SWwSpsWBV5o7fMO4HaA3NSCTroM+qkUJYNq7lumMXxax8XP6+GvgbXXfsF1K6VqwSPJHnFt5g1kvtBOA==",
+      "dependencies": {
+        "@material/animation": "14.0.0-canary.53b3cad2f.0",
+        "@material/base": "14.0.0-canary.53b3cad2f.0",
+        "@material/density": "14.0.0-canary.53b3cad2f.0",
+        "@material/elevation": "14.0.0-canary.53b3cad2f.0",
+        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+        "@material/tab": "14.0.0-canary.53b3cad2f.0",
+        "@material/tab-indicator": "14.0.0-canary.53b3cad2f.0",
+        "@material/tab-scroller": "14.0.0-canary.53b3cad2f.0",
+        "@material/theme": "14.0.0-canary.53b3cad2f.0",
+        "@material/typography": "14.0.0-canary.53b3cad2f.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/tab-indicator": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/tab-indicator/-/tab-indicator-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-CMh5MuQamk10oYs0NpQwJ+JLPcY+WftU1b2NpAxbke+6yaV0XrcEkymSfHDkMB5itDvtpXR4fe2Yw9wO8gvcgg==",
+      "dependencies": {
+        "@material/animation": "14.0.0-canary.53b3cad2f.0",
+        "@material/base": "14.0.0-canary.53b3cad2f.0",
+        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+        "@material/theme": "14.0.0-canary.53b3cad2f.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/tab-scroller": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/tab-scroller/-/tab-scroller-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-eJJWfNDSdjrRVNHkSecblN26PtM8rTeK2FqcZh3iCYRZ74ywhKmHF+elrM2KRH8ez+u/YcZoQacgS8rX3v6ygw==",
+      "dependencies": {
+        "@material/animation": "14.0.0-canary.53b3cad2f.0",
+        "@material/base": "14.0.0-canary.53b3cad2f.0",
+        "@material/dom": "14.0.0-canary.53b3cad2f.0",
+        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+        "@material/tab": "14.0.0-canary.53b3cad2f.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/theme": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/theme/-/theme-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-S06XAevDCDWMe+GgsEpITMS07imUidzadNaTbJsqssFajBLr53QWVZsG84BpjXKXoYvyEJvb0hX5U0lq6ip9UQ==",
+      "dependencies": {
+        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/top-app-bar": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/top-app-bar/-/top-app-bar-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-9vPLLxUbNrWNCPGHoIeIUtyXWQUNh+yQwnkTYVkVAVEb1CsWb2D+/NefytfvyFtXWBFQLybAeG5RH0ZqdcgQBQ==",
+      "dependencies": {
+        "@material/animation": "14.0.0-canary.53b3cad2f.0",
+        "@material/base": "14.0.0-canary.53b3cad2f.0",
+        "@material/elevation": "14.0.0-canary.53b3cad2f.0",
+        "@material/ripple": "14.0.0-canary.53b3cad2f.0",
+        "@material/rtl": "14.0.0-canary.53b3cad2f.0",
+        "@material/shape": "14.0.0-canary.53b3cad2f.0",
+        "@material/theme": "14.0.0-canary.53b3cad2f.0",
+        "@material/typography": "14.0.0-canary.53b3cad2f.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/touch-target": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/touch-target/-/touch-target-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-d83e5vbqoLyL542yOTTp4TLVltddWiqbI/j1w/D9ipE30YKfe2EDN+CNJc32Zufh5IUfK41DsZdrN8fI9cL99A==",
+      "dependencies": {
+        "@material/base": "14.0.0-canary.53b3cad2f.0",
+        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+        "@material/rtl": "14.0.0-canary.53b3cad2f.0",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@openscd/open-scd-core/node_modules/@material/typography": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/typography/-/typography-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-9J0k2fq7uyHsRzRqJDJLGmg3YzRpfRPtFDVeUH/xBcYoqpZE7wYw5Mb7s/l8eP626EtR7HhXhSPjvRTLA6NIJg==",
+      "dependencies": {
+        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+        "@material/theme": "14.0.0-canary.53b3cad2f.0",
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -4351,8 +4998,7 @@
     "node_modules/@types/trusted-types": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.3.tgz",
-      "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==",
-      "dev": true
+      "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g=="
     },
     "node_modules/@types/whatwg-url": {
       "version": "6.4.0",
@@ -11634,6 +12280,16 @@
       "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
       "dev": true
     },
+    "node_modules/lit": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+      "dependencies": {
+        "@lit/reactive-element": "^1.6.0",
+        "lit-element": "^3.3.0",
+        "lit-html": "^2.8.0"
+      }
+    },
     "node_modules/lit-element": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.5.1.tgz",
@@ -11653,6 +12309,24 @@
       "integrity": "sha512-jykKpkdRX0lx3JYq9jUMzVs02ISClOe2wxyPHat5wVKPyBRJQxgXxLxj1AbpuLNBCDZKEysMBpeJ1z0Y35Bk2Q==",
       "dependencies": {
         "lit-html": "^1.2.1"
+      }
+    },
+    "node_modules/lit/node_modules/lit-element": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.1.0",
+        "@lit/reactive-element": "^1.3.0",
+        "lit-html": "^2.8.0"
+      }
+    },
+    "node_modules/lit/node_modules/lit-html": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
       }
     },
     "node_modules/load-json-file": {
@@ -19759,6 +20433,28 @@
         "vary": "^1.1.2"
       }
     },
+    "@lit-labs/ssr-dom-shim": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.1.tgz",
+      "integrity": "sha512-kXOeFbfCm4fFf2A3WwVEeQj55tMZa8c8/f9AKHMobQMkzNUfUj+antR3fRPaZJawsa1aZiP/Da3ndpZrwEe4rQ=="
+    },
+    "@lit/localize": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/@lit/localize/-/localize-0.11.4.tgz",
+      "integrity": "sha512-RRIwIX2tAm3+DuEndoXSJrFjGrAK5cb5IXo5K6jcJ6sbgD829B8rSqHC5MaKVUmXTVLIR1bk5IZOZDf9wFereA==",
+      "requires": {
+        "@lit/reactive-element": "^1.4.0",
+        "lit": "^2.3.0"
+      }
+    },
+    "@lit/reactive-element": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "requires": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
+      }
+    },
     "@material/animation": {
       "version": "12.0.0-canary.22d29cbb4.0",
       "resolved": "https://registry.npmjs.org/@material/animation/-/animation-12.0.0-canary.22d29cbb4.0.tgz",
@@ -19883,6 +20579,53 @@
         "@material/theme": "12.0.0-canary.22d29cbb4.0",
         "@material/typography": "12.0.0-canary.22d29cbb4.0",
         "tslib": "^2.1.0"
+      }
+    },
+    "@material/focus-ring": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/focus-ring/-/focus-ring-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-exPX5VrjQimipBwgcFDGRiEE783sOBgpkFui59A6i6iGvS2UrLHlYY2E65fyyyQnD1f/rv4Po1OOnCesE1kulg==",
+      "requires": {
+        "@material/dom": "14.0.0-canary.53b3cad2f.0",
+        "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+        "@material/rtl": "14.0.0-canary.53b3cad2f.0"
+      },
+      "dependencies": {
+        "@material/dom": {
+          "version": "14.0.0-canary.53b3cad2f.0",
+          "resolved": "https://registry.npmjs.org/@material/dom/-/dom-14.0.0-canary.53b3cad2f.0.tgz",
+          "integrity": "sha512-aR+rfncF6oi2ivdOlKSJI4UXwNzWV5rXM88MLDoSJF1D7lXxhAKhge+tMUBodWGV/q0+FnXLuVAa0WYTrKjo+A==",
+          "requires": {
+            "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/feature-targeting": {
+          "version": "14.0.0-canary.53b3cad2f.0",
+          "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-14.0.0-canary.53b3cad2f.0.tgz",
+          "integrity": "sha512-fn7Af3PRyARtNeYqtjxXmE3Y/dCpnpQVWWys57MqiGR/nvc6qpgOfJ6rOdcu/MrOysOE/oebTUDmDnTmwpe9Hw==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/rtl": {
+          "version": "14.0.0-canary.53b3cad2f.0",
+          "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-14.0.0-canary.53b3cad2f.0.tgz",
+          "integrity": "sha512-f08LT0HSa0WYU+4Jz/tbm1TQ9Fcf2k+H6dPPYv0J1sZmX6hMgCEmNiUdUFLQFvszoXx2XrRi1/hIFjbz2e69Yg==",
+          "requires": {
+            "@material/theme": "14.0.0-canary.53b3cad2f.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/theme": {
+          "version": "14.0.0-canary.53b3cad2f.0",
+          "resolved": "https://registry.npmjs.org/@material/theme/-/theme-14.0.0-canary.53b3cad2f.0.tgz",
+          "integrity": "sha512-S06XAevDCDWMe+GgsEpITMS07imUidzadNaTbJsqssFajBLr53QWVZsG84BpjXKXoYvyEJvb0hX5U0lq6ip9UQ==",
+          "requires": {
+            "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+            "tslib": "^2.1.0"
+          }
+        }
       }
     },
     "@material/form-field": {
@@ -20585,6 +21328,71 @@
         "tslib": "^2.1.0"
       }
     },
+    "@material/tokens": {
+      "version": "14.0.0-canary.53b3cad2f.0",
+      "resolved": "https://registry.npmjs.org/@material/tokens/-/tokens-14.0.0-canary.53b3cad2f.0.tgz",
+      "integrity": "sha512-myHFB7vac8zErA3qgkqmV+kpE+i9JEwc/6Yf0MOumDSpylJGw28QikpNC6eAVBK2EmPQTaFn20mqUxyud8dGqw==",
+      "requires": {
+        "@material/elevation": "14.0.0-canary.53b3cad2f.0"
+      },
+      "dependencies": {
+        "@material/animation": {
+          "version": "14.0.0-canary.53b3cad2f.0",
+          "resolved": "https://registry.npmjs.org/@material/animation/-/animation-14.0.0-canary.53b3cad2f.0.tgz",
+          "integrity": "sha512-GBuR4VmcTQW1D0lPXEosf5Giho72LLbyGIydWGtaEUtLJoive/D9kFkwTN4Fsyt9Kkl7hbhs35vrNe6QkAH4/Q==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/base": {
+          "version": "14.0.0-canary.53b3cad2f.0",
+          "resolved": "https://registry.npmjs.org/@material/base/-/base-14.0.0-canary.53b3cad2f.0.tgz",
+          "integrity": "sha512-UJKbXwZtkrA3sfQDmj8Zbw1Q3Tqtl6KdfVFws95Yf7TCUgTFzbZI/FSx1w7dVugQPOEnIBuZnzqZam/MtHkx4w==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/elevation": {
+          "version": "14.0.0-canary.53b3cad2f.0",
+          "resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-14.0.0-canary.53b3cad2f.0.tgz",
+          "integrity": "sha512-3h+EkR588RMZ5TSNQ4UeXD1FOBnL3ABQix0DQIGwtNJCqSMoPndT/oJEFvwQbTkZNDbFIKN9p1Q7/KuFPVY8Pw==",
+          "requires": {
+            "@material/animation": "14.0.0-canary.53b3cad2f.0",
+            "@material/base": "14.0.0-canary.53b3cad2f.0",
+            "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+            "@material/rtl": "14.0.0-canary.53b3cad2f.0",
+            "@material/theme": "14.0.0-canary.53b3cad2f.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/feature-targeting": {
+          "version": "14.0.0-canary.53b3cad2f.0",
+          "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-14.0.0-canary.53b3cad2f.0.tgz",
+          "integrity": "sha512-fn7Af3PRyARtNeYqtjxXmE3Y/dCpnpQVWWys57MqiGR/nvc6qpgOfJ6rOdcu/MrOysOE/oebTUDmDnTmwpe9Hw==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/rtl": {
+          "version": "14.0.0-canary.53b3cad2f.0",
+          "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-14.0.0-canary.53b3cad2f.0.tgz",
+          "integrity": "sha512-f08LT0HSa0WYU+4Jz/tbm1TQ9Fcf2k+H6dPPYv0J1sZmX6hMgCEmNiUdUFLQFvszoXx2XrRi1/hIFjbz2e69Yg==",
+          "requires": {
+            "@material/theme": "14.0.0-canary.53b3cad2f.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/theme": {
+          "version": "14.0.0-canary.53b3cad2f.0",
+          "resolved": "https://registry.npmjs.org/@material/theme/-/theme-14.0.0-canary.53b3cad2f.0.tgz",
+          "integrity": "sha512-S06XAevDCDWMe+GgsEpITMS07imUidzadNaTbJsqssFajBLr53QWVZsG84BpjXKXoYvyEJvb0hX5U0lq6ip9UQ==",
+          "requires": {
+            "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+            "tslib": "^2.1.0"
+          }
+        }
+      }
+    },
     "@material/top-app-bar": {
       "version": "12.0.0-canary.22d29cbb4.0",
       "resolved": "https://registry.npmjs.org/@material/top-app-bar/-/top-app-bar-12.0.0-canary.22d29cbb4.0.tgz",
@@ -21030,6 +21838,524 @@
         "@open-wc/scoped-elements": "^1.2.4",
         "lit-element": "^2.2.1",
         "lit-html": "^1.0.0"
+      }
+    },
+    "@openscd/open-scd-core": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@openscd/open-scd-core/-/open-scd-core-0.0.2.tgz",
+      "integrity": "sha512-GIXLFo5c4YvhTwZRhofB9rR9gftfCEHM7iEraQj+tqoMw7NChvbQUfpo6kPvNXnB7RElreRNdPQG2TaHqA6xAQ==",
+      "requires": {
+        "@lit/localize": "^0.11.4",
+        "@material/mwc-button": "^0.27.0",
+        "@material/mwc-dialog": "^0.27.0",
+        "@material/mwc-drawer": "^0.27.0",
+        "@material/mwc-icon": "^0.27.0",
+        "@material/mwc-icon-button": "^0.27.0",
+        "@material/mwc-list": "^0.27.0",
+        "@material/mwc-tab-bar": "^0.27.0",
+        "@material/mwc-top-app-bar-fixed": "^0.27.0",
+        "lit": "^2.2.7"
+      },
+      "dependencies": {
+        "@material/animation": {
+          "version": "14.0.0-canary.53b3cad2f.0",
+          "resolved": "https://registry.npmjs.org/@material/animation/-/animation-14.0.0-canary.53b3cad2f.0.tgz",
+          "integrity": "sha512-GBuR4VmcTQW1D0lPXEosf5Giho72LLbyGIydWGtaEUtLJoive/D9kFkwTN4Fsyt9Kkl7hbhs35vrNe6QkAH4/Q==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/base": {
+          "version": "14.0.0-canary.53b3cad2f.0",
+          "resolved": "https://registry.npmjs.org/@material/base/-/base-14.0.0-canary.53b3cad2f.0.tgz",
+          "integrity": "sha512-UJKbXwZtkrA3sfQDmj8Zbw1Q3Tqtl6KdfVFws95Yf7TCUgTFzbZI/FSx1w7dVugQPOEnIBuZnzqZam/MtHkx4w==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/button": {
+          "version": "14.0.0-canary.53b3cad2f.0",
+          "resolved": "https://registry.npmjs.org/@material/button/-/button-14.0.0-canary.53b3cad2f.0.tgz",
+          "integrity": "sha512-IPBAByKpQjrWNVmAWx5VCTCLnOw4ymbLsbHmBkLiDgcLPs1EtwYnKKIwQ+/t3bV02OShUdMiyboL8V/C0gMS1A==",
+          "requires": {
+            "@material/density": "14.0.0-canary.53b3cad2f.0",
+            "@material/dom": "14.0.0-canary.53b3cad2f.0",
+            "@material/elevation": "14.0.0-canary.53b3cad2f.0",
+            "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+            "@material/focus-ring": "14.0.0-canary.53b3cad2f.0",
+            "@material/ripple": "14.0.0-canary.53b3cad2f.0",
+            "@material/rtl": "14.0.0-canary.53b3cad2f.0",
+            "@material/shape": "14.0.0-canary.53b3cad2f.0",
+            "@material/theme": "14.0.0-canary.53b3cad2f.0",
+            "@material/tokens": "14.0.0-canary.53b3cad2f.0",
+            "@material/touch-target": "14.0.0-canary.53b3cad2f.0",
+            "@material/typography": "14.0.0-canary.53b3cad2f.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/density": {
+          "version": "14.0.0-canary.53b3cad2f.0",
+          "resolved": "https://registry.npmjs.org/@material/density/-/density-14.0.0-canary.53b3cad2f.0.tgz",
+          "integrity": "sha512-Eh/vZ3vVyqtpylg5Ci33qlgtToS4H1/ppd450Ib3tcdISIoodgijYY0w4XsRvrnZgbI/h/1STFdLxdzS0UNuFw==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/dialog": {
+          "version": "14.0.0-canary.53b3cad2f.0",
+          "resolved": "https://registry.npmjs.org/@material/dialog/-/dialog-14.0.0-canary.53b3cad2f.0.tgz",
+          "integrity": "sha512-yiG2nlVKTW0Ro3CF8Z/MVpTwSyG/8Kio3AaTUbeQdbjt5r692s4x5Yhd8m1IjEQKUeulY4CndvIbCUwZ8/G2PA==",
+          "requires": {
+            "@material/animation": "14.0.0-canary.53b3cad2f.0",
+            "@material/base": "14.0.0-canary.53b3cad2f.0",
+            "@material/button": "14.0.0-canary.53b3cad2f.0",
+            "@material/dom": "14.0.0-canary.53b3cad2f.0",
+            "@material/elevation": "14.0.0-canary.53b3cad2f.0",
+            "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+            "@material/icon-button": "14.0.0-canary.53b3cad2f.0",
+            "@material/ripple": "14.0.0-canary.53b3cad2f.0",
+            "@material/rtl": "14.0.0-canary.53b3cad2f.0",
+            "@material/shape": "14.0.0-canary.53b3cad2f.0",
+            "@material/theme": "14.0.0-canary.53b3cad2f.0",
+            "@material/tokens": "14.0.0-canary.53b3cad2f.0",
+            "@material/touch-target": "14.0.0-canary.53b3cad2f.0",
+            "@material/typography": "14.0.0-canary.53b3cad2f.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/dom": {
+          "version": "14.0.0-canary.53b3cad2f.0",
+          "resolved": "https://registry.npmjs.org/@material/dom/-/dom-14.0.0-canary.53b3cad2f.0.tgz",
+          "integrity": "sha512-aR+rfncF6oi2ivdOlKSJI4UXwNzWV5rXM88MLDoSJF1D7lXxhAKhge+tMUBodWGV/q0+FnXLuVAa0WYTrKjo+A==",
+          "requires": {
+            "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/drawer": {
+          "version": "14.0.0-canary.53b3cad2f.0",
+          "resolved": "https://registry.npmjs.org/@material/drawer/-/drawer-14.0.0-canary.53b3cad2f.0.tgz",
+          "integrity": "sha512-MXzRGq7NoONgbHa+AhAu4HvOUA9V37nSsY4g4Alita08UqRAvvFFr4K1CF9GI2K9pLCpyQv1UbN0Lw5b78HrVQ==",
+          "requires": {
+            "@material/animation": "14.0.0-canary.53b3cad2f.0",
+            "@material/base": "14.0.0-canary.53b3cad2f.0",
+            "@material/dom": "14.0.0-canary.53b3cad2f.0",
+            "@material/elevation": "14.0.0-canary.53b3cad2f.0",
+            "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+            "@material/list": "14.0.0-canary.53b3cad2f.0",
+            "@material/ripple": "14.0.0-canary.53b3cad2f.0",
+            "@material/rtl": "14.0.0-canary.53b3cad2f.0",
+            "@material/shape": "14.0.0-canary.53b3cad2f.0",
+            "@material/theme": "14.0.0-canary.53b3cad2f.0",
+            "@material/typography": "14.0.0-canary.53b3cad2f.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/elevation": {
+          "version": "14.0.0-canary.53b3cad2f.0",
+          "resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-14.0.0-canary.53b3cad2f.0.tgz",
+          "integrity": "sha512-3h+EkR588RMZ5TSNQ4UeXD1FOBnL3ABQix0DQIGwtNJCqSMoPndT/oJEFvwQbTkZNDbFIKN9p1Q7/KuFPVY8Pw==",
+          "requires": {
+            "@material/animation": "14.0.0-canary.53b3cad2f.0",
+            "@material/base": "14.0.0-canary.53b3cad2f.0",
+            "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+            "@material/rtl": "14.0.0-canary.53b3cad2f.0",
+            "@material/theme": "14.0.0-canary.53b3cad2f.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/feature-targeting": {
+          "version": "14.0.0-canary.53b3cad2f.0",
+          "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-14.0.0-canary.53b3cad2f.0.tgz",
+          "integrity": "sha512-fn7Af3PRyARtNeYqtjxXmE3Y/dCpnpQVWWys57MqiGR/nvc6qpgOfJ6rOdcu/MrOysOE/oebTUDmDnTmwpe9Hw==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/icon-button": {
+          "version": "14.0.0-canary.53b3cad2f.0",
+          "resolved": "https://registry.npmjs.org/@material/icon-button/-/icon-button-14.0.0-canary.53b3cad2f.0.tgz",
+          "integrity": "sha512-BFdj3CP0JXHC/F2bDmpmzWhum4fkzIDgCCavvnpE/KcCbr0AaoSULRde+LtqvbdLIYW20cXhvjinIOlRhSOshA==",
+          "requires": {
+            "@material/base": "14.0.0-canary.53b3cad2f.0",
+            "@material/density": "14.0.0-canary.53b3cad2f.0",
+            "@material/dom": "14.0.0-canary.53b3cad2f.0",
+            "@material/elevation": "14.0.0-canary.53b3cad2f.0",
+            "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+            "@material/focus-ring": "14.0.0-canary.53b3cad2f.0",
+            "@material/ripple": "14.0.0-canary.53b3cad2f.0",
+            "@material/rtl": "14.0.0-canary.53b3cad2f.0",
+            "@material/theme": "14.0.0-canary.53b3cad2f.0",
+            "@material/touch-target": "14.0.0-canary.53b3cad2f.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/list": {
+          "version": "14.0.0-canary.53b3cad2f.0",
+          "resolved": "https://registry.npmjs.org/@material/list/-/list-14.0.0-canary.53b3cad2f.0.tgz",
+          "integrity": "sha512-mkMpltSKAYLBtFnTTCk/mQIDzwxF/VLh1gh59ehOtmRXt7FvTz83RoAa4tqe53hpVrbX4HoLDBu+vILhq/wkjw==",
+          "requires": {
+            "@material/base": "14.0.0-canary.53b3cad2f.0",
+            "@material/density": "14.0.0-canary.53b3cad2f.0",
+            "@material/dom": "14.0.0-canary.53b3cad2f.0",
+            "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+            "@material/ripple": "14.0.0-canary.53b3cad2f.0",
+            "@material/rtl": "14.0.0-canary.53b3cad2f.0",
+            "@material/shape": "14.0.0-canary.53b3cad2f.0",
+            "@material/theme": "14.0.0-canary.53b3cad2f.0",
+            "@material/typography": "14.0.0-canary.53b3cad2f.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/mwc-base": {
+          "version": "0.27.0",
+          "resolved": "https://registry.npmjs.org/@material/mwc-base/-/mwc-base-0.27.0.tgz",
+          "integrity": "sha512-oCWWtjbyQ52AaUbzINLGBKScIPyqhps2Y7c8t6Gu6fcFeDxhKXMV1Cqvtj/OMhtAt53XjHfD2XruWwYv3cYYUA==",
+          "requires": {
+            "@material/base": "=14.0.0-canary.53b3cad2f.0",
+            "@material/dom": "=14.0.0-canary.53b3cad2f.0",
+            "lit": "^2.0.0",
+            "tslib": "^2.0.1"
+          }
+        },
+        "@material/mwc-button": {
+          "version": "0.27.0",
+          "resolved": "https://registry.npmjs.org/@material/mwc-button/-/mwc-button-0.27.0.tgz",
+          "integrity": "sha512-t5m2zfE93RNKHMjdsU67X6csFzuSG08VJKKvXVQ+BriGE3xBgzY5nZdmZXomFpaWjDENPAlyS4ppCFm6o+DILw==",
+          "requires": {
+            "@material/mwc-icon": "^0.27.0",
+            "@material/mwc-ripple": "^0.27.0",
+            "lit": "^2.0.0",
+            "tslib": "^2.0.1"
+          }
+        },
+        "@material/mwc-checkbox": {
+          "version": "0.27.0",
+          "resolved": "https://registry.npmjs.org/@material/mwc-checkbox/-/mwc-checkbox-0.27.0.tgz",
+          "integrity": "sha512-EY0iYZLwo8qaqMwR5da4fdn0xI0BZNAvKTcwoubYWpDDHlGxDcqwvjp/40ChGo3Q/zv8/4/A0Qp7cwapI82EkA==",
+          "requires": {
+            "@material/mwc-base": "^0.27.0",
+            "@material/mwc-ripple": "^0.27.0",
+            "lit": "^2.0.0",
+            "tslib": "^2.0.1"
+          }
+        },
+        "@material/mwc-dialog": {
+          "version": "0.27.0",
+          "resolved": "https://registry.npmjs.org/@material/mwc-dialog/-/mwc-dialog-0.27.0.tgz",
+          "integrity": "sha512-rkOEmCroVs0wBQbj87vH79SvSHHZ61QRCTUYsU2rHGZCvdzlmvHjWdoyKjJER6WwwM3rrT8xthfecmjICI28CA==",
+          "requires": {
+            "@material/dialog": "=14.0.0-canary.53b3cad2f.0",
+            "@material/dom": "=14.0.0-canary.53b3cad2f.0",
+            "@material/mwc-base": "^0.27.0",
+            "@material/mwc-button": "^0.27.0",
+            "blocking-elements": "^0.1.0",
+            "lit": "^2.0.0",
+            "tslib": "^2.0.1",
+            "wicg-inert": "^3.0.0"
+          }
+        },
+        "@material/mwc-drawer": {
+          "version": "0.27.0",
+          "resolved": "https://registry.npmjs.org/@material/mwc-drawer/-/mwc-drawer-0.27.0.tgz",
+          "integrity": "sha512-dy/uwt+aI5aiUDqFcT6Z4GhGmLZR7fu3HMkfqtQDwoJShxnf5hHwk18fiD1VHHCDf9CZ5wjl7ug4fjpcs9r18A==",
+          "requires": {
+            "@material/drawer": "=14.0.0-canary.53b3cad2f.0",
+            "@material/mwc-base": "^0.27.0",
+            "blocking-elements": "^0.1.0",
+            "lit": "^2.0.0",
+            "tslib": "^2.0.1",
+            "wicg-inert": "^3.0.0"
+          }
+        },
+        "@material/mwc-icon": {
+          "version": "0.27.0",
+          "resolved": "https://registry.npmjs.org/@material/mwc-icon/-/mwc-icon-0.27.0.tgz",
+          "integrity": "sha512-Sul44I37M9Ewynn0A9DjkEBrmll2VtNbth6Pxj7I1A/EAwEfaCrPvryyGqfIu1T2hTsRcaojzQx6QjF+B5QW9A==",
+          "requires": {
+            "lit": "^2.0.0",
+            "tslib": "^2.0.1"
+          }
+        },
+        "@material/mwc-icon-button": {
+          "version": "0.27.0",
+          "resolved": "https://registry.npmjs.org/@material/mwc-icon-button/-/mwc-icon-button-0.27.0.tgz",
+          "integrity": "sha512-wReiPa1UkLaCSPtpkAs1OGKEBtvqPnz9kzuY+RvN5ZQnpo3Uh7n3plHV4y/stsUBfrWtBCcOgYnCdNRaR/r2nQ==",
+          "requires": {
+            "@material/mwc-ripple": "^0.27.0",
+            "lit": "^2.0.0",
+            "tslib": "^2.0.1"
+          }
+        },
+        "@material/mwc-list": {
+          "version": "0.27.0",
+          "resolved": "https://registry.npmjs.org/@material/mwc-list/-/mwc-list-0.27.0.tgz",
+          "integrity": "sha512-oAhNQsBuAOgF3ENOIY8PeWjXsl35HoYaUkl0ixBQk8jJP2HIEf+MdbS5688y/UXxFbSjr0m//LfwR5gauEashg==",
+          "requires": {
+            "@material/base": "=14.0.0-canary.53b3cad2f.0",
+            "@material/dom": "=14.0.0-canary.53b3cad2f.0",
+            "@material/list": "=14.0.0-canary.53b3cad2f.0",
+            "@material/mwc-base": "^0.27.0",
+            "@material/mwc-checkbox": "^0.27.0",
+            "@material/mwc-radio": "^0.27.0",
+            "@material/mwc-ripple": "^0.27.0",
+            "lit": "^2.0.0",
+            "tslib": "^2.0.1"
+          }
+        },
+        "@material/mwc-radio": {
+          "version": "0.27.0",
+          "resolved": "https://registry.npmjs.org/@material/mwc-radio/-/mwc-radio-0.27.0.tgz",
+          "integrity": "sha512-+rSO9a373BgyMgQOM0Z8vVkuieobBylPJ8qpltytM+yGPj8+n+MtwRZyg+ry3WwEjYYDMP6GxZPHwLgWs6lMpQ==",
+          "requires": {
+            "@material/mwc-base": "^0.27.0",
+            "@material/mwc-ripple": "^0.27.0",
+            "@material/radio": "=14.0.0-canary.53b3cad2f.0",
+            "lit": "^2.0.0",
+            "tslib": "^2.0.1"
+          }
+        },
+        "@material/mwc-ripple": {
+          "version": "0.27.0",
+          "resolved": "https://registry.npmjs.org/@material/mwc-ripple/-/mwc-ripple-0.27.0.tgz",
+          "integrity": "sha512-by0O8d8g3Rd96/sUB8hxy6MrDx1QTstqOsA64vqypWd526hMTBGRik08jTNap5sVIyrN9Vq17jb4NJLWQLnNHQ==",
+          "requires": {
+            "@material/dom": "=14.0.0-canary.53b3cad2f.0",
+            "@material/mwc-base": "^0.27.0",
+            "@material/ripple": "=14.0.0-canary.53b3cad2f.0",
+            "lit": "^2.0.0",
+            "tslib": "^2.0.1"
+          }
+        },
+        "@material/mwc-tab": {
+          "version": "0.27.0",
+          "resolved": "https://registry.npmjs.org/@material/mwc-tab/-/mwc-tab-0.27.0.tgz",
+          "integrity": "sha512-BhX6hZYjPL+d3Gcl6rVHNPiEAudgMHA+7mHo2keqbIiFRLKa2CU+omHZO/82+EBan/TPL6ZK39Oki8aIaAJcRQ==",
+          "requires": {
+            "@material/mwc-base": "^0.27.0",
+            "@material/mwc-ripple": "^0.27.0",
+            "@material/mwc-tab-indicator": "^0.27.0",
+            "@material/tab": "=14.0.0-canary.53b3cad2f.0",
+            "lit": "^2.0.0",
+            "tslib": "^2.0.1"
+          }
+        },
+        "@material/mwc-tab-bar": {
+          "version": "0.27.0",
+          "resolved": "https://registry.npmjs.org/@material/mwc-tab-bar/-/mwc-tab-bar-0.27.0.tgz",
+          "integrity": "sha512-CqRZ38m8kOfSJo87Ek61eubO8AGR10Dp12c3pCyyy6mtK/0FSY+rfcmnMPxEzkxREqUnQPgw9lhqmGZXBSqzZQ==",
+          "requires": {
+            "@material/mwc-base": "^0.27.0",
+            "@material/mwc-tab": "^0.27.0",
+            "@material/mwc-tab-scroller": "^0.27.0",
+            "@material/tab": "=14.0.0-canary.53b3cad2f.0",
+            "@material/tab-bar": "=14.0.0-canary.53b3cad2f.0",
+            "lit": "^2.0.0",
+            "tslib": "^2.0.1"
+          }
+        },
+        "@material/mwc-tab-indicator": {
+          "version": "0.27.0",
+          "resolved": "https://registry.npmjs.org/@material/mwc-tab-indicator/-/mwc-tab-indicator-0.27.0.tgz",
+          "integrity": "sha512-bdE5mYP2ze/8d8cGTTJUS0+ByzEK5tmWsXfphFr/Dyy9b+gOnIOt1iX8tmKTOpbYKsV43LxtSkumhTTPDXEJLg==",
+          "requires": {
+            "@material/mwc-base": "^0.27.0",
+            "@material/tab-indicator": "=14.0.0-canary.53b3cad2f.0",
+            "lit": "^2.0.0",
+            "tslib": "^2.0.1"
+          }
+        },
+        "@material/mwc-tab-scroller": {
+          "version": "0.27.0",
+          "resolved": "https://registry.npmjs.org/@material/mwc-tab-scroller/-/mwc-tab-scroller-0.27.0.tgz",
+          "integrity": "sha512-WL/CYVx1cHjC1a/STIB/BaBfxGz3Rz4szNNX35FkYzm6GSGxUNkXZfKOAK7R8RdZOAETa8Gy5tTEhKZKKJ/aUA==",
+          "requires": {
+            "@material/dom": "=14.0.0-canary.53b3cad2f.0",
+            "@material/mwc-base": "^0.27.0",
+            "@material/tab-scroller": "=14.0.0-canary.53b3cad2f.0",
+            "lit": "^2.0.0",
+            "tslib": "^2.0.1"
+          }
+        },
+        "@material/mwc-top-app-bar": {
+          "version": "0.27.0",
+          "resolved": "https://registry.npmjs.org/@material/mwc-top-app-bar/-/mwc-top-app-bar-0.27.0.tgz",
+          "integrity": "sha512-vHn10exeDhUVFpo4TgBsS8pta4AxZtjuuxrYFHMYxceGifEATvGbYoPyw1x7cCMcXMMIITElgfCURAbCmn3BgA==",
+          "requires": {
+            "@material/mwc-base": "^0.27.0",
+            "@material/top-app-bar": "=14.0.0-canary.53b3cad2f.0",
+            "lit": "^2.0.0",
+            "tslib": "^2.0.1"
+          }
+        },
+        "@material/mwc-top-app-bar-fixed": {
+          "version": "0.27.0",
+          "resolved": "https://registry.npmjs.org/@material/mwc-top-app-bar-fixed/-/mwc-top-app-bar-fixed-0.27.0.tgz",
+          "integrity": "sha512-kU1RKmx8U7YCbsBuAXfNLtu+V/Jwos+o2mSY94tZpv36dIsvcsGQ4pB2zW0EaU8g9bQVdwLMVxj4oooxSmbZXw==",
+          "requires": {
+            "@material/mwc-top-app-bar": "^0.27.0",
+            "@material/top-app-bar": "=14.0.0-canary.53b3cad2f.0",
+            "lit": "^2.0.0",
+            "tslib": "^2.0.1"
+          }
+        },
+        "@material/radio": {
+          "version": "14.0.0-canary.53b3cad2f.0",
+          "resolved": "https://registry.npmjs.org/@material/radio/-/radio-14.0.0-canary.53b3cad2f.0.tgz",
+          "integrity": "sha512-V/AgWEOuHFoh9d4Gq1rqBZnKSGtMLQNh23Bwrv0c1FhPqFvUpwt9jR3SVwhJk5gvQQWGy9p3iiGc9QCJ+0+P8Q==",
+          "requires": {
+            "@material/animation": "14.0.0-canary.53b3cad2f.0",
+            "@material/base": "14.0.0-canary.53b3cad2f.0",
+            "@material/density": "14.0.0-canary.53b3cad2f.0",
+            "@material/dom": "14.0.0-canary.53b3cad2f.0",
+            "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+            "@material/focus-ring": "14.0.0-canary.53b3cad2f.0",
+            "@material/ripple": "14.0.0-canary.53b3cad2f.0",
+            "@material/theme": "14.0.0-canary.53b3cad2f.0",
+            "@material/touch-target": "14.0.0-canary.53b3cad2f.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/ripple": {
+          "version": "14.0.0-canary.53b3cad2f.0",
+          "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-14.0.0-canary.53b3cad2f.0.tgz",
+          "integrity": "sha512-6g2G62vd8DsMuIUSXlRrzb98qkZ4o8ZREknNwNP2zaLQEOkJ//4j9HaqDt98/3LIjUTY9UIVFTQENiMmlwKHYQ==",
+          "requires": {
+            "@material/animation": "14.0.0-canary.53b3cad2f.0",
+            "@material/base": "14.0.0-canary.53b3cad2f.0",
+            "@material/dom": "14.0.0-canary.53b3cad2f.0",
+            "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+            "@material/rtl": "14.0.0-canary.53b3cad2f.0",
+            "@material/theme": "14.0.0-canary.53b3cad2f.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/rtl": {
+          "version": "14.0.0-canary.53b3cad2f.0",
+          "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-14.0.0-canary.53b3cad2f.0.tgz",
+          "integrity": "sha512-f08LT0HSa0WYU+4Jz/tbm1TQ9Fcf2k+H6dPPYv0J1sZmX6hMgCEmNiUdUFLQFvszoXx2XrRi1/hIFjbz2e69Yg==",
+          "requires": {
+            "@material/theme": "14.0.0-canary.53b3cad2f.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/shape": {
+          "version": "14.0.0-canary.53b3cad2f.0",
+          "resolved": "https://registry.npmjs.org/@material/shape/-/shape-14.0.0-canary.53b3cad2f.0.tgz",
+          "integrity": "sha512-RyjInLCNe+nI/ulKea0ZLHphXQDiDqYazS25SRn18g8Hoa5qGNaY5oOBncDXUYn3jm5oI5kFc9oif//kulkbjg==",
+          "requires": {
+            "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+            "@material/rtl": "14.0.0-canary.53b3cad2f.0",
+            "@material/theme": "14.0.0-canary.53b3cad2f.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/tab": {
+          "version": "14.0.0-canary.53b3cad2f.0",
+          "resolved": "https://registry.npmjs.org/@material/tab/-/tab-14.0.0-canary.53b3cad2f.0.tgz",
+          "integrity": "sha512-Vmjugm9TBF906pNE2kORSDcMUYXQXV+uspFdbyoSH3hVOTjX+Bw+ODL9agW+pDsJRqGMLO/BAoZ0YQDCrCNX/A==",
+          "requires": {
+            "@material/base": "14.0.0-canary.53b3cad2f.0",
+            "@material/elevation": "14.0.0-canary.53b3cad2f.0",
+            "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+            "@material/focus-ring": "14.0.0-canary.53b3cad2f.0",
+            "@material/ripple": "14.0.0-canary.53b3cad2f.0",
+            "@material/rtl": "14.0.0-canary.53b3cad2f.0",
+            "@material/tab-indicator": "14.0.0-canary.53b3cad2f.0",
+            "@material/theme": "14.0.0-canary.53b3cad2f.0",
+            "@material/typography": "14.0.0-canary.53b3cad2f.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/tab-bar": {
+          "version": "14.0.0-canary.53b3cad2f.0",
+          "resolved": "https://registry.npmjs.org/@material/tab-bar/-/tab-bar-14.0.0-canary.53b3cad2f.0.tgz",
+          "integrity": "sha512-qLTxl0SWwSpsWBV5o7fMO4HaA3NSCTroM+qkUJYNq7lumMXxax8XP6+GvgbXXfsF1K6VqwSPJHnFt5g1kvtBOA==",
+          "requires": {
+            "@material/animation": "14.0.0-canary.53b3cad2f.0",
+            "@material/base": "14.0.0-canary.53b3cad2f.0",
+            "@material/density": "14.0.0-canary.53b3cad2f.0",
+            "@material/elevation": "14.0.0-canary.53b3cad2f.0",
+            "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+            "@material/tab": "14.0.0-canary.53b3cad2f.0",
+            "@material/tab-indicator": "14.0.0-canary.53b3cad2f.0",
+            "@material/tab-scroller": "14.0.0-canary.53b3cad2f.0",
+            "@material/theme": "14.0.0-canary.53b3cad2f.0",
+            "@material/typography": "14.0.0-canary.53b3cad2f.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/tab-indicator": {
+          "version": "14.0.0-canary.53b3cad2f.0",
+          "resolved": "https://registry.npmjs.org/@material/tab-indicator/-/tab-indicator-14.0.0-canary.53b3cad2f.0.tgz",
+          "integrity": "sha512-CMh5MuQamk10oYs0NpQwJ+JLPcY+WftU1b2NpAxbke+6yaV0XrcEkymSfHDkMB5itDvtpXR4fe2Yw9wO8gvcgg==",
+          "requires": {
+            "@material/animation": "14.0.0-canary.53b3cad2f.0",
+            "@material/base": "14.0.0-canary.53b3cad2f.0",
+            "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+            "@material/theme": "14.0.0-canary.53b3cad2f.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/tab-scroller": {
+          "version": "14.0.0-canary.53b3cad2f.0",
+          "resolved": "https://registry.npmjs.org/@material/tab-scroller/-/tab-scroller-14.0.0-canary.53b3cad2f.0.tgz",
+          "integrity": "sha512-eJJWfNDSdjrRVNHkSecblN26PtM8rTeK2FqcZh3iCYRZ74ywhKmHF+elrM2KRH8ez+u/YcZoQacgS8rX3v6ygw==",
+          "requires": {
+            "@material/animation": "14.0.0-canary.53b3cad2f.0",
+            "@material/base": "14.0.0-canary.53b3cad2f.0",
+            "@material/dom": "14.0.0-canary.53b3cad2f.0",
+            "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+            "@material/tab": "14.0.0-canary.53b3cad2f.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/theme": {
+          "version": "14.0.0-canary.53b3cad2f.0",
+          "resolved": "https://registry.npmjs.org/@material/theme/-/theme-14.0.0-canary.53b3cad2f.0.tgz",
+          "integrity": "sha512-S06XAevDCDWMe+GgsEpITMS07imUidzadNaTbJsqssFajBLr53QWVZsG84BpjXKXoYvyEJvb0hX5U0lq6ip9UQ==",
+          "requires": {
+            "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/top-app-bar": {
+          "version": "14.0.0-canary.53b3cad2f.0",
+          "resolved": "https://registry.npmjs.org/@material/top-app-bar/-/top-app-bar-14.0.0-canary.53b3cad2f.0.tgz",
+          "integrity": "sha512-9vPLLxUbNrWNCPGHoIeIUtyXWQUNh+yQwnkTYVkVAVEb1CsWb2D+/NefytfvyFtXWBFQLybAeG5RH0ZqdcgQBQ==",
+          "requires": {
+            "@material/animation": "14.0.0-canary.53b3cad2f.0",
+            "@material/base": "14.0.0-canary.53b3cad2f.0",
+            "@material/elevation": "14.0.0-canary.53b3cad2f.0",
+            "@material/ripple": "14.0.0-canary.53b3cad2f.0",
+            "@material/rtl": "14.0.0-canary.53b3cad2f.0",
+            "@material/shape": "14.0.0-canary.53b3cad2f.0",
+            "@material/theme": "14.0.0-canary.53b3cad2f.0",
+            "@material/typography": "14.0.0-canary.53b3cad2f.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/touch-target": {
+          "version": "14.0.0-canary.53b3cad2f.0",
+          "resolved": "https://registry.npmjs.org/@material/touch-target/-/touch-target-14.0.0-canary.53b3cad2f.0.tgz",
+          "integrity": "sha512-d83e5vbqoLyL542yOTTp4TLVltddWiqbI/j1w/D9ipE30YKfe2EDN+CNJc32Zufh5IUfK41DsZdrN8fI9cL99A==",
+          "requires": {
+            "@material/base": "14.0.0-canary.53b3cad2f.0",
+            "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+            "@material/rtl": "14.0.0-canary.53b3cad2f.0",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@material/typography": {
+          "version": "14.0.0-canary.53b3cad2f.0",
+          "resolved": "https://registry.npmjs.org/@material/typography/-/typography-14.0.0-canary.53b3cad2f.0.tgz",
+          "integrity": "sha512-9J0k2fq7uyHsRzRqJDJLGmg3YzRpfRPtFDVeUH/xBcYoqpZE7wYw5Mb7s/l8eP626EtR7HhXhSPjvRTLA6NIJg==",
+          "requires": {
+            "@material/feature-targeting": "14.0.0-canary.53b3cad2f.0",
+            "@material/theme": "14.0.0-canary.53b3cad2f.0",
+            "tslib": "^2.1.0"
+          }
+        }
       }
     },
     "@rollup/plugin-babel": {
@@ -21706,8 +23032,7 @@
     "@types/trusted-types": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.3.tgz",
-      "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==",
-      "dev": true
+      "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g=="
     },
     "@types/whatwg-url": {
       "version": "6.4.0",
@@ -27340,6 +28665,36 @@
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
           "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
           "dev": true
+        }
+      }
+    },
+    "lit": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+      "requires": {
+        "@lit/reactive-element": "^1.6.0",
+        "lit-element": "^3.3.0",
+        "lit-html": "^2.8.0"
+      },
+      "dependencies": {
+        "lit-element": {
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+          "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+          "requires": {
+            "@lit-labs/ssr-dom-shim": "^1.1.0",
+            "@lit/reactive-element": "^1.3.0",
+            "lit-html": "^2.8.0"
+          }
+        },
+        "lit-html": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+          "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+          "requires": {
+            "@types/trusted-types": "^2.0.2"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@material/mwc-textarea": "0.22.1",
     "@material/mwc-textfield": "0.22.1",
     "@material/mwc-top-app-bar-fixed": "0.22.1",
+    "@openscd/open-scd-core": "^0.0.2",
     "ace-custom-element": "^1.6.5",
     "lit-element": "2.5.1",
     "lit-html": "1.4.1",

--- a/src/foundation.ts
+++ b/src/foundation.ts
@@ -10,6 +10,8 @@ import { WizardTextField } from './wizard-textfield.js';
 import { WizardSelect } from './wizard-select.js';
 import { WizardCheckbox } from './wizard-checkbox.js';
 
+import { Edit } from '@openscd/open-scd-core';
+
 export type SimpleAction = Update | Create | Replace | Delete | Move;
 export type ComplexAction = {
   actions: SimpleAction[];
@@ -378,6 +380,12 @@ export interface CommitDetail extends LogDetailBase {
   kind: 'action';
   action: EditorAction;
 }
+/** The [[`LogEntry`]] for a committed open-scd-core [[`Edit`]]. */
+export interface EditDetail extends LogDetailBase {
+  kind: 'edit';
+  undo: Edit;
+  redo: Edit;
+}
 /** A [[`LogEntry`]] for notifying the user. */
 export interface InfoDetail extends LogDetailBase {
   kind: InfoEntryKind;
@@ -388,7 +396,7 @@ export interface ResetDetail {
   kind: 'reset';
 }
 
-export type LogDetail = InfoDetail | CommitDetail | ResetDetail;
+export type LogDetail = InfoDetail | CommitDetail | EditDetail | ResetDetail;
 export type LogEvent = CustomEvent<LogDetail>;
 export function newLogEvent(
   detail: LogDetail,
@@ -424,9 +432,10 @@ interface Timestamped {
 }
 
 export type CommitEntry = Timestamped & CommitDetail;
+export type EditEntry = Timestamped & EditDetail;
 export type InfoEntry = Timestamped & InfoDetail;
 
-export type LogEntry = InfoEntry | CommitEntry;
+export type LogEntry = InfoEntry | CommitEntry | EditEntry;
 
 /** Represents some work pending completion, upon which `promise` resolves. */
 export interface PendingStateDetail {


### PR DESCRIPTION
This adds the Edit API from https://github.com/ca-d/open-scd-core to the Editing and Logging mixins, enabling editing through both APIs.

This change is needed in order to be able to handle namespaced updates at all.

> [!WARNING]
> Do not factor out plugins using this version of the Edit API!
> For compatibility reasons with existing open-scd-core plugins, this pull request just adds the Edit API in its current version, which - while working as intended - still handles namespaced attribute updates quite poorly, as I described in https://github.com/openscd/open-scd-core/issues/132 . I therefore strongly suggest adapting the Edit API before considering it stable. That change could either be made in open-scd-core, with the dependency being updated afterwards, or open-scd-core could be deprecated outright and the change made here, in which case all tests for the Edit API would have to move here, as well.