### PR TITLE
feat: Add oscd api with plugin state

### DIFF
--- a/docs/core-api/oscd-api.md
+++ b/docs/core-api/oscd-api.md
@@ -1,0 +1,40 @@
+# OSCD API
+
+Open scd passes an API object as the property `oscdApi` to every plugin. At the moment the API only includes the plugin state API. Here is an example usage in a Lit based plugin.
+
+```
+import { OscdApi } from '@openscd/core';
+
+class SomePlugin extends LitElement {
+
+  @property()
+  oscdApi: OscdApi | null = null;
+
+  connectedCallback() {
+    const pluginState = this.oscdApi?.pluginState.getState();
+
+    ...
+  }
+
+  disconnectedCallback() {
+    this.oscdApi?.pluginState.setState(someStateObject);
+  }
+}
+```
+
+⚠️ Be aware that not every open scd distribution provides this API, so your plugin should have a null check if you want it to be compatible with other distributions.
+
+## Plugin state API
+
+The plugin state API stores an arbitrary object as your plugin's state in memory. Be aware that this state is only persisted during the open scd distribution's runtime and will not be stored in local storage for example.
+
+```
+interface PluginStateApi {
+  setState(state: PluginState | null): void;
+
+  getState(): PluginState | null;
+
+  updateState(partialState: Partial<PluginState>): void
+}
+```
+

--- a/packages/core/api/api.ts
+++ b/packages/core/api/api.ts
@@ -1,5 +1,9 @@
 import { PluginStateApi } from './plugin-state-api.js';
 
 export class OscdApi {
-  protected pluginState = new PluginStateApi();
+  public pluginState: PluginStateApi;
+
+  constructor(pluginTag: string) {
+    this.pluginState = new PluginStateApi(pluginTag);
+  }
 }

--- a/packages/core/api/api.ts
+++ b/packages/core/api/api.ts
@@ -1,0 +1,5 @@
+import { PluginStateApi } from './plugin-state-api.js';
+
+export class OscdApi {
+  protected pluginState = new PluginStateApi();
+}

--- a/packages/core/api/plugin-state-api.ts
+++ b/packages/core/api/plugin-state-api.ts
@@ -3,20 +3,35 @@ type PluginState = {
 }
 
 export class PluginStateApi {
-  private state: PluginState | null = null;
+  private static state: { [tag: string]: PluginState | null } = {};
+  private pluginTag: string;
+
+  constructor(tag: string) {
+    this.pluginTag = tag;
+  }
 
   public setState(state: PluginState): void {
-    this.state = state;
+    this.setPluginState(state);
   }
 
-  getState(): PluginState | null {
-    return this.state;
+  public getState(): PluginState | null {
+    return this.getPluginState();
   }
 
-  updateState(partialState: Partial<PluginState>): void {
-    this.state = {
-      ...this.state,
+  public updateState(partialState: Partial<PluginState>): void {
+    const pluginState = this.getPluginState();
+    const patchedState = {
+      ...pluginState,
       ...partialState
     };
+    this.setPluginState(patchedState);
+  }
+
+  private setPluginState(state: PluginState): void {
+    PluginStateApi.state[this.pluginTag] = state;
+  }
+
+  private getPluginState(): PluginState | null {
+    return PluginStateApi.state[this.pluginTag] ?? null;
   }
 }

--- a/packages/core/api/plugin-state-api.ts
+++ b/packages/core/api/plugin-state-api.ts
@@ -10,7 +10,7 @@ export class PluginStateApi {
     this.pluginTag = tag;
   }
 
-  public setState(state: PluginState): void {
+  public setState(state: PluginState | null): void {
     this.setPluginState(state);
   }
 
@@ -27,7 +27,7 @@ export class PluginStateApi {
     this.setPluginState(patchedState);
   }
 
-  private setPluginState(state: PluginState): void {
+  private setPluginState(state: PluginState | null): void {
     PluginStateApi.state[this.pluginTag] = state;
   }
 

--- a/packages/core/api/plugin-state-api.ts
+++ b/packages/core/api/plugin-state-api.ts
@@ -1,0 +1,22 @@
+type PluginState = {
+  [key: string]: unknown
+}
+
+export class PluginStateApi {
+  private state: PluginState | null = null;
+
+  public setState(state: PluginState): void {
+    this.state = state;
+  }
+
+  getState(): PluginState | null {
+    return this.state;
+  }
+
+  updateState(partialState: Partial<PluginState>): void {
+    this.state = {
+      ...this.state,
+      ...partialState
+    };
+  }
+}

--- a/packages/core/foundation.ts
+++ b/packages/core/foundation.ts
@@ -66,3 +66,5 @@ export function crossProduct<T>(...arrays: T[][]): T[][] {
     [[]]
   );
 }
+
+export { OscdApi } from './api/api.js';

--- a/packages/openscd/src/open-scd.ts
+++ b/packages/openscd/src/open-scd.ts
@@ -45,6 +45,7 @@ import type {
   Plugin as CorePlugin,
   EditCompletedEvent,
 } from '@openscd/core';
+import { OscdApi } from '@openscd/core';
 
 import { HistoryState, historyStateEvent } from './addons/History.js';
 
@@ -431,6 +432,7 @@ export class OpenSCD extends LitElement {
             .nsdoc=${this.nsdoc}
             .docs=${this.docs}
             .locale=${this.locale}
+            .oscdApi=${new OscdApi()}
             class="${classMap({
               plugin: true,
               menu: plugin.kind === 'menu',

--- a/packages/openscd/src/open-scd.ts
+++ b/packages/openscd/src/open-scd.ts
@@ -432,7 +432,7 @@ export class OpenSCD extends LitElement {
             .nsdoc=${this.nsdoc}
             .docs=${this.docs}
             .locale=${this.locale}
-            .oscdApi=${new OscdApi()}
+            .oscdApi=${new OscdApi(tag)}
             class="${classMap({
               plugin: true,
               menu: plugin.kind === 'menu',

--- a/packages/plugins/src/editors/IED.ts
+++ b/packages/plugins/src/editors/IED.ts
@@ -42,7 +42,7 @@ export default class IedPlugin extends LitElement {
   nsdoc!: Nsdoc;
   
   @property()
-  oscdApi!: OscdApi;
+  oscdApi: OscdApi | null = null;
   
   @state()
   selectedIEDs: string[] = [];


### PR DESCRIPTION
Add an api to allow plugins to store state before being closed, so they can open the same context on their next activation. Use the state to preserve selected IED in the IED Plugin.

closes #1379