### PR TITLE
chore: fix failing deployment action

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "clean": "rimraf .tsbuildinfo dist",
     "build": "tsc -b",
-    "doc": "npm run analyze -- --exclude dist && typedoc --out doc foundation.ts",
+    "doc": "typedoc --out doc foundation.ts",
     "prepublish": "npm run lint && npm run build && npm run doc",
     "lint": "eslint --ext .ts,.html . --ignore-path .gitignore && prettier \"**/*.ts\" --check --ignore-path .gitignore",
     "format": "eslint --ext .ts,.html . --fix --ignore-path .gitignore && prettier \"**/*.ts\" --write --ignore-path .gitignore"


### PR DESCRIPTION
When a PR is merged to main, the deployment action gets triggered. This action now fails because the doc script in core references to analyze, which doesn't exist in core anymore. 

In this PR the non existing script reference from doc has been removed.