### PR TITLE
fix: Move menu item content outside drawer

### DIFF
--- a/packages/openscd/src/open-scd.ts
+++ b/packages/openscd/src/open-scd.ts
@@ -51,6 +51,7 @@ import { HistoryState, historyStateEvent } from './addons/History.js';
 import { InstalledOfficialPlugin, MenuPosition, PluginKind, Plugin } from "./plugin.js"
 import { ConfigurePluginEvent, ConfigurePluginDetail, newConfigurePluginEvent } from './plugin.events.js';
 import { newLogEvent } from '@openscd/core/foundation/deprecated/history';
+import { pluginTag } from './plugin-tag.js';
 
 
 
@@ -445,33 +446,13 @@ export class OpenSCD extends LitElement {
 
   // PLUGGING INTERFACES
   @state() private pluginTags = new Map<string, string>();
-  /**
-   * Hashes `uri` using cyrb64 analogous to
-   * https://github.com/bryc/code/blob/master/jshash/experimental/cyrb53.js .
-   * @returns a valid customElement tagName containing the URI hash.
-   */
+
   private pluginTag(uri: string): string {
     if (!this.pluginTags.has(uri)) {
-      let h1 = 0xdeadbeef,
-        h2 = 0x41c6ce57;
-      for (let i = 0, ch; i < uri.length; i++) {
-        ch = uri.charCodeAt(i);
-        h1 = Math.imul(h1 ^ ch, 2654435761);
-        h2 = Math.imul(h2 ^ ch, 1597334677);
-      }
-      h1 =
-        Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^
-        Math.imul(h2 ^ (h2 >>> 13), 3266489909);
-      h2 =
-        Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^
-        Math.imul(h1 ^ (h1 >>> 13), 3266489909);
-      this.pluginTags.set(
-        uri,
-        'oscd-plugin' +
-          ((h2 >>> 0).toString(16).padStart(8, '0') +
-            (h1 >>> 0).toString(16).padStart(8, '0'))
-      );
+      const tag = pluginTag(uri);
+      this.pluginTags.set(uri, tag);
     }
+
     return this.pluginTags.get(uri)!;
   }
 
@@ -492,6 +473,7 @@ declare global {
 export interface MenuItem {
   icon: string;
   name: string;
+  src?: string;
   hint?: string;
   actionItem?: boolean;
   action?: (event: CustomEvent<ActionDetail>) => void;

--- a/packages/openscd/src/plugin-tag.ts
+++ b/packages/openscd/src/plugin-tag.ts
@@ -1,0 +1,24 @@
+
+/**
+ * Hashes `uri` using cyrb64 analogous to
+ * https://github.com/bryc/code/blob/master/jshash/experimental/cyrb53.js .
+ * @returns a valid customElement tagName containing the URI hash.
+ */
+export function pluginTag(uri: string): string {
+    let h1 = 0xdeadbeef,
+    h2 = 0x41c6ce57;
+    for (let i = 0, ch; i < uri.length; i++) {
+    ch = uri.charCodeAt(i);
+    h1 = Math.imul(h1 ^ ch, 2654435761);
+    h2 = Math.imul(h2 ^ ch, 1597334677);
+    }
+    h1 =
+    Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^
+    Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+    h2 =
+    Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^
+    Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+    return 'oscd-plugin' +
+        ((h2 >>> 0).toString(16).padStart(8, '0') +
+        (h1 >>> 0).toString(16).padStart(8, '0'))
+}


### PR DESCRIPTION
Move menu item content outside of menu drawer, this is necessary for menu items which open a dialog, because otherwise the dialog will only be visible if the menu drawer is also open. Additionally selecting a plugin by tag is more robust than using nextElementSibling.