### PR TITLE
Remove required for inst attribute

### DIFF
--- a/packages/plugins/src/wizards/ln.ts
+++ b/packages/plugins/src/wizards/ln.ts
@@ -48,7 +48,6 @@ export function renderLNWizard(
     ></wizard-textfield>`,
     html`<wizard-textfield
       label="inst"
-      required
       .maybeValue=${inst}
       helper="${get('ln.wizard.instHelper')}"
     ></wizard-textfield>`,

--- a/packages/plugins/src/wizards/ln0.ts
+++ b/packages/plugins/src/wizards/ln0.ts
@@ -41,7 +41,6 @@ export function renderLN0Wizard(
     ></wizard-textfield>`,
     html`<wizard-textfield
       label="inst"
-      required
       .maybeValue=${inst}
       helper="${get('ln0.wizard.instHelper')}"
     ></wizard-textfield>`,

--- a/packages/plugins/test/unit/wizards/ln.test.ts
+++ b/packages/plugins/test/unit/wizards/ln.test.ts
@@ -24,7 +24,6 @@ describe('ln wizards', () => {
   const requiredFields = [
     'lnType',
     'lnClass',
-    'inst',
   ];
 
   const ln = <Element>(

--- a/packages/plugins/test/unit/wizards/ln0.test.ts
+++ b/packages/plugins/test/unit/wizards/ln0.test.ts
@@ -23,7 +23,6 @@ describe('ln0 wizards', () => {
   const requiredFields = [
     'lnType',
     'lnClass',
-    'inst',
   ];
 
   const ln = <Element>(


### PR DESCRIPTION
The attribute "inst" is formally required, but empty string as a value is allowed. After testing removing the required on the input, empty string will be saved when the user empties the input.