### PR TITLE
fix: do and da wizard lnclass textfield correction

### DIFF
--- a/packages/open-scd/src/editors/ied/da-wizard.ts
+++ b/packages/open-scd/src/editors/ied/da-wizard.ts
@@ -145,7 +145,7 @@ function renderFields(
     `,
     html`
       <mwc-textfield
-        label="${translate('iededitor.wizard.lnDescription')}"
+        label="${translate('scl.lnClass')}"
         value="${logicalNodeElement
           ? nsdoc.getDataDescription(logicalNodeElement, ancestors).label
           : '-'}"

--- a/packages/open-scd/src/editors/ied/do-wizard.ts
+++ b/packages/open-scd/src/editors/ied/do-wizard.ts
@@ -91,7 +91,7 @@ function renderFields(
     `,
     html`
       <mwc-textfield
-        label="${translate('iededitor.wizard.lnDescription')}"
+        label="${translate('scl.lnClass')}"
         value="${logicalNodeElement
           ? nsdoc.getDataDescription(logicalNodeElement, ancestors).label
           : '-'}"

--- a/packages/open-scd/test/unit/editors/ied/__snapshots__/da-wizard.test.snap.js
+++ b/packages/open-scd/test/unit/editors/ied/__snapshots__/da-wizard.test.snap.js
@@ -88,7 +88,7 @@ snapshots["with no ancestors looks like the latest snapshot"] =
     <mwc-textfield
       disabled=""
       id="lnPrefix"
-      label="[iededitor.wizard.lnDescription]"
+      label="[scl.lnClass]"
       readonly=""
       value="-"
     >
@@ -225,7 +225,7 @@ snapshots["with a DA element looks like the latest snapshot"] =
     <mwc-textfield
       disabled=""
       id="lnPrefix"
-      label="[iededitor.wizard.lnDescription]"
+      label="[scl.lnClass]"
       readonly=""
       value="XCBR"
     >
@@ -362,7 +362,7 @@ snapshots["with a BDA element looks like the latest snapshot"] =
     <mwc-textfield
       disabled=""
       id="lnPrefix"
-      label="[iededitor.wizard.lnDescription]"
+      label="[scl.lnClass]"
       readonly=""
       value="LPHD"
     >
@@ -499,7 +499,7 @@ snapshots["with a DA element and DAI Element looks like the latest snapshot"] =
     <mwc-textfield
       disabled=""
       id="lnPrefix"
-      label="[iededitor.wizard.lnDescription]"
+      label="[scl.lnClass]"
       readonly=""
       value="XCBR"
     >

--- a/packages/open-scd/test/unit/editors/ied/__snapshots__/do-wizard.test.snap.js
+++ b/packages/open-scd/test/unit/editors/ied/__snapshots__/do-wizard.test.snap.js
@@ -55,7 +55,7 @@ snapshots["with no ancestors looks like the latest snapshot"] =
     <mwc-textfield
       disabled=""
       id="lnPrefix"
-      label="[iededitor.wizard.lnDescription]"
+      label="[scl.lnClass]"
       readonly=""
       value="-"
     >
@@ -159,7 +159,7 @@ snapshots["with a DO element looks like the latest snapshot"] =
     <mwc-textfield
       disabled=""
       id="lnPrefix"
-      label="[iededitor.wizard.lnDescription]"
+      label="[scl.lnClass]"
       readonly=""
       value="Some LN title (LLN0)"
     >
@@ -263,7 +263,7 @@ snapshots["with a DO element and DOI Element looks like the latest snapshot"] =
     <mwc-textfield
       disabled=""
       id="lnPrefix"
-      label="[iededitor.wizard.lnDescription]"
+      label="[scl.lnClass]"
       readonly=""
       value="CSWI"
     >


### PR DESCRIPTION
@DavoodSooran noticed an error in the do-wizard and da-wizard. In these wizards there's a `logical node description` field with the lnclass value. This PR changed the field title from  `Logical node description` to  `Logical node class` 