### PR TITLE
fix(action): correct source folder

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -29,6 +29,6 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@4.1.5
         with:
           branch: master
-          folder: build
+          folder: packages/open-scd/build
           repository-name: openscd/openscd.github.io
           ssh-key: ${{ secrets.DEPLOY_KEY }}


### PR DESCRIPTION
The deploy action does not use the `working-directory` default parameter so the full path is needed.