### PR TITLE
infra: mark stale issues automatically

### DIFF
--- a/.github/workflows/stale-issues-cron.yml
+++ b/.github/workflows/stale-issues-cron.yml
@@ -8,4 +8,4 @@ jobs:
   run-stale:
     uses: "./.github/workflows/stale-issues.yml"
     secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TOKEN_FOR_STALE_ISSUES: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale-issues-cron.yml
+++ b/.github/workflows/stale-issues-cron.yml
@@ -8,4 +8,4 @@ jobs:
   run-stale:
     uses: "./.github/workflows/stale-issues.yml"
     secrets:
-      ORG_GITHUB_ACTION_SECRET: ${{ secrets.ORG_GITHUB_ACTION_SECRET }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale-issues-cron.yml
+++ b/.github/workflows/stale-issues-cron.yml
@@ -1,0 +1,11 @@
+name: Mark stale issues (cronjob)
+
+on:
+  schedule:
+    - cron: '0 19 * * *'
+
+jobs:
+  run-stale:
+    uses: "./.github/workflows/stale-issues.yml"
+    secrets:
+      ORG_GITHUB_ACTION_SECRET: ${{ secrets.ORG_GITHUB_ACTION_SECRET }}

--- a/.github/workflows/stale-issues-manual.yml
+++ b/.github/workflows/stale-issues-manual.yml
@@ -8,4 +8,4 @@ jobs:
   run-stale:
     uses: "./.github/workflows/stale-issues.yml"
     secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TOKEN_FOR_STALE_ISSUES: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale-issues-manual.yml
+++ b/.github/workflows/stale-issues-manual.yml
@@ -8,4 +8,4 @@ jobs:
   run-stale:
     uses: "./.github/workflows/stale-issues.yml"
     secrets:
-      ORG_GITHUB_ACTION_SECRET: ${{ secrets.ORG_GITHUB_ACTION_SECRET }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale-issues-manual.yml
+++ b/.github/workflows/stale-issues-manual.yml
@@ -1,0 +1,11 @@
+
+name: Mark stale issues (manual)
+
+on:
+  workflow_dispatch
+
+jobs:
+  run-stale:
+    uses: "./.github/workflows/stale-issues.yml"
+    secrets:
+      ORG_GITHUB_ACTION_SECRET: ${{ secrets.ORG_GITHUB_ACTION_SECRET }}

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -5,9 +5,10 @@
 name: Mark stale issues
 
 on:
-  workflow_dispatch
-#  schedule:
-#  - cron: '* * * * *'
+  workflow_call:
+    secrets:
+      ORG_GITHUB_ACTION_SECRET:
+        required: true
 
 jobs:
   stale:
@@ -22,6 +23,18 @@ jobs:
         debug-only: true # temporary
         repo-token: ${{ secrets.ORG_GITHUB_ACTION_SECRET }}
         days-before-stale: 60
-        stale-issue-message: '' # 'Stale issue message'
         stale-issue-label: 'stale'
-        days-before-close: -1
+        days-before-close: -1 # `-1` disables closing
+        stale-issue-message: |
+          Hello there,
+
+          Thank you for opening this issue! We appreciate your interest in our project.
+          However, it seems that this issue hasn't had any activity for a while. To ensure that our issue tracker remains organized and efficient, we occasionally review and address stale issues.
+
+          If you believe this issue is still relevant and requires attention, please provide any additional context, updates, or details that might help us understand the problem better.
+          Feel free to continue the conversation here.
+
+          If the issue is no longer relevant, you can simply close it. If you're uncertain, you can always reopen it later.
+
+          Remember, our project thrives on community contributions, and your input matters. We're here to collaborate and improve.
+          Thank you for being part of this journey!

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -7,7 +7,7 @@ name: Mark stale issues
 on:
   workflow_call:
     secrets:
-      GITHUB_TOKEN:
+      TOKEN_FOR_STALE_ISSUES:
         required: true
 
 jobs:
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/stale@v5
       with:
         debug-only: true # temporary
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        repo-token: ${{ secrets.TOKEN_FOR_STALE_ISSUES }}
         days-before-stale: 60
         stale-issue-label: 'stale'
         days-before-close: -1 # `-1` disables closing

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -7,7 +7,7 @@ name: Mark stale issues
 on:
   workflow_call:
     secrets:
-      ORG_GITHUB_ACTION_SECRET:
+      GITHUB_TOKEN:
         required: true
 
 jobs:
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/stale@v5
       with:
         debug-only: true # temporary
-        repo-token: ${{ secrets.ORG_GITHUB_ACTION_SECRET }}
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-stale: 60
         stale-issue-label: 'stale'
         days-before-close: -1 # `-1` disables closing

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,27 @@
+# This workflow labels stale issues.
+#
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues
+
+on:
+  workflow_dispatch
+#  schedule:
+#  - cron: '* * * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        debug-only: true # temporary
+        repo-token: ${{ secrets.ORG_GITHUB_ACTION_SECRET }}
+        days-before-stale: 60
+        stale-issue-message: '' # 'Stale issue message'
+        stale-issue-label: 'stale'
+        days-before-close: -1

--- a/docs/decisions/0001-record-architecture-decisions.md
+++ b/docs/decisions/0001-record-architecture-decisions.md
@@ -1,0 +1,28 @@
+# 1. Record architecture decisions
+
+Date: 2023-07
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will follow the decisions recorded in the central organizational 
+repository ([.github](https://github.com/openscd/.github)), 
+and record new repo-specific decisions in this repository.
+
+
+We write ADRs in the `docs/decisions` folder instead of a standard `doc/adr`:
+- `docs` instead of `doc` because `doc` is used for the generated documentation.
+- `decisions` instead of `adrs` because it is more explicit and a followed practice:
+  [↗ Markdown Any Decision Records - Applying MADR to your project ](https://adr.github.io/madr/#applying-madr-to-your-project)
+
+## Consequences
+
+- It will be harder to track which decisions have to be taken into consideration
+- Local decisions will be easier to find


### PR DESCRIPTION
This PR sets up a GitHub action to automatically mark stale issues.
It also add a manual trigger so we can run it manually if we want to test it.

---

please ignore: the `docs/decisions/0001-record-architecture-decisions.md` it shows up because of rebase