### PR TITLE
fix(ci): remove unneeded permission check

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -12,10 +12,7 @@ on:
 
 jobs:
   stale:
-
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
 
     steps:
     - uses: actions/stale@v5


### PR DESCRIPTION
The permissions check does not seem to work in sub-workflows nor is it needed at all.