### PR TITLE
ci: missing updates for build and deploy workflow to work again

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -27,11 +27,11 @@ jobs:
 
       - name: Copy Core Docs to OpenSCD
         run: |
-          cp -R packages/core/doc packages/open-scd/build/core-doc
+          cp -R packages/core/doc packages/distribution/build/core-doc
 
       - name: Copy Plugin Docs to OpenSCD
         run: |
-          cp -R packages/plugins/doc packages/open-scd/build/plugin-doc
+          cp -R packages/plugins/doc packages/distribution/build/plugin-doc
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@4.1.5

--- a/packages/distribution/package.json
+++ b/packages/distribution/package.json
@@ -37,6 +37,7 @@
     "doc:typedoc": "typedoc --plugin none --out doc src",
     "doc:wca": "wca src --outDir doc/components",
     "doc": "npm run doc:clean && npm run doc:typedoc && npm run doc:wca",
+    "build": "snowpack build && workbox generateSW workbox-config.cjs && cp .nojekyll build/",
     "start": "snowpack dev"
   },
   "devDependencies": {


### PR DESCRIPTION
In this PR:

- Recovered build script for distribution package
- Updated build-and-deploy workflow