### PR TITLE
fix: re-enable input fields in custom plugins dialog

### DIFF
--- a/packages/openscd/src/addons/Layout.ts
+++ b/packages/openscd/src/addons/Layout.ts
@@ -544,7 +544,7 @@ export class OscdLayout extends LitElement {
                 padding: 20px;
                 padding-left: 50px;
               }
-              #menu[selected] ~ #menudetails {
+              #pluginKindList [value="menu"][selected] ~ #menudetails {
                 display: grid;
               }
               #enabledefault {


### PR DESCRIPTION
Closes #1540 