### PR TITLE
fix(Import IED): Fix order of edits

### DIFF
--- a/packages/plugins/src/menu/ImportIEDs.ts
+++ b/packages/plugins/src/menu/ImportIEDs.ts
@@ -425,13 +425,13 @@ export default class ImportingIedPlugin extends LitElement {
 
     const dataTypeTemplateActions = addDataTypeTemplates(ied, this.doc);
     const communicationActions = addCommunicationElements(ied, this.doc);
-    const actions = communicationActions.concat(dataTypeTemplateActions);
-    actions.push({
+    const insertIed = {
       new: {
         parent: this.doc!.querySelector(':root')!,
         element: ied,
       },
-    });
+    };
+    const actions = [ ...communicationActions, insertIed, ...dataTypeTemplateActions ];
 
     this.dispatchEvent(
       newActionEvent({


### PR DESCRIPTION
In the old edit action API the editor ran a `getReference` method to determine where to add an element, while the edit-action to edit converter does this as well, the edit action API ran this method right before inserting an element while the converter has to convert all edit actions in a complex edit before passing them to the editor.

Since the new edit API forces the user to pass a reference explicitly, it makes sense to arrange the edits in the correct order (Communication -> IED -> DataTypeTemplates).