### PR TITLE
fix(gh-action): build-and-deploy should first build core before building OpenSCD

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -9,10 +9,6 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
-        working-directory: packages/open-scd
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.1
@@ -22,10 +18,22 @@ jobs:
         with:
           node-version: '18.x'
 
-      - name: Install and Build
+      - name: Install and build Core
         run: |
+          cd packages/core
           npm clean-install
           npm run-script build
+          npm run-script doc
+
+      - name: Install and Build OpenSCD
+        run: |
+          cd packages/open-scd
+          npm clean-install
+          npm run-script build
+
+      - name: Copy Core Docs to OpenSCD
+        run: |
+          cp -R packages/core/doc packages/open-scd/build/core-doc
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@4.1.5

--- a/packages/open-scd/README.md
+++ b/packages/open-scd/README.md
@@ -36,7 +36,7 @@ This will start a local development server and open a browser window which will 
 
 ### TypeDoc
 
-This project uses [TypeDoc](https://typedoc.org/) to transform documentation comments in the source code into a rendered HTML document that can be queried and navigated through. If you want to consult the generated documentation for the TypeScript components, mixins, modules and other relevant artifacts of this project, you can [do it here](https://openscd.github.io/doc/).
+This project uses [TypeDoc](https://typedoc.org/) to transform documentation comments in the source code into a rendered HTML document that can be queried and navigated through. If you want to consult the generated documentation for the TypeScript components, mixins, modules and other relevant artifacts of this project, you can [do it here](https://openscd.github.io/doc/). Documentation for OpenSCD Core [can be found here](https://openscd.github.io/core-doc).
 
 ### Linting & Formatting
 


### PR DESCRIPTION
 Building and deploying OpenSCD failed, because the package `@openscd/core` hasn't been built yet.
This step has been added.
Also, the documentation (TypeDoc) from core will be pushed to `packages/open-scd/build/core-doc`, so it will be published as well