### PR TITLE
fix(wizards/foundation): Added missing DAI bTypes

### DIFF
--- a/src/wizards/foundation/dai-field-type.ts
+++ b/src/wizards/foundation/dai-field-type.ts
@@ -38,6 +38,11 @@ const daiFieldTypes = [
   'VisString65',
   'VisString129',
   'VisString255',
+  'ObjRef',
+  'Currency',
+  'Octet64',
+  'Octet6',
+  'Octet16',
 ] as const;
 export type DaiFieldTypes = typeof daiFieldTypes[number];
 const emptyIfNull = <T>(item: T | null, value: string): string => {
@@ -65,6 +70,11 @@ export function getCustomField(): Record<DaiFieldTypes, CustomField> {
     VisString65: stringField('VisString65', 65),
     VisString129: stringField('VisString129', 129),
     VisString255: stringField('VisString255', 255),
+    ObjRef: stringField('VisString129', 129),
+    Currency: stringField('Currency', 3),
+    Octet64: stringField('Octet64', 64 * 2),
+    Octet6: stringField('Octet6', 6 * 2),
+    Octet16: stringField('Octet16', 16 * 2),
   };
 
   function booleanField(): CustomField {

--- a/src/wizards/foundation/enums.ts
+++ b/src/wizards/foundation/enums.ts
@@ -49,7 +49,10 @@ export const predefinedBasicTypeEnum = [
   'TrgOps',
   'OptFlds',
   'SvOptFlds',
+  'LogOptFlds',
   'EntryID',
+  'Octet6',
+  'Octet16',
 ];
 
 export const valKindEnum = ['Spec', 'Conf', 'RO', 'Set'];

--- a/test/integration/wizards/__snapshots__/bda-wizarding-editing.test.snap.js
+++ b/test/integration/wizards/__snapshots__/bda-wizarding-editing.test.snap.js
@@ -371,9 +371,36 @@ snapshots["BDA wizarding editing integration defines a editBDaWizard to edit an 
         mwc-list-item=""
         role="option"
         tabindex="-1"
+        value="LogOptFlds"
+      >
+        LogOptFlds
+      </mwc-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        mwc-list-item=""
+        role="option"
+        tabindex="-1"
         value="EntryID"
       >
         EntryID
+      </mwc-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        mwc-list-item=""
+        role="option"
+        tabindex="-1"
+        value="Octet6"
+      >
+        Octet6
+      </mwc-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        mwc-list-item=""
+        role="option"
+        tabindex="-1"
+        value="Octet16"
+      >
+        Octet16
       </mwc-list-item>
     </wizard-select>
     <wizard-select
@@ -972,9 +999,36 @@ snapshots["BDA wizarding editing integration defines a createBDaWizard to create
         mwc-list-item=""
         role="option"
         tabindex="-1"
+        value="LogOptFlds"
+      >
+        LogOptFlds
+      </mwc-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        mwc-list-item=""
+        role="option"
+        tabindex="-1"
         value="EntryID"
       >
         EntryID
+      </mwc-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        mwc-list-item=""
+        role="option"
+        tabindex="-1"
+        value="Octet6"
+      >
+        Octet6
+      </mwc-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        mwc-list-item=""
+        role="option"
+        tabindex="-1"
+        value="Octet16"
+      >
+        Octet16
       </mwc-list-item>
     </wizard-select>
     <wizard-select

--- a/test/integration/wizards/__snapshots__/da-wizarding-editing.test.snap.js
+++ b/test/integration/wizards/__snapshots__/da-wizarding-editing.test.snap.js
@@ -371,9 +371,36 @@ snapshots["DA wizarding editing integration defines a editDaWizard to edit an ex
         mwc-list-item=""
         role="option"
         tabindex="-1"
+        value="LogOptFlds"
+      >
+        LogOptFlds
+      </mwc-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        mwc-list-item=""
+        role="option"
+        tabindex="-1"
         value="EntryID"
       >
         EntryID
+      </mwc-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        mwc-list-item=""
+        role="option"
+        tabindex="-1"
+        value="Octet6"
+      >
+        Octet6
+      </mwc-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        mwc-list-item=""
+        role="option"
+        tabindex="-1"
+        value="Octet16"
+      >
+        Octet16
       </mwc-list-item>
     </wizard-select>
     <wizard-select
@@ -1161,9 +1188,36 @@ snapshots["DA wizarding editing integration defines a createDaWizard to create a
         mwc-list-item=""
         role="option"
         tabindex="-1"
+        value="LogOptFlds"
+      >
+        LogOptFlds
+      </mwc-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        mwc-list-item=""
+        role="option"
+        tabindex="-1"
         value="EntryID"
       >
         EntryID
+      </mwc-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        mwc-list-item=""
+        role="option"
+        tabindex="-1"
+        value="Octet6"
+      >
+        Octet6
+      </mwc-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        mwc-list-item=""
+        role="option"
+        tabindex="-1"
+        value="Octet16"
+      >
+        Octet16
       </mwc-list-item>
     </wizard-select>
     <wizard-select

--- a/test/unit/wizards/__snapshots__/abstractda.test.snap.js
+++ b/test/unit/wizards/__snapshots__/abstractda.test.snap.js
@@ -309,9 +309,33 @@ snapshots["abstractda wizards renderWizard looks like the latest snapshot"] =
         aria-disabled="false"
         mwc-list-item=""
         tabindex="-1"
+        value="LogOptFlds"
+      >
+        LogOptFlds
+      </mwc-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        mwc-list-item=""
+        tabindex="-1"
         value="EntryID"
       >
         EntryID
+      </mwc-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        mwc-list-item=""
+        tabindex="-1"
+        value="Octet6"
+      >
+        Octet6
+      </mwc-list-item>
+      <mwc-list-item
+        aria-disabled="false"
+        mwc-list-item=""
+        tabindex="-1"
+        value="Octet16"
+      >
+        Octet16
       </mwc-list-item>
     </wizard-select>
     <wizard-select


### PR DESCRIPTION
Closes #1297 

* Added missing DAI bTypes from IEC 61850-6 ed. 2.1
* Updated test snapshots to include added bTypes
* Octet assumed to be no zero padding, no space hexadecimal string value

I think the treatment of Octet bTypes needs some consideration. However, this PR does allow for DAI of bType `ObjectReference` to be edited as requested.

I would appreciate a review, and further refinement if required.