### PR TITLE
bugfix: Create virtual IED does not consider multiple instances of a LNType within a function

### DIFF
--- a/packages/openscd/src/foundation.ts
+++ b/packages/openscd/src/foundation.ts
@@ -338,7 +338,7 @@ function lNodeIdentity(e: Element): string {
     'lnType',
   ].map(name => e.getAttribute(name));
   if (iedName === 'None')
-    return `${identity(e.parentElement)}>(${lnClass} ${lnType})`;
+    return `${identity(e.parentElement)}>(${lnClass} ${lnType} ${lnInst})`;
   return `${iedName} ${ldInst || '(Client)'}/${prefix ?? ''} ${lnClass} ${
     lnInst ?? ''
   }`;
@@ -347,7 +347,7 @@ function lNodeIdentity(e: Element): string {
 function lNodeSelector(tagName: SCLTag, identity: string): string {
   if (identity.endsWith(')')) {
     const [parentIdentity, childIdentity] = pathParts(identity);
-    const [lnClass, lnType] = childIdentity
+    const [lnClass, lnType, lnInst] = childIdentity
       .substring(1, childIdentity.length - 1)
       .split(' ');
 
@@ -360,7 +360,7 @@ function lNodeSelector(tagName: SCLTag, identity: string): string {
     return crossProduct(
       parentSelectors,
       ['>'],
-      [`${tagName}[iedName="None"][lnClass="${lnClass}"][lnType="${lnType}"]`]
+      [`${tagName}[iedName="None"][lnClass="${lnClass}"][lnType="${lnType}"][lnInst="${lnInst}"]`]
     )
       .map(strings => strings.join(''))
       .join(',');

--- a/packages/plugins/src/menu/VirtualTemplateIED.ts
+++ b/packages/plugins/src/menu/VirtualTemplateIED.ts
@@ -58,20 +58,16 @@ function getLDeviceDescriptions(
 			)!;
 			const lnType = lLN0?.split(": ")[1];
 
-			// Map to ensure unique prefixes based on node attributes
 			const anyLNs = [
 				{ prefix: null, lnClass: "LLN0", inst: "", lnType },
 				...selectedLNodes.map((lNode, index) => {
 					const lnClass = lNode.getAttribute("lnClass")!;
 					const inst = lNode.getAttribute("lnInst")!;
 					const lnType = lNode.getAttribute("lnType")!;
-					const existingPrefix = lNode.getAttribute("prefix") || "";
-
-					// Generate unique prefix if not already provided
-					const uniquePrefix = existingPrefix || `${lnClass}-${index + 1}`; // Prefix includes class and unique index
+					const prefix = lNode.getAttribute("prefix") || "";
 
 					return {
-						prefix: uniquePrefix,
+						prefix: prefix || `CSWI-${index}`,
 						lnClass,
 						inst,
 						lnType,

--- a/packages/plugins/src/menu/VirtualTemplateIED.ts
+++ b/packages/plugins/src/menu/VirtualTemplateIED.ts
@@ -60,17 +60,13 @@ function getLDeviceDescriptions(
 
 			const anyLNs = [
 				{ prefix: null, lnClass: "LLN0", inst: "", lnType },
-				...selectedLNodes.map((lNode, index) => {
-					const lnClass = lNode.getAttribute("lnClass")!;
-					const inst = lNode.getAttribute("lnInst")!;
-					const lnType = lNode.getAttribute("lnType")!;
-					const prefix = lNode.getAttribute("prefix") || "";
-
+				...selectedLNodes.map((lNode) => {
+					console.log("here: ", getFunctionNamingPrefix(lNode));
 					return {
-						prefix: prefix || `CSWI-${index}`,
-						lnClass,
-						inst,
-						lnType,
+						prefix: getFunctionNamingPrefix(lNode),
+						lnClass: lNode.getAttribute("lnClass")!,
+						inst: lNode.getAttribute("lnInst")!,
+						lnType: lNode.getAttribute("lnType")!,
 					};
 				}),
 			];

--- a/packages/plugins/src/menu/VirtualTemplateIED.ts
+++ b/packages/plugins/src/menu/VirtualTemplateIED.ts
@@ -43,49 +43,40 @@ export type FunctionElementDescription = {
 function getLDeviceDescriptions(
   functions: Record<string, FunctionElementDescription>,
   selectedLNodes: Element[],
-  selectedLLN0s: string[],
+  selectedLLN0s: string[]
 ): LDeviceDescription[] {
   const lDeviceDescriptions: LDeviceDescription[] = [];
 
-  console.log("LDeviceDescriptions input - selectedLNodes: ", selectedLNodes);
-
-  Object.values(functions).forEach((functionDescription) => {
+  Object.values(functions).forEach(functionDescription => {
     if (
-      functionDescription.lNodes.some((lNode) => selectedLNodes.includes(lNode))
+      functionDescription.lNodes.some(lNode => selectedLNodes.includes(lNode))
     ) {
-      const lLN0 = selectedLLN0s.find((selectedLLN0) =>
-        selectedLLN0.includes(functionDescription.uniqueName),
+      const lLN0 = selectedLLN0s.find(selectedLLN0 =>
+        selectedLLN0.includes(functionDescription.uniqueName)
       )!;
-      const lnType = lLN0?.split(": ")[1];
-
-      const anyLNs = [
-        { prefix: null, lnClass: "LLN0", inst: "", lnType },
-        ...selectedLNodes.map((lNode) => {
-          console.log("here: ", getFunctionNamingPrefix(lNode));
-          return {
-            prefix: getFunctionNamingPrefix(lNode),
-            lnClass: lNode.getAttribute("lnClass")!,
-            inst: lNode.getAttribute("lnInst")!,
-            lnType: lNode.getAttribute("lnType")!,
-          };
-        }),
-      ];
+      const lnType = lLN0?.split(': ')[1];
 
       lDeviceDescriptions.push({
         validLdInst: functionDescription.uniqueName,
-        anyLNs,
+        anyLNs: [
+          { prefix: null, lnClass: 'LLN0', inst: '', lnType },
+          ...functionDescription.lNodes
+            .filter(lNode => selectedLNodes.includes(lNode))
+            .map(lNode => {
+              return {
+                prefix: getFunctionNamingPrefix(lNode),
+                lnClass: lNode.getAttribute('lnClass')!,
+                inst: lNode.getAttribute('lnInst')!,
+                lnType: lNode.getAttribute('lnType')!,
+              };
+            }),
+        ],
       });
     }
   });
 
-  console.log(
-    "AFTER LDeviceDescriptions input - selectedLNodes: ",
-    lDeviceDescriptions,
-  );
-
   return lDeviceDescriptions;
 }
-
 
 /** Groups all incomming LNode's with non-leaf parent function type elements */
 function groupLNodesToFunctions(

--- a/packages/plugins/src/menu/VirtualTemplateIED.ts
+++ b/packages/plugins/src/menu/VirtualTemplateIED.ts
@@ -1,281 +1,279 @@
 import {
-	css,
-	html,
-	LitElement,
-	property,
-	query,
-	queryAll,
-	state,
-	TemplateResult,
-} from "lit-element";
-import { get } from "lit-translate";
+  css,
+  html,
+  LitElement,
+  property,
+  query,
+  queryAll,
+  state,
+  TemplateResult,
+} from 'lit-element';
+import { get } from 'lit-translate';
 
-import "@material/mwc-dialog";
-import "@material/mwc-list";
-import "@material/mwc-list/mwc-list-item";
-import "@material/mwc-list/mwc-check-list-item";
-import "@material/mwc-list/mwc-radio-list-item";
-import { Dialog } from "@material/mwc-dialog";
-import { CheckListItem } from "@material/mwc-list/mwc-check-list-item";
-import { Select } from "@material/mwc-select";
+import '@material/mwc-dialog';
+import '@material/mwc-list';
+import '@material/mwc-list/mwc-list-item';
+import '@material/mwc-list/mwc-check-list-item';
+import '@material/mwc-list/mwc-radio-list-item';
+import { Dialog } from '@material/mwc-dialog';
+import { CheckListItem } from '@material/mwc-list/mwc-check-list-item';
+import { Select } from '@material/mwc-select';
 
-import "@openscd/open-scd/src/filtered-list.js";
-import { find, identity } from "@openscd/open-scd/src/foundation.js";
-import { getChildElementsByTagName } from "@openscd/xml";
+import '@openscd/open-scd/src/filtered-list.js';
+import { find, identity } from '@openscd/open-scd/src/foundation.js';
+import { getChildElementsByTagName } from '@openscd/xml';
 
-import { newActionEvent } from "@openscd/core/foundation/deprecated/editor.js";
-import { WizardTextField } from "@openscd/open-scd/src/wizard-textfield.js";
+import { newActionEvent } from '@openscd/core/foundation/deprecated/editor.js';
+import { WizardTextField } from '@openscd/open-scd/src/wizard-textfield.js';
 import {
-	getFunctionNamingPrefix,
-	getNonLeafParent,
-	getSpecificationIED,
-	getUniqueFunctionName,
-	LDeviceDescription,
-} from "./virtualtemplateied/foundation.js";
+  getFunctionNamingPrefix,
+  getNonLeafParent,
+  getSpecificationIED,
+  getUniqueFunctionName,
+  LDeviceDescription,
+} from './virtualtemplateied/foundation.js';
 
 export type FunctionElementDescription = {
-	uniqueName: string;
-	lNodes: Element[];
-	lln0?: Element;
+  uniqueName: string;
+  lNodes: Element[];
+  lln0?: Element;
 };
 
 /** converts FunctionElementDescription's to LDeviceDescription's */
 function getLDeviceDescriptions(
-	functions: Record<string, FunctionElementDescription>,
-	selectedLNodes: Element[],
-	selectedLLN0s: string[],
+  functions: Record<string, FunctionElementDescription>,
+  selectedLNodes: Element[],
+  selectedLLN0s: string[],
 ): LDeviceDescription[] {
-	const lDeviceDescriptions: LDeviceDescription[] = [];
+  const lDeviceDescriptions: LDeviceDescription[] = [];
 
-	console.log("LDeviceDescriptions input - selectedLNodes: ", selectedLNodes);
+  console.log("LDeviceDescriptions input - selectedLNodes: ", selectedLNodes);
 
-	Object.values(functions).forEach((functionDescription) => {
-		if (
-			functionDescription.lNodes.some((lNode) => selectedLNodes.includes(lNode))
-		) {
-			const lLN0 = selectedLLN0s.find((selectedLLN0) =>
-				selectedLLN0.includes(functionDescription.uniqueName),
-			)!;
-			const lnType = lLN0?.split(": ")[1];
+  Object.values(functions).forEach((functionDescription) => {
+    if (
+      functionDescription.lNodes.some((lNode) => selectedLNodes.includes(lNode))
+    ) {
+      const lLN0 = selectedLLN0s.find((selectedLLN0) =>
+        selectedLLN0.includes(functionDescription.uniqueName),
+      )!;
+      const lnType = lLN0?.split(": ")[1];
 
-			const anyLNs = [
-				{ prefix: null, lnClass: "LLN0", inst: "", lnType },
-				...selectedLNodes.map((lNode) => {
-					console.log("here: ", getFunctionNamingPrefix(lNode));
-					return {
-						prefix: getFunctionNamingPrefix(lNode),
-						lnClass: lNode.getAttribute("lnClass")!,
-						inst: lNode.getAttribute("lnInst")!,
-						lnType: lNode.getAttribute("lnType")!,
-					};
-				}),
-			];
+      const anyLNs = [
+        { prefix: null, lnClass: "LLN0", inst: "", lnType },
+        ...selectedLNodes.map((lNode) => {
+          console.log("here: ", getFunctionNamingPrefix(lNode));
+          return {
+            prefix: getFunctionNamingPrefix(lNode),
+            lnClass: lNode.getAttribute("lnClass")!,
+            inst: lNode.getAttribute("lnInst")!,
+            lnType: lNode.getAttribute("lnType")!,
+          };
+        }),
+      ];
 
-			lDeviceDescriptions.push({
-				validLdInst: functionDescription.uniqueName,
-				anyLNs,
-			});
-		}
-	});
+      lDeviceDescriptions.push({
+        validLdInst: functionDescription.uniqueName,
+        anyLNs,
+      });
+    }
+  });
 
-	console.log(
-		"AFTER LDeviceDescriptions input - selectedLNodes: ",
-		lDeviceDescriptions,
-	);
+  console.log(
+    "AFTER LDeviceDescriptions input - selectedLNodes: ",
+    lDeviceDescriptions,
+  );
 
-	return lDeviceDescriptions;
+  return lDeviceDescriptions;
 }
+
 
 /** Groups all incomming LNode's with non-leaf parent function type elements */
 function groupLNodesToFunctions(
-	lNodes: Element[],
+  lNodes: Element[]
 ): Record<string, FunctionElementDescription> {
-	const functionElements: Record<string, FunctionElementDescription> = {};
+  const functionElements: Record<string, FunctionElementDescription> = {};
 
-	lNodes.forEach((lNode) => {
-		const parentFunction = getNonLeafParent(lNode);
-		if (!parentFunction) return;
+  lNodes.forEach(lNode => {
+    const parentFunction = getNonLeafParent(lNode);
+    if (!parentFunction) return;
 
-		if (functionElements[identity(parentFunction)])
-			functionElements[identity(parentFunction)].lNodes.push(lNode);
-		else {
-			functionElements[identity(parentFunction)] = {
-				uniqueName: getUniqueFunctionName(parentFunction),
-				lNodes: [lNode],
-				lln0: getChildElementsByTagName(parentFunction, "LNode").find(
-					(lNode) => lNode.getAttribute("lnClass") === "LLN0",
-				),
-			};
-		}
-	});
+    if (functionElements[identity(parentFunction)])
+      functionElements[identity(parentFunction)].lNodes.push(lNode);
+    else {
+      functionElements[identity(parentFunction)] = {
+        uniqueName: getUniqueFunctionName(parentFunction),
+        lNodes: [lNode],
+        lln0: getChildElementsByTagName(parentFunction, 'LNode').find(
+          lNode => lNode.getAttribute('lnClass') === 'LLN0'
+        ),
+      };
+    }
+  });
 
-	return functionElements;
+  return functionElements;
 }
 
 export default class VirtualTemplateIED extends LitElement {
-	@property({ attribute: false })
-	doc!: XMLDocument;
-	@property({ type: Number })
-	editCount = -1;
-	@state()
-	get isValidManufacturer(): boolean {
-		const manufacturer = this.dialog?.querySelector<WizardTextField>(
-			'wizard-textfield[label="manufacturer"]',
-		)!.value;
+  @property({ attribute: false })
+  doc!: XMLDocument;
+  @property({ type: Number })
+  editCount = -1;
+  @state()
+  get isValidManufacturer(): boolean {
+    const manufacturer = this.dialog?.querySelector<WizardTextField>(
+      'wizard-textfield[label="manufacturer"]'
+    )!.value;
 
-		return (manufacturer && manufacturer !== "") || false;
-	}
-	@state()
-	get isValidApName(): boolean {
-		const apName = this.dialog?.querySelector<WizardTextField>(
-			'wizard-textfield[label="AccessPoint name"]',
-		)!.value;
+    return (manufacturer && manufacturer !== '') || false;
+  }
+  @state()
+  get isValidApName(): boolean {
+    const apName = this.dialog?.querySelector<WizardTextField>(
+      'wizard-textfield[label="AccessPoint name"]'
+    )!.value;
 
-		return (apName && apName !== "") || false;
-	}
-	@state()
-	get someItemsSelected(): boolean {
-		if (!this.selectedLNodeItems) return false;
-		return !!this.selectedLNodeItems.length;
-	}
-	@state()
-	get validPriparyAction(): boolean {
-		return (
-			this.someItemsSelected && this.isValidManufacturer && this.isValidApName
-		);
-	}
+    return (apName && apName !== '') || false;
+  }
+  @state()
+  get someItemsSelected(): boolean {
+    if (!this.selectedLNodeItems) return false;
+    return !!this.selectedLNodeItems.length;
+  }
+  @state()
+  get validPriparyAction(): boolean {
+    return (
+      this.someItemsSelected && this.isValidManufacturer && this.isValidApName
+    );
+  }
 
-	get unreferencedLNodes(): Element[] {
-		return Array.from(
-			this.doc.querySelectorAll('LNode[iedName="None"]'),
-		).filter((lNode) => lNode.getAttribute("lnClass") !== "LLN0");
-	}
+  get unreferencedLNodes(): Element[] {
+    return Array.from(
+      this.doc.querySelectorAll('LNode[iedName="None"]')
+    ).filter(lNode => lNode.getAttribute('lnClass') !== 'LLN0');
+  }
 
-	get lLN0s(): Element[] {
-		return Array.from(this.doc.querySelectorAll('LNodeType[lnClass="LLN0"]'));
-	}
+  get lLN0s(): Element[] {
+    return Array.from(this.doc.querySelectorAll('LNodeType[lnClass="LLN0"]'));
+  }
 
-	@query("mwc-dialog") dialog!: Dialog;
-	@queryAll("mwc-check-list-item[selected]")
-	selectedLNodeItems?: CheckListItem[];
+  @query('mwc-dialog') dialog!: Dialog;
+  @queryAll('mwc-check-list-item[selected]')
+  selectedLNodeItems?: CheckListItem[];
 
-	async run(): Promise<void> {
-		this.dialog.open = true;
-	}
+  async run(): Promise<void> {
+    this.dialog.open = true;
+  }
 
-	private onPrimaryAction(
-		functions: Record<string, FunctionElementDescription>,
-	): void {
-		const selectedLNode = Array.from(
-			this.dialog.querySelectorAll<CheckListItem>(
-				"mwc-check-list-item[selected]:not([disabled])",
-			) ?? [],
-		).map((selectedItem) => find(this.doc, "LNode", selectedItem.value)!);
-		selectedLNode.forEach((lNode, index) => {
-			lNode.setAttribute("prefix", `CSWI-${index}`);
-		});
-		if (!selectedLNode.length) return;
+  private onPrimaryAction(
+    functions: Record<string, FunctionElementDescription>
+  ): void {
+    const selectedLNode = Array.from(
+      this.dialog.querySelectorAll<CheckListItem>(
+        'mwc-check-list-item[selected]:not([disabled])'
+      ) ?? []
+    ).map(selectedItem => find(this.doc, 'LNode', selectedItem.value)!);
+    if (!selectedLNode.length) return;
 
-		const selectedLLN0s = Array.from(
-			this.dialog.querySelectorAll<Select>("mwc-select") ?? [],
-		).map((selectedItem) => selectedItem.value);
+    const selectedLLN0s = Array.from(
+      this.dialog.querySelectorAll<Select>('mwc-select') ?? []
+    ).map(selectedItem => selectedItem.value);
 
-		const manufacturer = this.dialog.querySelector<WizardTextField>(
-			'wizard-textfield[label="manufacturer"]',
-		)!.value;
-		const desc = this.dialog.querySelector<WizardTextField>(
-			'wizard-textfield[label="desc"]',
-		)!.maybeValue;
-		const apName = this.dialog.querySelector<WizardTextField>(
-			'wizard-textfield[label="AccessPoint name"]',
-		)!.value;
+    const manufacturer = this.dialog.querySelector<WizardTextField>(
+      'wizard-textfield[label="manufacturer"]'
+    )!.value;
+    const desc = this.dialog.querySelector<WizardTextField>(
+      'wizard-textfield[label="desc"]'
+    )!.maybeValue;
+    const apName = this.dialog.querySelector<WizardTextField>(
+      'wizard-textfield[label="AccessPoint name"]'
+    )!.value;
 
-		const ied = getSpecificationIED(this.doc, {
-			manufacturer,
-			desc,
-			apName,
-			lDevices: getLDeviceDescriptions(functions, selectedLNode, selectedLLN0s),
-		});
+    const ied = getSpecificationIED(this.doc, {
+      manufacturer,
+      desc,
+      apName,
+      lDevices: getLDeviceDescriptions(functions, selectedLNode, selectedLLN0s),
+    });
 
-		// checkValidity: () => true disables name check as is the same here: SPECIFICATION
-		this.dispatchEvent(
-			newActionEvent({
-				new: { parent: this.doc.documentElement, element: ied },
-				checkValidity: () => true,
-			}),
-		);
-		this.dialog.close();
-	}
+    // checkValidity: () => true disables name check as is the same here: SPECIFICATION
+    this.dispatchEvent(
+      newActionEvent({
+        new: { parent: this.doc.documentElement, element: ied },
+        checkValidity: () => true,
+      })
+    );
+    this.dialog.close();
+  }
 
-	private onClosed(ae: CustomEvent<{ action: string } | null>): void {
-		if (!(ae.target instanceof Dialog && ae.detail?.action)) return;
-	}
+  private onClosed(ae: CustomEvent<{ action: string } | null>): void {
+    if (!(ae.target instanceof Dialog && ae.detail?.action)) return;
+  }
 
-	private renderLLN0s(
-		functionID: string,
-		lLN0Types: Element[],
-		lNode?: Element,
-	): TemplateResult {
-		if (!lNode && !lLN0Types.length) return html``;
+  private renderLLN0s(
+    functionID: string,
+    lLN0Types: Element[],
+    lNode?: Element
+  ): TemplateResult {
+    if (!lNode && !lLN0Types.length) return html``;
 
-		if (lNode)
-			return html`<mwc-select
+    if (lNode)
+      return html`<mwc-select
         disabled
         naturalMenuWidth
-        value="${functionID + ": " + lNode.getAttribute("lnType")}"
+        value="${functionID + ': ' + lNode.getAttribute('lnType')}"
         style="width:100%"
         label="LLN0"
         >${html`<mwc-list-item
-          value="${functionID + ": " + lNode.getAttribute("lnType")}"
-          >${lNode.getAttribute("lnType")}
+          value="${functionID + ': ' + lNode.getAttribute('lnType')}"
+          >${lNode.getAttribute('lnType')}
         </mwc-list-item>`}</mwc-select
       >`;
 
-		return html`<mwc-select
+    return html`<mwc-select
       naturalMenuWidth
       style="width:100%"
       label="LLN0"
-      value="${functionID + ": " + lLN0Types[0].getAttribute("id")}"
-      >${lLN0Types.map((lLN0Type) => {
-				return html`<mwc-list-item
-          value="${functionID + ": " + lLN0Type.getAttribute("id")}"
-          >${lLN0Type.getAttribute("id")}</mwc-list-item
+      value="${functionID + ': ' + lLN0Types[0].getAttribute('id')}"
+      >${lLN0Types.map(lLN0Type => {
+        return html`<mwc-list-item
+          value="${functionID + ': ' + lLN0Type.getAttribute('id')}"
+          >${lLN0Type.getAttribute('id')}</mwc-list-item
         >`;
-			})}</mwc-select
+      })}</mwc-select
     >`;
-	}
+  }
 
-	private renderLNodes(lNodes: Element[], disabled: boolean): TemplateResult[] {
-		return lNodes.map((lNode) => {
-			const prefix = getFunctionNamingPrefix(lNode);
-			const lnClass = lNode.getAttribute("lnClass")!;
-			const lnInst = lNode.getAttribute("lnInst")!;
+  private renderLNodes(lNodes: Element[], disabled: boolean): TemplateResult[] {
+    return lNodes.map(lNode => {
+      const prefix = getFunctionNamingPrefix(lNode);
+      const lnClass = lNode.getAttribute('lnClass')!;
+      const lnInst = lNode.getAttribute('lnInst')!;
 
-			const label = prefix + " " + lnClass + " " + lnInst;
-			return html`<mwc-check-list-item
+      const label = prefix + ' ' + lnClass + ' ' + lnInst;
+      return html`<mwc-check-list-item
         ?disabled=${disabled}
         value="${identity(lNode)}"
         >${label}</mwc-check-list-item
       >`;
-		});
-	}
+    });
+  }
 
-	render(): TemplateResult {
-		if (!this.doc) return html``;
+  render(): TemplateResult {
+    if (!this.doc) return html``;
 
-		const existValidLLN0 = this.lLN0s.length !== 0;
+    const existValidLLN0 = this.lLN0s.length !== 0;
 
-		const functionElementDescriptions = groupLNodesToFunctions(
-			this.unreferencedLNodes,
-		);
+    const functionElementDescriptions = groupLNodesToFunctions(
+      this.unreferencedLNodes
+    );
 
-		return html`<mwc-dialog
+    return html`<mwc-dialog
       heading="Create SPECIFICATION type IED"
       @closed=${this.onClosed}
       ><div>
         <wizard-textfield
           label="manufacturer"
-          .maybeValue=${""}
+          .maybeValue=${''}
           required
           @keypress=${() => this.requestUpdate()}
         ></wizard-textfield>
@@ -286,52 +284,52 @@ export default class VirtualTemplateIED extends LitElement {
         ></wizard-textfield>
         <wizard-textfield
           label="AccessPoint name"
-          .maybeValue=${""}
+          .maybeValue=${''}
           required
           @keypress=${() => this.requestUpdate()}
         ></wizard-textfield>
         <filtered-list multi @selected=${() => this.requestUpdate()}
           >${Object.entries(functionElementDescriptions).flatMap(
-						([id, functionDescription]) => [
-							html`<mwc-list-item
+            ([id, functionDescription]) => [
+              html`<mwc-list-item
                 twoline
                 noninteractive
                 value="${id}"
                 style="font-weight:500"
                 ><span>${functionDescription.uniqueName}</span
                 ><span slot="secondary"
-                  >${existValidLLN0 ? id : "Invalid LD: Missing LLN0"}</span
+                  >${existValidLLN0 ? id : 'Invalid LD: Missing LLN0'}</span
                 ></mwc-list-item
               >`,
-							this.renderLLN0s(
-								functionDescription.uniqueName,
-								this.lLN0s,
-								functionDescription.lln0,
-							),
-							...this.renderLNodes(functionDescription.lNodes, !existValidLLN0),
-							html`<li padded divider role="separator"></li>`,
-						],
-					)}</filtered-list
+              this.renderLLN0s(
+                functionDescription.uniqueName,
+                this.lLN0s,
+                functionDescription.lln0
+              ),
+              ...this.renderLNodes(functionDescription.lNodes, !existValidLLN0),
+              html`<li padded divider role="separator"></li>`,
+            ]
+          )}</filtered-list
         >
       </div>
       <mwc-button
         slot="secondaryAction"
         dialogAction="close"
-        label="${get("close")}"
+        label="${get('close')}"
         style="--mdc-theme-primary: var(--mdc-theme-error)"
       ></mwc-button>
       <mwc-button
         ?disabled=${!this.validPriparyAction}
         slot="primaryAction"
         icon="save"
-        label="${get("save")}"
+        label="${get('save')}"
         trailingIcon
         @click=${() => this.onPrimaryAction(functionElementDescriptions)}
       ></mwc-button
     ></mwc-dialog>`;
-	}
+  }
 
-	static styles = css`
+  static styles = css`
     mwc-dialog {
       --mdc-dialog-max-width: 92vw;
     }

--- a/packages/plugins/src/menu/VirtualTemplateIED.ts
+++ b/packages/plugins/src/menu/VirtualTemplateIED.ts
@@ -58,14 +58,25 @@ function getLDeviceDescriptions(
 			)!;
 			const lnType = lLN0?.split(": ")[1];
 
+			// Map to ensure unique prefixes based on node attributes
 			const anyLNs = [
 				{ prefix: null, lnClass: "LLN0", inst: "", lnType },
-				...selectedLNodes.map((lNode, index) => ({
-					prefix: `CSWI-${index + 1}`, // Assigns a unique prefix based on the index
-					lnClass: lNode.getAttribute("lnClass")!,
-					inst: lNode.getAttribute("lnInst")!,
-					lnType: lNode.getAttribute("lnType")!,
-				})),
+				...selectedLNodes.map((lNode, index) => {
+					const lnClass = lNode.getAttribute("lnClass")!;
+					const inst = lNode.getAttribute("lnInst")!;
+					const lnType = lNode.getAttribute("lnType")!;
+					const existingPrefix = lNode.getAttribute("prefix") || "";
+
+					// Generate unique prefix if not already provided
+					const uniquePrefix = existingPrefix || `${lnClass}-${index + 1}`; // Prefix includes class and unique index
+
+					return {
+						prefix: uniquePrefix,
+						lnClass,
+						inst,
+						lnType,
+					};
+				}),
 			];
 
 			lDeviceDescriptions.push({

--- a/packages/plugins/src/menu/VirtualTemplateIED.ts
+++ b/packages/plugins/src/menu/VirtualTemplateIED.ts
@@ -1,270 +1,278 @@
 import {
-  css,
-  html,
-  LitElement,
-  property,
-  query,
-  queryAll,
-  state,
-  TemplateResult,
-} from 'lit-element';
-import { get } from 'lit-translate';
+	css,
+	html,
+	LitElement,
+	property,
+	query,
+	queryAll,
+	state,
+	TemplateResult,
+} from "lit-element";
+import { get } from "lit-translate";
 
-import '@material/mwc-dialog';
-import '@material/mwc-list';
-import '@material/mwc-list/mwc-list-item';
-import '@material/mwc-list/mwc-check-list-item';
-import '@material/mwc-list/mwc-radio-list-item';
-import { Dialog } from '@material/mwc-dialog';
-import { CheckListItem } from '@material/mwc-list/mwc-check-list-item';
-import { Select } from '@material/mwc-select';
+import "@material/mwc-dialog";
+import "@material/mwc-list";
+import "@material/mwc-list/mwc-list-item";
+import "@material/mwc-list/mwc-check-list-item";
+import "@material/mwc-list/mwc-radio-list-item";
+import { Dialog } from "@material/mwc-dialog";
+import { CheckListItem } from "@material/mwc-list/mwc-check-list-item";
+import { Select } from "@material/mwc-select";
 
-import '@openscd/open-scd/src/filtered-list.js';
-import { find, identity } from '@openscd/open-scd/src/foundation.js';
-import { getChildElementsByTagName } from '@openscd/xml';
+import "@openscd/open-scd/src/filtered-list.js";
+import { find, identity } from "@openscd/open-scd/src/foundation.js";
+import { getChildElementsByTagName } from "@openscd/xml";
 
-import { newActionEvent } from '@openscd/core/foundation/deprecated/editor.js';
-import { WizardTextField } from '@openscd/open-scd/src/wizard-textfield.js';
+import { newActionEvent } from "@openscd/core/foundation/deprecated/editor.js";
+import { WizardTextField } from "@openscd/open-scd/src/wizard-textfield.js";
 import {
-  getFunctionNamingPrefix,
-  getNonLeafParent,
-  getSpecificationIED,
-  getUniqueFunctionName,
-  LDeviceDescription,
-} from './virtualtemplateied/foundation.js';
+	getFunctionNamingPrefix,
+	getNonLeafParent,
+	getSpecificationIED,
+	getUniqueFunctionName,
+	LDeviceDescription,
+} from "./virtualtemplateied/foundation.js";
 
 export type FunctionElementDescription = {
-  uniqueName: string;
-  lNodes: Element[];
-  lln0?: Element;
+	uniqueName: string;
+	lNodes: Element[];
+	lln0?: Element;
 };
 
 /** converts FunctionElementDescription's to LDeviceDescription's */
 function getLDeviceDescriptions(
-  functions: Record<string, FunctionElementDescription>,
-  selectedLNodes: Element[],
-  selectedLLN0s: string[]
+	functions: Record<string, FunctionElementDescription>,
+	selectedLNodes: Element[],
+	selectedLLN0s: string[],
 ): LDeviceDescription[] {
-  const lDeviceDescriptions: LDeviceDescription[] = [];
+	const lDeviceDescriptions: LDeviceDescription[] = [];
 
-  Object.values(functions).forEach(functionDescription => {
-    if (
-      functionDescription.lNodes.some(lNode => selectedLNodes.includes(lNode))
-    ) {
-      const lLN0 = selectedLLN0s.find(selectedLLN0 =>
-        selectedLLN0.includes(functionDescription.uniqueName)
-      )!;
-      const lnType = lLN0?.split(': ')[1];
+	console.log("LDeviceDescriptions input - selectedLNodes: ", selectedLNodes);
 
-      lDeviceDescriptions.push({
-        validLdInst: functionDescription.uniqueName,
-        anyLNs: [
-          { prefix: null, lnClass: 'LLN0', inst: '', lnType },
-          ...functionDescription.lNodes
-            .filter(lNode => selectedLNodes.includes(lNode))
-            .map(lNode => {
-              return {
-                prefix: getFunctionNamingPrefix(lNode),
-                lnClass: lNode.getAttribute('lnClass')!,
-                inst: lNode.getAttribute('lnInst')!,
-                lnType: lNode.getAttribute('lnType')!,
-              };
-            }),
-        ],
-      });
-    }
-  });
+	Object.values(functions).forEach((functionDescription) => {
+		if (
+			functionDescription.lNodes.some((lNode) => selectedLNodes.includes(lNode))
+		) {
+			const lLN0 = selectedLLN0s.find((selectedLLN0) =>
+				selectedLLN0.includes(functionDescription.uniqueName),
+			)!;
+			const lnType = lLN0?.split(": ")[1];
 
-  return lDeviceDescriptions;
+			const anyLNs = [
+				{ prefix: null, lnClass: "LLN0", inst: "", lnType },
+				...selectedLNodes.map((lNode, index) => ({
+					prefix: `CSWI-${index + 1}`, // Assigns a unique prefix based on the index
+					lnClass: lNode.getAttribute("lnClass")!,
+					inst: lNode.getAttribute("lnInst")!,
+					lnType: lNode.getAttribute("lnType")!,
+				})),
+			];
+
+			lDeviceDescriptions.push({
+				validLdInst: functionDescription.uniqueName,
+				anyLNs,
+			});
+		}
+	});
+
+	console.log(
+		"AFTER LDeviceDescriptions input - selectedLNodes: ",
+		lDeviceDescriptions,
+	);
+
+	return lDeviceDescriptions;
 }
 
 /** Groups all incomming LNode's with non-leaf parent function type elements */
 function groupLNodesToFunctions(
-  lNodes: Element[]
+	lNodes: Element[],
 ): Record<string, FunctionElementDescription> {
-  const functionElements: Record<string, FunctionElementDescription> = {};
+	const functionElements: Record<string, FunctionElementDescription> = {};
 
-  lNodes.forEach(lNode => {
-    const parentFunction = getNonLeafParent(lNode);
-    if (!parentFunction) return;
+	lNodes.forEach((lNode) => {
+		const parentFunction = getNonLeafParent(lNode);
+		if (!parentFunction) return;
 
-    if (functionElements[identity(parentFunction)])
-      functionElements[identity(parentFunction)].lNodes.push(lNode);
-    else {
-      functionElements[identity(parentFunction)] = {
-        uniqueName: getUniqueFunctionName(parentFunction),
-        lNodes: [lNode],
-        lln0: getChildElementsByTagName(parentFunction, 'LNode').find(
-          lNode => lNode.getAttribute('lnClass') === 'LLN0'
-        ),
-      };
-    }
-  });
+		if (functionElements[identity(parentFunction)])
+			functionElements[identity(parentFunction)].lNodes.push(lNode);
+		else {
+			functionElements[identity(parentFunction)] = {
+				uniqueName: getUniqueFunctionName(parentFunction),
+				lNodes: [lNode],
+				lln0: getChildElementsByTagName(parentFunction, "LNode").find(
+					(lNode) => lNode.getAttribute("lnClass") === "LLN0",
+				),
+			};
+		}
+	});
 
-  return functionElements;
+	return functionElements;
 }
 
 export default class VirtualTemplateIED extends LitElement {
-  @property({ attribute: false })
-  doc!: XMLDocument;
-  @property({ type: Number })
-  editCount = -1;
-  @state()
-  get isValidManufacturer(): boolean {
-    const manufacturer = this.dialog?.querySelector<WizardTextField>(
-      'wizard-textfield[label="manufacturer"]'
-    )!.value;
+	@property({ attribute: false })
+	doc!: XMLDocument;
+	@property({ type: Number })
+	editCount = -1;
+	@state()
+	get isValidManufacturer(): boolean {
+		const manufacturer = this.dialog?.querySelector<WizardTextField>(
+			'wizard-textfield[label="manufacturer"]',
+		)!.value;
 
-    return (manufacturer && manufacturer !== '') || false;
-  }
-  @state()
-  get isValidApName(): boolean {
-    const apName = this.dialog?.querySelector<WizardTextField>(
-      'wizard-textfield[label="AccessPoint name"]'
-    )!.value;
+		return (manufacturer && manufacturer !== "") || false;
+	}
+	@state()
+	get isValidApName(): boolean {
+		const apName = this.dialog?.querySelector<WizardTextField>(
+			'wizard-textfield[label="AccessPoint name"]',
+		)!.value;
 
-    return (apName && apName !== '') || false;
-  }
-  @state()
-  get someItemsSelected(): boolean {
-    if (!this.selectedLNodeItems) return false;
-    return !!this.selectedLNodeItems.length;
-  }
-  @state()
-  get validPriparyAction(): boolean {
-    return (
-      this.someItemsSelected && this.isValidManufacturer && this.isValidApName
-    );
-  }
+		return (apName && apName !== "") || false;
+	}
+	@state()
+	get someItemsSelected(): boolean {
+		if (!this.selectedLNodeItems) return false;
+		return !!this.selectedLNodeItems.length;
+	}
+	@state()
+	get validPriparyAction(): boolean {
+		return (
+			this.someItemsSelected && this.isValidManufacturer && this.isValidApName
+		);
+	}
 
-  get unreferencedLNodes(): Element[] {
-    return Array.from(
-      this.doc.querySelectorAll('LNode[iedName="None"]')
-    ).filter(lNode => lNode.getAttribute('lnClass') !== 'LLN0');
-  }
+	get unreferencedLNodes(): Element[] {
+		return Array.from(
+			this.doc.querySelectorAll('LNode[iedName="None"]'),
+		).filter((lNode) => lNode.getAttribute("lnClass") !== "LLN0");
+	}
 
-  get lLN0s(): Element[] {
-    return Array.from(this.doc.querySelectorAll('LNodeType[lnClass="LLN0"]'));
-  }
+	get lLN0s(): Element[] {
+		return Array.from(this.doc.querySelectorAll('LNodeType[lnClass="LLN0"]'));
+	}
 
-  @query('mwc-dialog') dialog!: Dialog;
-  @queryAll('mwc-check-list-item[selected]')
-  selectedLNodeItems?: CheckListItem[];
+	@query("mwc-dialog") dialog!: Dialog;
+	@queryAll("mwc-check-list-item[selected]")
+	selectedLNodeItems?: CheckListItem[];
 
-  async run(): Promise<void> {
-    this.dialog.open = true;
-  }
+	async run(): Promise<void> {
+		this.dialog.open = true;
+	}
 
-  private onPrimaryAction(
-    functions: Record<string, FunctionElementDescription>
-  ): void {
-    const selectedLNode = Array.from(
-      this.dialog.querySelectorAll<CheckListItem>(
-        'mwc-check-list-item[selected]:not([disabled])'
-      ) ?? []
-    ).map(selectedItem => find(this.doc, 'LNode', selectedItem.value)!);
-    if (!selectedLNode.length) return;
+	private onPrimaryAction(
+		functions: Record<string, FunctionElementDescription>,
+	): void {
+		const selectedLNode = Array.from(
+			this.dialog.querySelectorAll<CheckListItem>(
+				"mwc-check-list-item[selected]:not([disabled])",
+			) ?? [],
+		).map((selectedItem) => find(this.doc, "LNode", selectedItem.value)!);
+		selectedLNode.forEach((lNode, index) => {
+			lNode.setAttribute("prefix", `CSWI-${index}`);
+		});
+		if (!selectedLNode.length) return;
 
-    const selectedLLN0s = Array.from(
-      this.dialog.querySelectorAll<Select>('mwc-select') ?? []
-    ).map(selectedItem => selectedItem.value);
+		const selectedLLN0s = Array.from(
+			this.dialog.querySelectorAll<Select>("mwc-select") ?? [],
+		).map((selectedItem) => selectedItem.value);
 
-    const manufacturer = this.dialog.querySelector<WizardTextField>(
-      'wizard-textfield[label="manufacturer"]'
-    )!.value;
-    const desc = this.dialog.querySelector<WizardTextField>(
-      'wizard-textfield[label="desc"]'
-    )!.maybeValue;
-    const apName = this.dialog.querySelector<WizardTextField>(
-      'wizard-textfield[label="AccessPoint name"]'
-    )!.value;
+		const manufacturer = this.dialog.querySelector<WizardTextField>(
+			'wizard-textfield[label="manufacturer"]',
+		)!.value;
+		const desc = this.dialog.querySelector<WizardTextField>(
+			'wizard-textfield[label="desc"]',
+		)!.maybeValue;
+		const apName = this.dialog.querySelector<WizardTextField>(
+			'wizard-textfield[label="AccessPoint name"]',
+		)!.value;
 
-    const ied = getSpecificationIED(this.doc, {
-      manufacturer,
-      desc,
-      apName,
-      lDevices: getLDeviceDescriptions(functions, selectedLNode, selectedLLN0s),
-    });
+		const ied = getSpecificationIED(this.doc, {
+			manufacturer,
+			desc,
+			apName,
+			lDevices: getLDeviceDescriptions(functions, selectedLNode, selectedLLN0s),
+		});
 
-    // checkValidity: () => true disables name check as is the same here: SPECIFICATION
-    this.dispatchEvent(
-      newActionEvent({
-        new: { parent: this.doc.documentElement, element: ied },
-        checkValidity: () => true,
-      })
-    );
-    this.dialog.close();
-  }
+		// checkValidity: () => true disables name check as is the same here: SPECIFICATION
+		this.dispatchEvent(
+			newActionEvent({
+				new: { parent: this.doc.documentElement, element: ied },
+				checkValidity: () => true,
+			}),
+		);
+		this.dialog.close();
+	}
 
-  private onClosed(ae: CustomEvent<{ action: string } | null>): void {
-    if (!(ae.target instanceof Dialog && ae.detail?.action)) return;
-  }
+	private onClosed(ae: CustomEvent<{ action: string } | null>): void {
+		if (!(ae.target instanceof Dialog && ae.detail?.action)) return;
+	}
 
-  private renderLLN0s(
-    functionID: string,
-    lLN0Types: Element[],
-    lNode?: Element
-  ): TemplateResult {
-    if (!lNode && !lLN0Types.length) return html``;
+	private renderLLN0s(
+		functionID: string,
+		lLN0Types: Element[],
+		lNode?: Element,
+	): TemplateResult {
+		if (!lNode && !lLN0Types.length) return html``;
 
-    if (lNode)
-      return html`<mwc-select
+		if (lNode)
+			return html`<mwc-select
         disabled
         naturalMenuWidth
-        value="${functionID + ': ' + lNode.getAttribute('lnType')}"
+        value="${functionID + ": " + lNode.getAttribute("lnType")}"
         style="width:100%"
         label="LLN0"
         >${html`<mwc-list-item
-          value="${functionID + ': ' + lNode.getAttribute('lnType')}"
-          >${lNode.getAttribute('lnType')}
+          value="${functionID + ": " + lNode.getAttribute("lnType")}"
+          >${lNode.getAttribute("lnType")}
         </mwc-list-item>`}</mwc-select
       >`;
 
-    return html`<mwc-select
+		return html`<mwc-select
       naturalMenuWidth
       style="width:100%"
       label="LLN0"
-      value="${functionID + ': ' + lLN0Types[0].getAttribute('id')}"
-      >${lLN0Types.map(lLN0Type => {
-        return html`<mwc-list-item
-          value="${functionID + ': ' + lLN0Type.getAttribute('id')}"
-          >${lLN0Type.getAttribute('id')}</mwc-list-item
+      value="${functionID + ": " + lLN0Types[0].getAttribute("id")}"
+      >${lLN0Types.map((lLN0Type) => {
+				return html`<mwc-list-item
+          value="${functionID + ": " + lLN0Type.getAttribute("id")}"
+          >${lLN0Type.getAttribute("id")}</mwc-list-item
         >`;
-      })}</mwc-select
+			})}</mwc-select
     >`;
-  }
+	}
 
-  private renderLNodes(lNodes: Element[], disabled: boolean): TemplateResult[] {
-    return lNodes.map(lNode => {
-      const prefix = getFunctionNamingPrefix(lNode);
-      const lnClass = lNode.getAttribute('lnClass')!;
-      const lnInst = lNode.getAttribute('lnInst')!;
+	private renderLNodes(lNodes: Element[], disabled: boolean): TemplateResult[] {
+		return lNodes.map((lNode) => {
+			const prefix = getFunctionNamingPrefix(lNode);
+			const lnClass = lNode.getAttribute("lnClass")!;
+			const lnInst = lNode.getAttribute("lnInst")!;
 
-      const label = prefix + ' ' + lnClass + ' ' + lnInst;
-      return html`<mwc-check-list-item
+			const label = prefix + " " + lnClass + " " + lnInst;
+			return html`<mwc-check-list-item
         ?disabled=${disabled}
         value="${identity(lNode)}"
         >${label}</mwc-check-list-item
       >`;
-    });
-  }
+		});
+	}
 
-  render(): TemplateResult {
-    if (!this.doc) return html``;
+	render(): TemplateResult {
+		if (!this.doc) return html``;
 
-    const existValidLLN0 = this.lLN0s.length !== 0;
+		const existValidLLN0 = this.lLN0s.length !== 0;
 
-    const functionElementDescriptions = groupLNodesToFunctions(
-      this.unreferencedLNodes
-    );
+		const functionElementDescriptions = groupLNodesToFunctions(
+			this.unreferencedLNodes,
+		);
 
-    return html`<mwc-dialog
+		return html`<mwc-dialog
       heading="Create SPECIFICATION type IED"
       @closed=${this.onClosed}
       ><div>
         <wizard-textfield
           label="manufacturer"
-          .maybeValue=${''}
+          .maybeValue=${""}
           required
           @keypress=${() => this.requestUpdate()}
         ></wizard-textfield>
@@ -275,52 +283,52 @@ export default class VirtualTemplateIED extends LitElement {
         ></wizard-textfield>
         <wizard-textfield
           label="AccessPoint name"
-          .maybeValue=${''}
+          .maybeValue=${""}
           required
           @keypress=${() => this.requestUpdate()}
         ></wizard-textfield>
         <filtered-list multi @selected=${() => this.requestUpdate()}
           >${Object.entries(functionElementDescriptions).flatMap(
-            ([id, functionDescription]) => [
-              html`<mwc-list-item
+						([id, functionDescription]) => [
+							html`<mwc-list-item
                 twoline
                 noninteractive
                 value="${id}"
                 style="font-weight:500"
                 ><span>${functionDescription.uniqueName}</span
                 ><span slot="secondary"
-                  >${existValidLLN0 ? id : 'Invalid LD: Missing LLN0'}</span
+                  >${existValidLLN0 ? id : "Invalid LD: Missing LLN0"}</span
                 ></mwc-list-item
               >`,
-              this.renderLLN0s(
-                functionDescription.uniqueName,
-                this.lLN0s,
-                functionDescription.lln0
-              ),
-              ...this.renderLNodes(functionDescription.lNodes, !existValidLLN0),
-              html`<li padded divider role="separator"></li>`,
-            ]
-          )}</filtered-list
+							this.renderLLN0s(
+								functionDescription.uniqueName,
+								this.lLN0s,
+								functionDescription.lln0,
+							),
+							...this.renderLNodes(functionDescription.lNodes, !existValidLLN0),
+							html`<li padded divider role="separator"></li>`,
+						],
+					)}</filtered-list
         >
       </div>
       <mwc-button
         slot="secondaryAction"
         dialogAction="close"
-        label="${get('close')}"
+        label="${get("close")}"
         style="--mdc-theme-primary: var(--mdc-theme-error)"
       ></mwc-button>
       <mwc-button
         ?disabled=${!this.validPriparyAction}
         slot="primaryAction"
         icon="save"
-        label="${get('save')}"
+        label="${get("save")}"
         trailingIcon
         @click=${() => this.onPrimaryAction(functionElementDescriptions)}
       ></mwc-button
     ></mwc-dialog>`;
-  }
+	}
 
-  static styles = css`
+	static styles = css`
     mwc-dialog {
       --mdc-dialog-max-width: 92vw;
     }

--- a/packages/plugins/test/unit/menu/__snapshots__/VirtualTemplateIED.test.snap.js
+++ b/packages/plugins/test/unit/menu/__snapshots__/VirtualTemplateIED.test.snap.js
@@ -1,7 +1,7 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["Plugin that creates with some user input a virtual template IED - SPECIFICATION looks like the latest snapshot"] = 
+snapshots["Plugin that creates with some user input a virtual template IED - SPECIFICATION looks like the latest snapshot"] =
 `<mwc-dialog
   heading="Create SPECIFICATION type IED"
   open=""
@@ -72,7 +72,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         graphic="control"
         mwc-list-item=""
         tabindex="0"
-        value="AA1>E1>Q01>QC9>Earth_Switch>(CSWI OpenSCD_CSWI)"
+        value="AA1>E1>Q01>QC9>Earth_Switch>(CSWI OpenSCD_CSWI 1)"
       >
         CSWI 1
       </mwc-check-list-item>
@@ -81,7 +81,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         graphic="control"
         mwc-list-item=""
         tabindex="-1"
-        value="AA1>E1>Q01>QC9>Earth_Switch>(CILO OpenSCD_CILO)"
+        value="AA1>E1>Q01>QC9>Earth_Switch>(CILO OpenSCD_CILO 1)"
       >
         CILO 1
       </mwc-check-list-item>
@@ -90,7 +90,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         graphic="control"
         mwc-list-item=""
         tabindex="-1"
-        value="AA1>E1>Q01>QC9>Earth_Switch>(XSWI OpenSCD_XSWI_EarthSwitch)"
+        value="AA1>E1>Q01>QC9>Earth_Switch>(XSWI OpenSCD_XSWI_EarthSwitch 1)"
       >
         XSWI 1
       </mwc-check-list-item>
@@ -148,7 +148,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         graphic="control"
         mwc-list-item=""
         tabindex="-1"
-        value="AA1>E1>Q01>QB1>Disconnector>(CSWI OpenSCD_CSWI)"
+        value="AA1>E1>Q01>QB1>Disconnector>(CSWI OpenSCD_CSWI 1)"
       >
         CSWI 1
       </mwc-check-list-item>
@@ -157,7 +157,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         graphic="control"
         mwc-list-item=""
         tabindex="-1"
-        value="AA1>E1>Q01>QB1>Disconnector>(XSWI OpenSCD_XSWI_DIS)"
+        value="AA1>E1>Q01>QB1>Disconnector>(XSWI OpenSCD_XSWI_DIS 1)"
       >
         XSWI 1
       </mwc-check-list-item>
@@ -166,7 +166,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         graphic="control"
         mwc-list-item=""
         tabindex="-1"
-        value="AA1>E1>Q01>QB1>Disconnector>(CILO OpenSCD_CILO)"
+        value="AA1>E1>Q01>QB1>Disconnector>(CILO OpenSCD_CILO 1)"
       >
         CILO 1
       </mwc-check-list-item>
@@ -224,7 +224,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         graphic="control"
         mwc-list-item=""
         tabindex="-1"
-        value="AA1>E1>Q01>QA1>Circuit_Breaker>(CSWI OpenSCD_CSWI)"
+        value="AA1>E1>Q01>QA1>Circuit_Breaker>(CSWI OpenSCD_CSWI 1)"
       >
         CSWI 1
       </mwc-check-list-item>
@@ -233,7 +233,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         graphic="control"
         mwc-list-item=""
         tabindex="-1"
-        value="AA1>E1>Q01>QA1>Circuit_Breaker>(CILO OpenSCD_CILO)"
+        value="AA1>E1>Q01>QA1>Circuit_Breaker>(CILO OpenSCD_CILO 1)"
       >
         CILO 1
       </mwc-check-list-item>
@@ -242,7 +242,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         graphic="control"
         mwc-list-item=""
         tabindex="-1"
-        value="AA1>E1>Q01>QA1>Circuit_Breaker>(XCBR OpenSCD_XCBR)"
+        value="AA1>E1>Q01>QA1>Circuit_Breaker>(XCBR OpenSCD_XCBR 1)"
       >
         XCBR 1
       </mwc-check-list-item>
@@ -292,7 +292,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         graphic="control"
         mwc-list-item=""
         tabindex="-1"
-        value="AA1>E1>Q01>Timed_Overcurrent>(PTOC OpenSCD_PTOC)"
+        value="AA1>E1>Q01>Timed_Overcurrent>(PTOC OpenSCD_PTOC 2)"
       >
         ID_ PTOC 2
       </mwc-check-list-item>
@@ -301,7 +301,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         graphic="control"
         mwc-list-item=""
         tabindex="-1"
-        value="AA1>E1>Q01>Timed_Overcurrent>(PTOC OpenSCD_PTOC)"
+        value="AA1>E1>Q01>Timed_Overcurrent>(PTOC OpenSCD_PTOC 1)"
       >
         IDD_ PTOC 1
       </mwc-check-list-item>
@@ -359,7 +359,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         graphic="control"
         mwc-list-item=""
         tabindex="-1"
-        value="AA1>E1>Q01>Distance_Protection>Zone4>(PDIS OpenSCD_PDIS)"
+        value="AA1>E1>Q01>Distance_Protection>Zone4>(PDIS OpenSCD_PDIS 1)"
       >
         Zone4 PDIS 1
       </mwc-check-list-item>
@@ -368,7 +368,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         graphic="control"
         mwc-list-item=""
         tabindex="-1"
-        value="AA1>E1>Q01>Distance_Protection>Zon3>(PDIS OpenSCD_PDIS)"
+        value="AA1>E1>Q01>Distance_Protection>Zon3>(PDIS OpenSCD_PDIS 1)"
       >
         Zon3 PDIS 1
       </mwc-check-list-item>
@@ -377,7 +377,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         graphic="control"
         mwc-list-item=""
         tabindex="-1"
-        value="AA1>E1>Q01>Distance_Protection>Zone2>(PDIS OpenSCD_PDIS)"
+        value="AA1>E1>Q01>Distance_Protection>Zone2>(PDIS OpenSCD_PDIS 1)"
       >
         Zone2 PDIS 1
       </mwc-check-list-item>
@@ -386,7 +386,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         graphic="control"
         mwc-list-item=""
         tabindex="-1"
-        value="AA1>E1>Q01>Distance_Protection>Zone1>(PDIS OpenSCD_PDIS)"
+        value="AA1>E1>Q01>Distance_Protection>Zone1>(PDIS OpenSCD_PDIS 1)"
       >
         Zone1 PDIS 1
       </mwc-check-list-item>
@@ -444,7 +444,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         graphic="control"
         mwc-list-item=""
         tabindex="-1"
-        value="AA1>E1>Q02>QB1>Disconnector>(CSWI OpenSCD_CSWI)"
+        value="AA1>E1>Q02>QB1>Disconnector>(CSWI OpenSCD_CSWI 1)"
       >
         CSWI 1
       </mwc-check-list-item>
@@ -453,7 +453,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         graphic="control"
         mwc-list-item=""
         tabindex="-1"
-        value="AA1>E1>Q02>QB1>Disconnector>(XSWI OpenSCD_XSWI_DIS)"
+        value="AA1>E1>Q02>QB1>Disconnector>(XSWI OpenSCD_XSWI_DIS 1)"
       >
         XSWI 1
       </mwc-check-list-item>
@@ -462,7 +462,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         graphic="control"
         mwc-list-item=""
         tabindex="-1"
-        value="AA1>E1>Q02>QB1>Disconnector>(CILO OpenSCD_CILO)"
+        value="AA1>E1>Q02>QB1>Disconnector>(CILO OpenSCD_CILO 1)"
       >
         CILO 1
       </mwc-check-list-item>
@@ -520,7 +520,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         graphic="control"
         mwc-list-item=""
         tabindex="-1"
-        value="AA1>J1>Q01>QC9>Earth_Switch>(CSWI OpenSCD_CSWI)"
+        value="AA1>J1>Q01>QC9>Earth_Switch>(CSWI OpenSCD_CSWI 1)"
       >
         CSWI 1
       </mwc-check-list-item>
@@ -529,7 +529,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         graphic="control"
         mwc-list-item=""
         tabindex="-1"
-        value="AA1>J1>Q01>QC9>Earth_Switch>(CILO OpenSCD_CILO)"
+        value="AA1>J1>Q01>QC9>Earth_Switch>(CILO OpenSCD_CILO 1)"
       >
         CILO 1
       </mwc-check-list-item>
@@ -538,7 +538,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         graphic="control"
         mwc-list-item=""
         tabindex="-1"
-        value="AA1>J1>Q01>QC9>Earth_Switch>(XSWI OpenSCD_XSWI_EarthSwitch)"
+        value="AA1>J1>Q01>QC9>Earth_Switch>(XSWI OpenSCD_XSWI_EarthSwitch 1)"
       >
         XSWI 1
       </mwc-check-list-item>
@@ -569,7 +569,7 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
 `;
 /* end snapshot Plugin that creates with some user input a virtual template IED - SPECIFICATION looks like the latest snapshot */
 
-snapshots["Plugin that creates with some user input a virtual template IED - SPECIFICATION IEDs data model show selected logical nodes and its structure"] = 
+snapshots["Plugin that creates with some user input a virtual template IED - SPECIFICATION IEDs data model show selected logical nodes and its structure"] =
 `<IED
   manufacturer="SomeCompanyName"
   name="SPECIFICATION"

--- a/packages/plugins/test/unit/menu/__snapshots__/VirtualTemplateIED.test.snap.js
+++ b/packages/plugins/test/unit/menu/__snapshots__/VirtualTemplateIED.test.snap.js
@@ -601,10 +601,10 @@ snapshots["Plugin that creates with some user input a virtual template IED - SPE
         >
         </LN0>
         <LN
-          inst="2"
+          inst="1"
           lnClass="PTOC"
           lnType="OpenSCD_PTOC"
-          prefix="ID_"
+          prefix="IDD_"
         >
         </LN>
       </LDevice>


### PR DESCRIPTION
The bug is described here: https://github.com/openscd/open-scd/issues/1567
Description
When the user assigns multiple instances of a same LNType (even though instance numbers/prefixes are different) to a Function element, they are visualized just as normal with no problem like below;
<img width="862" alt="image" src="https://github.com/user-attachments/assets/35aa88fe-5845-4baa-a7ce-a7066098924e">
Next, user creates a Virtual IED out of Functions which should turn out to LDs including those LNs within; (expected)
<img width="431" alt="image" src="https://github.com/user-attachments/assets/32a78083-0c69-478c-a635-c32b90aae0cb">
But at the end, it turns out to only last or first LN is included in the datamodel, and others are ignored.



Expected behaviour
- [x] Expectation is all LNs are part of the datamodel of virtual IED, allocated under LD that is the name of Function element

Current problem:
<img width="444" alt="image" src="https://github.com/user-attachments/assets/3e490b7f-32c1-4c20-b9be-57d8196d5c5c">
