### PR TITLE
fix: store nsdocs correctly for descriptions (closes #1605)

### DIFF
--- a/packages/openscd/src/foundation/nsdoc.ts
+++ b/packages/openscd/src/foundation/nsdoc.ts
@@ -10,12 +10,17 @@ export interface Nsdoc {
 
 const [nsd72, nsd73, nsd74, nsd81] = await Promise.all([iec6185072, iec6185073, iec6185074, iec6185081]);
 
+let nsdoc72: Document | undefined = undefined;
+let nsdoc73: Document | undefined = undefined;
+let nsdoc74: Document | undefined = undefined;
+let nsdoc81: Document | undefined = undefined;
+
 /**
  * Initialize the full Nsdoc object.
  * @returns A fully initialized Nsdoc object for wizards/editors to use.
  */
 export function initializeNsdoc(): Nsdoc {
-  const [nsdoc72, nsdoc73, nsdoc74, nsdoc81] = [
+  [nsdoc72, nsdoc73, nsdoc74, nsdoc81] = [
     localStorage.getItem('IEC 61850-7-2') ? new DOMParser().parseFromString(localStorage.getItem('IEC 61850-7-2')!, 'application/xml') : undefined,
     localStorage.getItem('IEC 61850-7-3') ? new DOMParser().parseFromString(localStorage.getItem('IEC 61850-7-3')!, 'application/xml') : undefined,
     localStorage.getItem('IEC 61850-7-4') ? new DOMParser().parseFromString(localStorage.getItem('IEC 61850-7-4')!, 'application/xml') : undefined,


### PR DESCRIPTION
It seems better! I have not attempted to provide a regression test.

![image](https://github.com/user-attachments/assets/3a3850c9-7840-4eff-ade3-7acfe93b9feb)

We don't seem to have linter rules (maybe we never did?) so I've avoided any specific formatting changes on this small PR.