### PR TITLE
fix: update deprecated ubuntu image in pr-preview workflow

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,6 +1,5 @@
 name: Deploy PR previews
 
-
 on:
   pull_request:
     types:
@@ -18,7 +17,7 @@ env:
 jobs:
   deploy-preview:
     permissions: write-all
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -35,4 +34,3 @@ jobs:
         with:
           source-dir: packages/distribution/build
           umbrella-dir: pr-preview
-


### PR DESCRIPTION
The deploy PR preview job is no longer working because of a deprecated Ubuntu image (20.04). More info: https://github.com/actions/runner-images/issues/11101

To fix this, the ubuntu image is set to latest.