### PR TITLE
infra: limit github action to open-scd folder

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "packages/open-scd/**"
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
The action was running with every change. After the PR it will only run if there is a change in the packges/open-scd folder